### PR TITLE
chore(flake/nix-super): `e5a5fbc0` -> `4f4d3a53`

### DIFF
--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -6,28 +6,51 @@ on:
     - cron: "0 12 * * SAT,TUE" # At 12:00 on Saturday & Tuesday (UTC)
 
 jobs:
-  update-multiple-inputs:
+  get-flakes:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.get-flakes.outputs.matrix }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v2.3.5
+      - uses: cachix/install-nix-action@v16
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.MAXI_TOKEN }}
+            experimental-features = nix-command flakes recursive-nix
+      - id: get-flakes
+        run: |
+          get_flake_inputs() {
+            nix flake metadata --json \
+              | jq -c '
+                  .locks.nodes.root.inputs
+                  | {flake: keys}'
+          }
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v23
+          echo "::set-output name=matrix::$(get_flake_inputs)"
+
+  update-flake:
+    name: update-${{ matrix.flake }}
+    runs-on: ubuntu-latest
+    needs: get-flakes
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.get-flakes.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v2.3.5
+      - uses: cachix/install-nix-action@v23
         with:
           install_url: "https://releases.nixos.org/nix/nix-2.18.1/install"
-
-      - name: Update flake.lock
-        id: update
-        uses: DeterminateSystems/update-flake-lock@v20
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.MAXI_TOKEN }}
+            experimental-features = nix-command flakes recursive-nix
+      - run: git config --global user.email "59017537+MaximilianSforza@users.noreply.github.com"
+      - run: git config --global user.name "Maximilian"
+      - uses: cpcloud/flake-update-action@v1.0.2
         with:
-          pr-title: "Update flake.lock" # Title of PR to be created
-          pr-labels: | # Labels to be set on the PR
-            dependencies
-            automated
-
-      - name: merge
-        run: |
-          gh pr merge ${{ steps.update.outputs.pull-request-number }} --squash --delete-branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          dependency: ${{ matrix.flake }}
+          pull-request-token: ${{ secrets.PR_TOKEN }}
+          pull-request-author: Maximilian <59017537+MaximilianSforza@users.noreply.github.com>
+          delete-branch: true
+          github-token: ${{ secrets.MAXI_TOKEN }}
+          pull-request-branch-prefix: update-
+          automerge: true

--- a/flake.lock
+++ b/flake.lock
@@ -421,6 +421,22 @@
         "type": "github"
       }
     },
