### PR TITLE
chore(flake/spicetify-nix): `af4e84d4` -> `f6375add`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -821,11 +821,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700626492,
-        "narHash": "sha256-5n5d8NPUndHdm1bcDPu8NBIUnzWaATc0k+ftXNXCtos=",
+        "lastModified": 1700811744,
+        "narHash": "sha256-reU+B6cahWylLIM9gKwpoOKnP2XBipp/VsUvweUD3mY=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "af4e84d4d627dec995b144d957b732ed10979d4e",
+        "rev": "f6375add8e79bed9f2c1e94e36c48fb313023294",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`f6375add`](https://github.com/Gerg-L/spicetify-nix/commit/f6375add8e79bed9f2c1e94e36c48fb313023294) | `` big rework in progress ``     |
| [`bbaa4e74`](https://github.com/Gerg-L/spicetify-nix/commit/bbaa4e74ebe5ca657f6b7b045e723eae65944868) | `` CI update 2023-11-24 (#89) `` |
| [`b6f75fc4`](https://github.com/Gerg-L/spicetify-nix/commit/b6f75fc4e2a9d53145b439d5e6ac9a94493c1e0e) | `` CI update 2023-11-23 (#88) `` |