### PR TITLE
chore(flake/chaotic): `554e3f61` -> `b52e938a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1700588075,
-        "narHash": "sha256-Us7cFGza54mKSFv1GpyAYjLbr+VWFpeNF7UfNj/jv2w=",
+        "lastModified": 1700827896,
+        "narHash": "sha256-cQKVz8g9Fl4INTK8cIrbbv9Xffeu0nrRNV/39TLg/NE=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "554e3f61b64098385bf714e0c219cd3eceed220e",
+        "rev": "b52e938ad0203d20cfaf69ecbe367b3e01d4164d",
         "type": "github"
       },
       "original": {
@@ -279,12 +279,12 @@
         ]
       },
       "locked": {
-        "lastModified": 1700553346,
-        "narHash": "sha256-kW7uWsCv/lxuA824Ng6EYD9hlVYRyjuFn0xBbYltAeQ=",
-        "rev": "1aabb0a31b25ad83cfaa37c3fe29053417cd9a0f",
-        "revCount": 3134,
+        "lastModified": 1700814342,
+        "narHash": "sha256-orNc5wfsE7arQ9TWSTJwvk+utDvJrJ36V84N8o+VI/Y=",
+        "rev": "e1f3b36ab01573fd35cae57d21f45d520433df61",
+        "revCount": 3138,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/home-manager/0.1.3134%2Brev-1aabb0a31b25ad83cfaa37c3fe29053417cd9a0f/018bf0e1-c8d9-75f0-970b-854703e94d26/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/nix-community/home-manager/0.1.3138%2Brev-e1f3b36ab01573fd35cae57d21f45d520433df61/018c0080-ef69-7c8a-b60c-8405526d43fc/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -551,12 +551,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700390070,
-        "narHash": "sha256-de9KYi8rSJpqvBfNwscWdalIJXPo8NjdIZcEJum1mH0=",
-        "rev": "e4ad989506ec7d71f7302cc3067abd82730a4beb",
-        "revCount": 550515,
+        "lastModified": 1700612854,
+        "narHash": "sha256-yrQ8osMD+vDLGFX7pcwsY/Qr5PUd6OmDMYJZzZi0+zc=",
+        "rev": "19cbff58383a4ae384dea4d1d0c823d72b49d614",
+        "revCount": 551719,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.550515%2Brev-e4ad989506ec7d71f7302cc3067abd82730a4beb/018beb83-3bfa-7c0b-8582-037f54875998/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.551719%2Brev-19cbff58383a4ae384dea4d1d0c823d72b49d614/018bfdb3-08a8-7c17-b64e-5653b6d4c279/source.tar.gz"
       },
       "original": {
         "type": "tarball",


### PR DESCRIPTION
| Commit                                                                                          | Message                                        |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------- |
| [`b52e938a`](https://github.com/chaotic-cx/nyx/commit/b52e938ad0203d20cfaf69ecbe367b3e01d4164d) | `` Bump 20231124-1 (#449) ``                   |
| [`c3806922`](https://github.com/chaotic-cx/nyx/commit/c3806922fb8a494de9a0e39ef9916ee4784adafb) | `` Bump 20231123-3 (#448) ``                   |
| [`de4f2859`](https://github.com/chaotic-cx/nyx/commit/de4f2859a06a7c26565c0eb8bd9481764e59be98) | `` nixpkgs: bump to 20231123 ``                |
| [`f35715d9`](https://github.com/chaotic-cx/nyx/commit/f35715d9a2b524bed9059667a9db03ccbaa647e0) | `` linuxPackages_cachyos.zfs: update (#446) `` |
| [`2abb20fc`](https://github.com/chaotic-cx/nyx/commit/2abb20fc381113107c31113e006753a571e22e77) | `` Bump 20231123-1 (#447) ``                   |
| [`aaf2891e`](https://github.com/chaotic-cx/nyx/commit/aaf2891edc4be52cf27ab3a0411e34146f5259d3) | `` schemas: skip more paths in AARCH64 ``      |
| [`80635306`](https://github.com/chaotic-cx/nyx/commit/80635306c02400125ab014c3eac143e1990680b3) | `` Bump 20231122-2 (#445) ``                   |
| [`2ba9439a`](https://github.com/chaotic-cx/nyx/commit/2ba9439adbe670f6967a9f348e96171ec4648092) | `` Bump 20231122-1 (#444) ``                   |
| [`da898637`](https://github.com/chaotic-cx/nyx/commit/da8986373f02e53a7aee7bc4da1bb241a9aa1cab) | `` pkgsx86_64_v3-core: some fixes ``           |
| [`f76083be`](https://github.com/chaotic-cx/nyx/commit/f76083bedadc67011a03f2243bb9421e4b228059) | `` ci: add gccarch-x86-64-v3 feature ``        |
| [`fe33bb00`](https://github.com/chaotic-cx/nyx/commit/fe33bb0051d3b9697dc05aff28f8d408fcec500c) | `` pkgsx86_64_v3-core: init (#443) ``          |