+    "libgit2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1697646580,
+        "narHash": "sha256-oX4Z3S9WtJlwvj0uH9HlYcWv+x1hqp8mhXl7HsLu2f0=",
+        "owner": "libgit2",
+        "repo": "libgit2",
+        "rev": "45fd9ed7ae1a9b74b957ef4f337bc3c8b3df01b5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "libgit2",
+        "repo": "libgit2",
+        "type": "github"
+      }
+    },
     "lowdown-src": {
       "flake": false,
       "locked": {
@@ -516,16 +532,17 @@
     "nix-super": {
       "inputs": {
         "flake-compat": "flake-compat_3",
+        "libgit2": "libgit2",
         "lowdown-src": "lowdown-src",
         "nixpkgs": "nixpkgs_3",
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1698707137,
-        "narHash": "sha256-fiNU+WoFPApesEDN/2JwTKcivmsSicHBli9BSusQ6tY=",
+        "lastModified": 1700687412,
+        "narHash": "sha256-XJ/qOgzABDeSQnJkNfkg7AFVpdHnAvbxQtX6DEd57RA=",
         "owner": "privatevoid-net",
         "repo": "nix-super",
-        "rev": "e5a5fbc0fb926dc6e2ec8371634e1c8509466e18",
+        "rev": "4f4d3a538eb78a8232bc4cb4c9df6747a6703b2a",
         "type": "github"
       },
       "original": {
@@ -662,11 +679,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1695283060,
-        "narHash": "sha256-CJz71xhCLlRkdFUSQEL0pIAAfcnWFXMzd9vXhPrnrEg=",
+        "lastModified": 1700342017,
+        "narHash": "sha256-HaibwlWH5LuqsaibW3sIVjZQtEM/jWtOHX4Nk93abGE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "31ed632c692e6a36cfc18083b88ece892f863ed4",
+        "rev": "decdf666c833a325cb4417041a90681499e06a41",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| SHA256                                                                                                     | Commit Message                                                                     |
| ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`5d4161ea`](https://github.com/privatevoid-net/nix-super/commit/5d4161ea25080b3cb95e159f4895be8bccf52a61) | `fix build`                                                                        |
| [`b1ab592f`](https://github.com/privatevoid-net/nix-super/commit/b1ab592f28f08da5dc7c060e5c3b19dc66dbc111) | `Use the StorePath-based cache interface`                                          |
| [`5292f364`](https://github.com/privatevoid-net/nix-super/commit/5292f364267eb74005a2e06dfe69c0d0dc8bd2a3) | `Fix compile warning due to unused variable binding.`                              |
| [`61b76f5f`](https://github.com/privatevoid-net/nix-super/commit/61b76f5f34db7f863a6f22bd9083f677b339fcf6) | `Apply suggestion`                                                                 |
| [`46131567`](https://github.com/privatevoid-net/nix-super/commit/46131567da96ffac298b9ec54016b37114b0dfd5) | ``Add missing `-lrapidcheck` fixing build with shared lib``                        |
| [`03c3af1b`](https://github.com/privatevoid-net/nix-super/commit/03c3af1bf97354e281230a82f76d84b2db65db91) | `mounted-ssh-ng store: integration tests`                                          |
| [`b32b20a6`](https://github.com/privatevoid-net/nix-super/commit/b32b20a6d7cf3a9cf2c81a133c255e9c2ee8e308) | ``release note entry for the `mounted-ssh-ng://` store``                           |
| [`06b89025`](https://github.com/privatevoid-net/nix-super/commit/06b8902562089811e5724aa0b8d719f891ab73f2) | `MountedSSHStore: stores on shared filesystems`                                    |
| [`226b0f39`](https://github.com/privatevoid-net/nix-super/commit/226b0f3956ef83ec51b6556d8f27e13a966b4ebf) | ``Extend the worker protocol with `wopAddPermRoot```                               |
| [`9796ebd7`](https://github.com/privatevoid-net/nix-super/commit/9796ebd7ef8c9a23ee8128273d925acae00e43b0) | ``Add `--process-ops` flag to `nix-daemon```                                       |
| [`949f5841`](https://github.com/privatevoid-net/nix-super/commit/949f5841f8a8611d0f49793bd8c4963462d62e3a) | ``Add the `MountedSSHStore` experimental feature``                                 |
| [`f8804691`](https://github.com/privatevoid-net/nix-super/commit/f880469173061a07f0b2a24734932c5a9ad633c6) | ``Put `canonicaliseTimestampAndPermissions` in its own header/file``               |
| [`4d8decbd`](https://github.com/privatevoid-net/nix-super/commit/4d8decbd135a78389c463fbb4c844f1bf22aed69) | `doc: fix number of template attributes`                                           |
| [`64827360`](https://github.com/privatevoid-net/nix-super/commit/64827360be35a3d16e818aa9d8426ca40b2c4dc2) | `Fix "unbound variable" errors in bash`                                            |
| [`99d5204b`](https://github.com/privatevoid-net/nix-super/commit/99d5204baaef211234d50f20610fa43d304888ce) | `Persistently cache InputAccessor::fetchToStore()`                                 |
| [`a0162d57`](https://github.com/privatevoid-net/nix-super/commit/a0162d5732b23e7fdc1f65df28826611e3a424e5) | `Improve SourceAccessor path display`                                              |
| [`071f14a0`](https://github.com/privatevoid-net/nix-super/commit/071f14a0bb25ffa8e5aaf8ad37031d205f49ef7d) | `Don't do shallow fetches over ssh`                                                |
| [`e4066c04`](https://github.com/privatevoid-net/nix-super/commit/e4066c04442f86a5a12d492d588e3e82b533053d) | `Fetch specific Git revisions`                                                     |
| [`e2b6821c`](https://github.com/privatevoid-net/nix-super/commit/e2b6821ca0147f36bcb9404aab080f80746984c8) | `Fix bad_format_string error when builder stdout contains %`                       |
| [`2a96445d`](https://github.com/privatevoid-net/nix-super/commit/2a96445d7505cb0a82ed2a49c7210b3073ffd153) | `Bump version`                                                                     |
| [`a5e51a9e`](https://github.com/privatevoid-net/nix-super/commit/a5e51a9e02efe2813170fdf0093c98b3d56aed84) | `refactor Worker::childStarted/Terminated: use switch`                             |
| [`7ac39ff0`](https://github.com/privatevoid-net/nix-super/commit/7ac39ff05c8353c665174e8df61dd76a2b0b93db) | `refactor Store::buildPaths: convert to string earlier`                            |
| [`1d6abec9`](https://github.com/privatevoid-net/nix-super/commit/1d6abec993a371091459d5e23f985c6d69621ce7) | `Revert use of boost::container::small_vector in the evaluator`                    |
| [`d5928085`](https://github.com/privatevoid-net/nix-super/commit/d5928085d5a542b19cc21b1f299392ee7a0c960b) | `builtins.concatMap: Fix typo in error message`                                    |
| [`796a7eb9`](https://github.com/privatevoid-net/nix-super/commit/796a7eb92d2b0caf75685126adc7460a4c39cfec) | `fetchTree: clarify docs for shallow flag`                                         |
| [`fe4f573d`](https://github.com/privatevoid-net/nix-super/commit/fe4f573d49a5c47cf9ffd0bd3fe8868104550818) | `flake.nix: Update nixpkgs: release-23.05 -> nixos-23.05-small`                    |
| [`70ddf298`](https://github.com/privatevoid-net/nix-super/commit/70ddf298e0882075dcb1cf69562c629a195718f7) | `doc: Add link to filterSource from path`                                          |
| [`251fb23a`](https://github.com/privatevoid-net/nix-super/commit/251fb23aeab8f85afb4f8376c2e6fc3d8b229d23) | `Shebang parser: add virtual destructor`                                           |
| [`4a539ac3`](https://github.com/privatevoid-net/nix-super/commit/4a539ac3eac90b2c2f839cae885df89a03240348) | `Fix buildNoGc`                                                                    |
| [`293ae592`](https://github.com/privatevoid-net/nix-super/commit/293ae592576bb9c48975466613fcba6a30d06f5e) | ``Fix `make check```                                                               |
| [`f7d59d0d`](https://github.com/privatevoid-net/nix-super/commit/f7d59d0dda5e4a793e701bc8fb9136b3ef22948c) | `Release notes`                                                                    |
| [`7b0e8c5c`](https://github.com/privatevoid-net/nix-super/commit/7b0e8c5c2c09146722349d3fd2dd69211d8b8945) | `Apply suggestions from code review`                                               |
| [`121665f3`](https://github.com/privatevoid-net/nix-super/commit/121665f3773bc46ca6df0dda6f66b1a86e7d9e72) | `nix-env: Use state.mkList, required for correct stats`                            |
| [`260c6147`](https://github.com/privatevoid-net/nix-super/commit/260c6147625e95e4772ccdee80d6463d242c7b64) | `Value: use std::span, change use of const`                                        |
| [`7055c652`](https://github.com/privatevoid-net/nix-super/commit/7055c6528532fdd3b0ce9b8f5282b002fc011470) | `Value: extract Value::Lambda`                                                     |
| [`6af1d9f7`](https://github.com/privatevoid-net/nix-super/commit/6af1d9f7b94da454252b62f0cfff4ce800c5a46b) | `Value: extract Value::FunctionApplicationThunk`                                   |
| [`b55203e8`](https://github.com/privatevoid-net/nix-super/commit/b55203e874f8e4b2fc5289129efba791937c23d0) | `Value: extract Value::ClosureThunk`                                               |
| [`d8ff5cfe`](https://github.com/privatevoid-net/nix-super/commit/d8ff5cfe8eba34c8b4b5cc53f3b40cd3dfd84224) | `Value: extract Value::Path`                                                       |
| [`2eb59c34`](https://github.com/privatevoid-net/nix-super/commit/2eb59c34b531f03a85f67b9246ccaf0ff5fcad23) | `Value: extract Value::StringWithContext`                                          |
| [`c8193757`](https://github.com/privatevoid-net/nix-super/commit/c81937576928ca494af0be6e7c61f2070be5d353) | `doc: Add example of inherit in a let expression`                                  |
| [`96d67620`](https://github.com/privatevoid-net/nix-super/commit/96d67620d551c7143b6682cfff74a2ee2edbe863) | `Fix a broken generated header file dependency`                                    |
| [`31ebc602`](https://github.com/privatevoid-net/nix-super/commit/31ebc6028b3682969d86a7b39ae87131c41cc604) | `Fix symlink handling`                                                             |
| [`6c8f4ef3`](https://github.com/privatevoid-net/nix-super/commit/6c8f4ef3502aa214557541ec00538e41aeced6e3) | `Allow installing unit tests`                                                      |
| [`4e27f194`](https://github.com/privatevoid-net/nix-super/commit/4e27f1947a444a36d6a85f41cbf1afdc70ac6c4c) | `libexpr: Reduce nonRecursiveStackReservation`                                     |
| [`a96be29d`](https://github.com/privatevoid-net/nix-super/commit/a96be29db536177fdc284b51a3b2af44a70496e0) | `removeAttrs: increase stack reservation to 64`                                    |
| [`1b9813e4`](https://github.com/privatevoid-net/nix-super/commit/1b9813e4e60836ddb1467efd50c572e7579ac945) | `primops: Name stack reservation limits`                                           |
| [`898c4738`](https://github.com/privatevoid-net/nix-super/commit/898c47384f651f51b3e4b63c271da274db8fca2e) | `primops: Err on the side of less stack usage`                                     |
| [`91114a6f`](https://github.com/privatevoid-net/nix-super/commit/91114a6fa48e2eb9399c23938eb12fdbd4fcda42) | `ExprCall::eval: Heap allocate at arity 5+`                                        |
| [`206ece0f`](https://github.com/privatevoid-net/nix-super/commit/206ece0f41142536a856c62c49bd202282f12db8) | `builtins.{any,all}: Use constant errorCtx`                                        |
| [`9fa133dd`](https://github.com/privatevoid-net/nix-super/commit/9fa133dde5610dfb0605399ffea83081bda1c6fc) | `readProcLink: Replace unnecessary value judgement by actual info`                 |
| [`12c91a82`](https://github.com/privatevoid-net/nix-super/commit/12c91a823e80b5e0a14a0abb0f34a6633b14bbfe) | `maxPrimOpArity: 64 -> 8`                                                          |
| [`0daccb11`](https://github.com/privatevoid-net/nix-super/commit/0daccb1121dfd5e98db3e41ba992b1b2c413dfc8) | `libexpr: Check primop arity earlier`                                              |
| [`ba3cb4a0`](https://github.com/privatevoid-net/nix-super/commit/ba3cb4a04949e043669299da5497bea27b944598) | `Remove all the occurences of VLAs`                                                |
| [`5196613e`](https://github.com/privatevoid-net/nix-super/commit/5196613e8290a9ee81f1b9d88e7bc61cc3f64d2b) | `Use boost small vectors instead of VLAs in the primops`                           |
| [`84128461`](https://github.com/privatevoid-net/nix-super/commit/84128461b68f6274f1cbf309fd019959132f3c2a) | ``Add a new `nix store add` command``                                              |
| [`7ab91e72`](https://github.com/privatevoid-net/nix-super/commit/7ab91e72387b96d1926f1b9c95b919020d4ba962) | `Implement shallow fetching`                                                       |
| [`5dd4ae86`](https://github.com/privatevoid-net/nix-super/commit/5dd4ae86877cedaf70ea70d80b89c66b850bdc5a) | `Remove unused cacheType field`                                                    |
| [`28909999`](https://github.com/privatevoid-net/nix-super/commit/28909999116781e194e2eb1646f3ccec005e774f) | `Show Git fetch progress`                                                          |
| [`70b39664`](https://github.com/privatevoid-net/nix-super/commit/70b396649c127760e4b123da41451aa7456bc68d) | `doc: logical implication is right-associative`                                    |
| [`9c7749e1`](https://github.com/privatevoid-net/nix-super/commit/9c7749e13508996eb9df83b1692664cc8cdbf952) | ``Fix makefile bug confusing `libnixutil-test` exe vs lib``                        |
| [`2964a9f5`](https://github.com/privatevoid-net/nix-super/commit/2964a9f562748cc698ee1f6ecf1e0da4e63211b9) | `Fix relative submodule handling`                                                  |
| [`6ec6b8aa`](https://github.com/privatevoid-net/nix-super/commit/6ec6b8aa363f566a8da0d6959753efa452b152cc) | `Improve git submodule error reporting`                                            |
| [`e07e3c10`](https://github.com/privatevoid-net/nix-super/commit/e07e3c106a9ac0537210e62286c4e696573e9f6f) | `code cleanup`                                                                     |
| [`4944cdb9`](https://github.com/privatevoid-net/nix-super/commit/4944cdb94d03742176cc7881f126e981c0e7e21c) | `nar dump-path command renamed to nar pack`                                        |
| [`c257c824`](https://github.com/privatevoid-net/nix-super/commit/c257c824475c92cdfda5daa027db334b6a0137f8) | `Cleanup`                                                                          |
| [`7f576f5d`](https://github.com/privatevoid-net/nix-super/commit/7f576f5dfe11c3f6b0e69179de95c921caddda18) | `Rename UnionInputAccessor to MountedInputAccessor`                                |
| [`21140c98`](https://github.com/privatevoid-net/nix-super/commit/21140c987b7a301c01498864efbc3d92be04aced) | `Fix doxygen comments`                                                             |
| [`4329bdf6`](https://github.com/privatevoid-net/nix-super/commit/4329bdf6a30fadad66384f0b8c835d7dba9f87b3) | `Move comment`                                                                     |
| [`25cf8f10`](https://github.com/privatevoid-net/nix-super/commit/25cf8f107125eda79e7faece90e7e05093a39e65) | `src/libfetchers/union-input-accessor.cc: Apply suggestion`                        |
| [`38b07d63`](https://github.com/privatevoid-net/nix-super/commit/38b07d63479ebdd4f43145264a026a22a72d940b) | `src/libfetchers/git.cc: Apply suggestion`                                         |
| [`d74d2fda`](https://github.com/privatevoid-net/nix-super/commit/d74d2fdaa721cd7cddceca2e0b4063a1d891bb9f) | `Move statusCallbackTrampoline`                                                    |
| [`21bb1805`](https://github.com/privatevoid-net/nix-super/commit/21bb180547118e29a66bf091bd6b1dd911b3114d) | `Use libgit2 with ssh-exec support`                                                |
| [`ad99c895`](https://github.com/privatevoid-net/nix-super/commit/ad99c8950b86b8f354f5c72efe690d3cba045d99) | `Update comment to reflect bind mounts are now used for store in chroot`           |
| [`742a63b9`](https://github.com/privatevoid-net/nix-super/commit/742a63b98f2008161fd00bdbbd39b8f1b14f6443) | `build(deps): bump zeebe-io/backport-action from 2.1.0 to 2.1.1`                   |
| [`0be84c83`](https://github.com/privatevoid-net/nix-super/commit/0be84c83b242b6e6a22400727752072b298e7cab) | `key and cat: no need for progressBar`                                             |
| [`fd5a4a84`](https://github.com/privatevoid-net/nix-super/commit/fd5a4a846752873331b6549f0778181dc4ecc2f3) | `nix upgrade-nix: make the source URL an option`                                   |
| [`20b95d62`](https://github.com/privatevoid-net/nix-super/commit/20b95d622336cf982082d7daf3075339f6edce70) | `Git object hashing in libutil`                                                    |
| [`9afa697a`](https://github.com/privatevoid-net/nix-super/commit/9afa697ab61ea6bbbb0d88e629b62606681cc744) | `Refactor bash test build system a bit`                                            |
| [`3d9d5dc1`](https://github.com/privatevoid-net/nix-super/commit/3d9d5dc18977d21a04299f4a37b366f9a1d32051) | ``Create `MemorySink```                                                            |
| [`cf59ea83`](https://github.com/privatevoid-net/nix-super/commit/cf59ea83ec98522113bf2fd81678537a871d0339) | `configure: Check for libgit2`                                                     |
| [`1d5a4824`](https://github.com/privatevoid-net/nix-super/commit/1d5a48240cd3c5b81939b0562141772323550d99) | ```.editorconfig`: Also affect Perl FFI `xs` file``                                |
| [`a903f85f`](https://github.com/privatevoid-net/nix-super/commit/a903f85f84b78a28490f3aa9615ba87d070d01d1) | ```nix-env --query`: fix `--json` ignoring `--drv-path```                          |
| [`12953b94`](https://github.com/privatevoid-net/nix-super/commit/12953b942c7752568070e0b703b448dd8f16f21b) | `Fixup docs`                                                                       |
| [`f0adb72c`](https://github.com/privatevoid-net/nix-super/commit/f0adb72c238aa6f21c2f07fe2e434a3adcea975d) | ``Mark `fetchTree` as unstable again``                                             |
| [`d854e869`](https://github.com/privatevoid-net/nix-super/commit/d854e8696b549de15ac9960736a39302d7846ece) | `Specify the size of the experimental feature array in a more robust way`          |
| [`df8bfe84`](https://github.com/privatevoid-net/nix-super/commit/df8bfe84cca62c89417d676af2c6fbe3bcf23412) | `Fix consts and casts`                                                             |
| [`c581143e`](https://github.com/privatevoid-net/nix-super/commit/c581143e0c6721fba455e6616e7c6f07e47000b1) | `Use structured binding for json iteration`                                        |
| [`77dceb28`](https://github.com/privatevoid-net/nix-super/commit/77dceb2844276217bff321d80f601297f3581530) | `Drop obsolete assert and cast`                                                    |
| [`6a476295`](https://github.com/privatevoid-net/nix-super/commit/6a47629530469b84d33444119e43c61effa88aa4) | `Fix initialization of struct members (wrong order)`                               |
| [`c0c7c4b6`](https://github.com/privatevoid-net/nix-super/commit/c0c7c4b6cd1aefaa65fc11fcdc8df7e608960825) | `Link to shebang interpreter docs from release notes`                              |
| [`ab69dc4d`](https://github.com/privatevoid-net/nix-super/commit/ab69dc4da3ce5dc270e11b460c5b99f549bcf5d3) | `Test parseShebangContent round trip`                                              |
| [`589d3387`](https://github.com/privatevoid-net/nix-super/commit/589d3387769b18de9c8d42035eea7ac1e21c6fde) | `parseShebangs: Make strings with backtick sequences representable`                |
| [`ffd414eb`](https://github.com/privatevoid-net/nix-super/commit/ffd414eb756dcb3c64348551d5dbaf674c0d4900) | `Fix nix shebang interaction with #8131 overhaul completions`                      |
| [`e91fd837`](https://github.com/privatevoid-net/nix-super/commit/e91fd837ee997cc1879cc9035158260f3dc7cf67) | `Move shebang docs from rl-next to nix.md`                                         |
| [`51bb6953`](https://github.com/privatevoid-net/nix-super/commit/51bb69535b76060582f91e5c044d5752d8e3998b) | `nix/installables.cc: Use getCommandBaseDir() where possible`                      |
| [`46627156`](https://github.com/privatevoid-net/nix-super/commit/466271568be7d3bcf0151dc7e09899775ac31f13) | `nix: Parse --file relative to shebang script`                                     |
| [`198bc22e`](https://github.com/privatevoid-net/nix-super/commit/198bc22e3b856bf2a86225c2ce5b3a7394e3ac0c) | `nix: Add command baseDir to parse --expr relative to shebang script`              |
| [`20ff61ab`](https://github.com/privatevoid-net/nix-super/commit/20ff61ab252fc1d2bd69987f51a000739b24c670) | `nix: Reserve shebang line syntax and only parse double backtick quotes`           |
| [`cc68ed8f`](https://github.com/privatevoid-net/nix-super/commit/cc68ed8ff7b9e3898308a39dfdad2660bacc153f) | `libcmd: lookupFileArg(): add baseDir`                                             |
| [`bbeddf06`](https://github.com/privatevoid-net/nix-super/commit/bbeddf06027424dc08742c1d54bf2fdc85ff6e8e) | `fix: refactor parseCmdline interface`                                             |
| [`e6ed7292`](https://github.com/privatevoid-net/nix-super/commit/e6ed7292433d2cf4c9d887d450d2fa9c4e5377e3) | `doc: remove reference to nix-shell`                                               |
| [`06f3583b`](https://github.com/privatevoid-net/nix-super/commit/06f3583b1c860b24f2f704f216f4db8fd1dcae9c) | `feat: break out of shebang processing for non-comments`                           |
| [`01f61cef`](https://github.com/privatevoid-net/nix-super/commit/01f61cefcb77f0177afd9d17589eb45c2ebf6cee) | `Read file incrementally`                                                          |
| [`bfcbf3b5`](https://github.com/privatevoid-net/nix-super/commit/bfcbf3b5bff21de2634f2713491f818702bea2a1) | `doc: shebang release notes, docs, tests`                                          |
| [`eea5a003`](https://github.com/privatevoid-net/nix-super/commit/eea5a003d99094d8488fd0d1ecd97f98d3573133) | `fix: test to ensure arguments are passed`                                         |
| [`5f9b5758`](https://github.com/privatevoid-net/nix-super/commit/5f9b5758b6f8b0d2c4bea5bcc11c64eb623e3650) | `src/libutil/util.hh: Formatting`                                                  |
| [`74210c12`](https://github.com/privatevoid-net/nix-super/commit/74210c12feccc6c6b717c5f39c28d7ce86614e60) | `Shellbang support with flakes`                                                    |
| [`1362a0a5`](https://github.com/privatevoid-net/nix-super/commit/1362a0a55aaddccef5a525e3b1179239d650bb07) | `Fix logic for default XDG_DATA_DIRS value`                                        |
| [`b733f4ab`](https://github.com/privatevoid-net/nix-super/commit/b733f4ab29cec07cf17e1fe6580c9d2f8a4362a0) | `maintainers: refine the mission statement phrasing`                               |
| [`9fec62a1`](https://github.com/privatevoid-net/nix-super/commit/9fec62a10044629ad4758ec95f9b1e67d7aefff5) | `build(deps): bump zeebe-io/backport-action from 2.0.0 to 2.1.0`                   |
| [`c60eba32`](https://github.com/privatevoid-net/nix-super/commit/c60eba3276d7417a7f51ef606e5b9ca580cf5e5b) | `Add release note on XDG_DATA_DIRS change`                                         |
| [`150b5aba`](https://github.com/privatevoid-net/nix-super/commit/150b5aba509d169a50c6ad62100c3ad7bf00242b) | `Update scripts/nix-profile-daemon.fish.in`                                        |
| [`896013ec`](https://github.com/privatevoid-net/nix-super/commit/896013ec0c0d4633349ff0373bdae626667adc77) | `Fix bad copy-paste`                                                               |
| [`867f8942`](https://github.com/privatevoid-net/nix-super/commit/867f894289437a96630579592a46a4253151f079) | `Populate $XDG_DATA_DIRS with appropriate folder from Nix profile`                 |
| [`61d6fe05`](https://github.com/privatevoid-net/nix-super/commit/61d6fe059e959455e156c1d57bb91155d363e983) | ``Fix `boost::bad_format_string` exception in `builtins.addErrorContext` (#9291)`` |
| [`cc46ea16`](https://github.com/privatevoid-net/nix-super/commit/cc46ea163024254d0b74646e1b38b19896d40040) | ``Make `nix path-info --json` return an object not array``                         |
| [`a7212e16`](https://github.com/privatevoid-net/nix-super/commit/a7212e169b7204f80ea67f60c855d05b72b5d4f7) | ``Include `compression` in the `NarInfo` JSON format``                             |
| [`937e02e7`](https://github.com/privatevoid-net/nix-super/commit/937e02e7b9538fd4500ade184eb4f0a888a9967d) | ``Shuffle `ValidPathInfo` JSON rendering``                                         |
| [`a4b7df7b`](https://github.com/privatevoid-net/nix-super/commit/a4b7df7bfaee7d27a152be2445886c81881daf94) | `More const, scope reductions, move fixes`                                         |
| [`f404e9b3`](https://github.com/privatevoid-net/nix-super/commit/f404e9b3b362a054219797df02bbe277de249f80) | `Make toJSONObject const`                                                          |
| [`ad385f9e`](https://github.com/privatevoid-net/nix-super/commit/ad385f9ec44f8d845e994764c45876042c715946) | `Minor improvements`                                                               |
| [`07ac5373`](https://github.com/privatevoid-net/nix-super/commit/07ac53732b8989758c264d4e847c94a5d28072cf) | `Fix moves in appendOrSet`                                                         |
| [`0b0d1b52`](https://github.com/privatevoid-net/nix-super/commit/0b0d1b521449e7a66e7fa33ca7afe292d88aa14b) | ``Add comparison functions for `NarInfo```                                         |
| [`2fb49759`](https://github.com/privatevoid-net/nix-super/commit/2fb49759b8307838dd1208d8ce756a60d41e4ebf) | `fix(ssh): log first line of stdout`                                               |
| [`6472c3bf`](https://github.com/privatevoid-net/nix-super/commit/6472c3bf0d4b529f28f9e50834e1fc3dd101c409) | `fix(ssh): extraneous master processes`                                            |
| [`ac89bb06`](https://github.com/privatevoid-net/nix-super/commit/ac89bb064aeea85a62b82a6daf0ecca7190a28b7) | ``Split up `util.{hh,cc}```                                                        |
| [`2678b51b`](https://github.com/privatevoid-net/nix-super/commit/2678b51b31febdc6464935e1680d2272a954c3b5) | ``Narrower scope for `nativeSystem```                                              |
| [`9b880e3e`](https://github.com/privatevoid-net/nix-super/commit/9b880e3e29c7a485b0e21495f2d089c5151589cc) | ``Factor out `MemorySourceAccessor`, implement missing features``                  |
| [`27193278`](https://github.com/privatevoid-net/nix-super/commit/271932782dd3d44e0e238bd3234ca1e97996cfea) | `fetchGit and flake: add commit signature verification tests`                      |
| [`098f0615`](https://github.com/privatevoid-net/nix-super/commit/098f0615c9401414a76e66653fbf4c9dd30d55a7) | `fetchGit and flake: add publicKeys list input`                                    |
| [`6df32889`](https://github.com/privatevoid-net/nix-super/commit/6df32889a51510dff44c776fa312b7ba61ab8edf) | `Add git commit verification input attributes`                                     |
| [`60b36393`](https://github.com/privatevoid-net/nix-super/commit/60b363936d2fd53ac8741d35ba30ff1e4c405a9f) | `libstore/ssh-ng: Fix phase reporting in log files.`                               |
| [`b0455e99`](https://github.com/privatevoid-net/nix-super/commit/b0455e9931fbcd996b1b240a4513132c36cf852c) | `Fix uninitialized variable warnings on i686-linux`                                |
| [`55dd1244`](https://github.com/privatevoid-net/nix-super/commit/55dd1244d280d768bfebb8ca2ec93e061d7aa4eb) | `parseDerivation(): Fix warning about uninitialized 'version' variable`            |
| [`e5908212`](https://github.com/privatevoid-net/nix-super/commit/e5908212e25f2cb7a36ec176a1c7fcb2d522088b) | `Fix nar-access test on macOS`                                                     |
| [`d15c3a33`](https://github.com/privatevoid-net/nix-super/commit/d15c3a33e680228c9deaa6d0898d4680cdc8dbc3) | ``Don't use `std::invocable` C++ concept yet``                                     |
| [`b1074318`](https://github.com/privatevoid-net/nix-super/commit/b107431816fcbf364aeae6942cc9d1e709635a44) | `Systematize characterization tests a bit more`                                    |
| [`d26c317b`](https://github.com/privatevoid-net/nix-super/commit/d26c317b14bc3f0ce82d5a91acc63e62a8836dee) | `Use expect`                                                                       |
| [`55ed09c4`](https://github.com/privatevoid-net/nix-super/commit/55ed09c4f251d87e5aa23c7fb931e87cea63c68d) | `Remove stray executable permissions on source files`                              |
| [`d7b7a79f`](https://github.com/privatevoid-net/nix-super/commit/d7b7a79f3ef865ebe5f61962a7c2737cdb5d6445) | `document store paths`                                                             |
| [`4ba8b182`](https://github.com/privatevoid-net/nix-super/commit/4ba8b182be350a04caf5b7efff6b804d789570ad) | `document store objects in terms of their constituent parts`                       |
| [`d7710a40`](https://github.com/privatevoid-net/nix-super/commit/d7710a40be1a871859d331e9a50cc7f31797d792) | `flake: Temporarily get Nixpkgs ahead of Hydra`                                    |
| [`e47984ce`](https://github.com/privatevoid-net/nix-super/commit/e47984ce0b37cb8e00b66e85703c1ff72de80a73) | `Fix whitespace`                                                                   |
| [`eab92927`](https://github.com/privatevoid-net/nix-super/commit/eab92927388bca29027a98199184ebb5e4e3c03a) | `fix: gcc complains about if which doesn't guard the indented statement`           |
| [`2f5c1a27`](https://github.com/privatevoid-net/nix-super/commit/2f5c1a27dc71275c1d4c96cff42beffed0d4d2f7) | `LocalStoreAccessor: Reuse PosixSourceAccessor`                                    |
| [`1a902f5f`](https://github.com/privatevoid-net/nix-super/commit/1a902f5fa7d4f268d0fec3e44a48ecc2445b3b6b) | `Merge FSAccessor into SourceAccessor`                                             |
| [`581693bd`](https://github.com/privatevoid-net/nix-super/commit/581693bdea3981eb0b106c904c7a1fed7f7582ae) | `fmt(): Handle std::string_view`                                                   |
| [`50aae0a1`](https://github.com/privatevoid-net/nix-super/commit/50aae0a14c5bbbde5785ead8f46b28333e6248ae) | `FSAccessor: Make the fileSize and narOffset fields optional`                      |
| [`53811238`](https://github.com/privatevoid-net/nix-super/commit/53811238790f4bb5f9df74bb25047fe5b734a61f) | `Unify DirEntries types`                                                           |
| [`cdb27c15`](https://github.com/privatevoid-net/nix-super/commit/cdb27c1519cd802f477e8fa90beabe1bddc4bac7) | `SourceAccessor: Change the main interface from lstat() to maybeLstat()`           |
| [`8ffd1695`](https://github.com/privatevoid-net/nix-super/commit/8ffd1695ce31ff81b038fdc995dd8da03b180f03) | `Unify FSAccessor::Type and SourceAccessor::Type`                                  |
| [`b2ac6fc0`](https://github.com/privatevoid-net/nix-super/commit/b2ac6fc040223a58f9b923a89798f72b48e310e5) | `Remove FSAccessor::Type::tMissing`                                                |
| [`bc4a1695`](https://github.com/privatevoid-net/nix-super/commit/bc4a1695ac71483831ac9ad591c872105794e88f) | `doc/hacking: Fix clangd for tests`                                                |
| [`1093d658`](https://github.com/privatevoid-net/nix-super/commit/1093d6585ff6478e50a5845de64cfcf114e35a95) | ``Make `ParseSink` a bit better``                                                  |
| [`b2cae33a`](https://github.com/privatevoid-net/nix-super/commit/b2cae33aef63644bf6e09dea253ed6e1af847fb8) | ``Remove bug-avoiding `StoreConfig *` casts for settings``                         |
| [`1f452553`](https://github.com/privatevoid-net/nix-super/commit/1f4525531e9b5e744830a55a2595880b135d93c0) | `Add configure test to ensure GCC bug is fixed`                                    |
| [`0c5eac9c`](https://github.com/privatevoid-net/nix-super/commit/0c5eac9c4550a6de2cd829d25e628f779e2a29c7) | `Git fetcher: Handle submodules for workdirs`                                      |
| [`f282ef5a`](https://github.com/privatevoid-net/nix-super/commit/f282ef5a56f6314d25044af62b4de38c66b29d38) | `fix: segfault in positional arg completion`                                       |
| [`c7dcdb83`](https://github.com/privatevoid-net/nix-super/commit/c7dcdb8325be7b8ecc3d480217808be899fc865a) | `Overhaul nix flake update and lock commands`                                      |
| [`c762b65d`](https://github.com/privatevoid-net/nix-super/commit/c762b65dc5314ed631381cf4bf26f5976e825bdc) | `Fix documentation of flake command output`                                        |
| [`1fd08673`](https://github.com/privatevoid-net/nix-super/commit/1fd0867389c2dd3e98d06decd4d35067885550a0) | `Fix missing output when creating lockfile`                                        |
| [`669b074f`](https://github.com/privatevoid-net/nix-super/commit/669b074f51c4fea6b362313f47eebb4a67f0e89d) | `Cleanup`                                                                          |
| [`d88106df`](https://github.com/privatevoid-net/nix-super/commit/d88106df24869104cc6c29c726ddfbbfda9dae10) | `Git fetcher: Improve submodule handling`                                          |
| [`ee36a44b`](https://github.com/privatevoid-net/nix-super/commit/ee36a44bf272c8cca62a2ce96a017a8150c4d35b) | `GitInputScheme: Use libgit2`                                                      |
| [`1d0e3d84`](https://github.com/privatevoid-net/nix-super/commit/1d0e3d84b6ed693c140c3b7fd6a72ef8a8a26ec3) | `Provide a InputScheme::fetch() built on top of InputScheme::getAccessor()`        |
| [`e1b8442f`](https://github.com/privatevoid-net/nix-super/commit/e1b8442fa1dbd2e69598dbeb701da4df8e6d2c38) | `Fetcher cache: Add support for caching facts not related to store paths`          |
| [`95f3f9ea`](https://github.com/privatevoid-net/nix-super/commit/95f3f9eac978466c812814c06716f26e9f668e54) | `build(deps): bump zeebe-io/backport-action from 1.4.0 to 2.0.0`                   |
| [`05316d40`](https://github.com/privatevoid-net/nix-super/commit/05316d401fa509557c71140e17bb19814412fcb8) | `Cleanup`                                                                          |
| [`077de296`](https://github.com/privatevoid-net/nix-super/commit/077de2968e8cf2d125818999adf8c149baf6384e) | `Include fetcher input scheme info in the CLI dump`                                |
| [`8381eeda`](https://github.com/privatevoid-net/nix-super/commit/8381eeda6fa858b74bc7b516b9af9eecbbddd594) | `Systematize fetcher input attribute validation`                                   |
| [`325db01d`](https://github.com/privatevoid-net/nix-super/commit/325db01d269ca8580fc05ca4b56f28232266ecb7) | `fix anchor in conf-file`                                                          |
| [`15c430f3`](https://github.com/privatevoid-net/nix-super/commit/15c430f38971c2f852effec22392cbe1da511aec) | `Remove unused LockFile::write()`                                                  |
| [`95d657c8`](https://github.com/privatevoid-net/nix-super/commit/95d657c8b3ae4282e24628ba7426edb90c8f3942) | `Input: Replace markFileChanged() by putFile()`                                    |
| [`00c90eae`](https://github.com/privatevoid-net/nix-super/commit/00c90eae95c5987a8352dd786d9687f3d213f54a) | `add note on highlighting examples and syntax definitions`                         |
| [`7f71fc75`](https://github.com/privatevoid-net/nix-super/commit/7f71fc7540502295202b075f82e89fcf993e7e3a) | ``fix: make sure `tar` reproducibility flags are set``                             |
| [`82ddb130`](https://github.com/privatevoid-net/nix-super/commit/82ddb130984c7bdc45cdffc14e81bed720089200) | `Unlock output paths when a derivation is already built`                           |