### PR TITLE
chore(flake/hyprland): `d417370b` -> `d79cf0af`

### DIFF
--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -6,28 +6,49 @@ on:
     - cron: "0 12 * * SAT,TUE" # At 12:00 on Saturday & Tuesday (UTC)
 
 jobs:
-  update-multiple-inputs:
+  get-flakes:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.get-flakes.outputs.matrix }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@v23
+      - uses: actions/checkout@v4.1.1
+      - uses: cachix/install-nix-action@v23
         with:
           install_url: "https://releases.nixos.org/nix/nix-2.18.1/install"
-
-      - name: Update flake.lock
-        id: update
-        uses: DeterminateSystems/update-flake-lock@v20
-        with:
-          pr-title: "Update flake.lock" # Title of PR to be created
-          pr-labels: | # Labels to be set on the PR
-            dependencies
-            automated
-
-      - name: merge
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GH_TOKEN }}
+            experimental-features = nix-command flakes recursive-nix
+      - name: generate flake matrix
+        id: get-flakes
         run: |
-          gh pr merge ${{ steps.update.outputs.pull-request-number }} --squash --delete-branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          set -euo pipefail
+
+          flakes="$(nix flake metadata --json | jq -rcM '.locks.nodes.root.inputs | {flake: keys}')"
+          echo "matrix=$flakes" >> "$GITHUB_OUTPUT"
+
+  update-flake:
+    name: update-${{ matrix.flake }}
+    runs-on: ubuntu-latest
+    needs: get-flakes
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.get-flakes.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - uses: cachix/install-nix-action@v23
+        with:
+          install_url: "https://releases.nixos.org/nix/nix-2.18.1/install"
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GH_TOKEN }}
+            experimental-features = nix-command flakes recursive-nix
+      - run: git config --global user.email "lewdovico@gnuweeb.org"
+      - run: git config --global user.name "Ludovico Piero"
+      - uses: cpcloud/flake-update-action@v1.0.4
+        with:
+          dependency: ${{ matrix.flake }}
+          pull-request-token: ${{ secrets.GH_TOKEN }}
+          pull-request-author: Ludovico Piero <lewdovico@gnuweeb.org>
+          github-token: ${{ secrets.GH_TOKEN }}
+          delete-branch: true
+          pull-request-branch-prefix: "flake/update-"
+          automerge: true

--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1700650956,
-        "narHash": "sha256-G6wte9cV8CH8x55ZdqpidSwGjuUE0l02+PdYikavmTE=",
+        "lastModified": 1700833656,
+        "narHash": "sha256-2961vctd4vybU+Nr1mEIxAyu7/wy4/U3NohQG6lQvWU=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "d417370bb725eb58f385b0cbfc924090462164f4",
+        "rev": "d79cf0afe26fd6503a47c17a524d45742bf2461a",
         "type": "github"
       },
       "original": {
@@ -948,18 +948,18 @@
       "flake": false,
       "locked": {
         "host": "gitlab.freedesktop.org",
-        "lastModified": 1699292815,
-        "narHash": "sha256-HXu98PyBMKEWLqiTb8viuLDznud/SdkdJsx5A5CWx7I=",
+        "lastModified": 1700736101,
+        "narHash": "sha256-1Fh1xf/JX5zFbGIF9LDaffaleG6JDwwwnKby0LyiXEA=",
         "owner": "wlroots",
         "repo": "wlroots",
-        "rev": "5de9e1a99d6642c2d09d589aa37ff0a8945dcee1",
+        "rev": "f1762f428b0ef2989c81f57ea9e810403d34d946",
         "type": "gitlab"
       },
       "original": {
         "host": "gitlab.freedesktop.org",
         "owner": "wlroots",
         "repo": "wlroots",
-        "rev": "5de9e1a99d6642c2d09d589aa37ff0a8945dcee1",
+        "rev": "f1762f428b0ef2989c81f57ea9e810403d34d946",
         "type": "gitlab"
       }
     },
@@ -979,11 +979,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1697981233,
-        "narHash": "sha256-y8q4XUwx+gVK7i2eLjfR32lVo7TYvEslyzrmzYEaPZU=",
+        "lastModified": 1700508250,
+        "narHash": "sha256-X4o/mifI7Nhu0UKYlxx53wIC+gYDo3pVM9L2u3PE2bE=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "22e7a65ff9633e1dedfa5317fdffc49f68de2ff2",
+        "rev": "eb120ff25265ecacd0fc13d7dab12131b60d0f47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                       |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
| [`d79cf0af`](https://github.com/hyprwm/Hyprland/commit/d79cf0afe26fd6503a47c17a524d45742bf2461a) | `` renderer: fix software cursors on nvidia ``                                |
| [`334d0ae3`](https://github.com/hyprwm/Hyprland/commit/334d0ae31b9b192b6d8c35a40bc83f9076d22b9d) | `` monitor: fix transform matrix calculations for transformed ``              |
| [`be3d6352`](https://github.com/hyprwm/Hyprland/commit/be3d635265331543b37c6106185fbb67b1293fb3) | `` makefile: update wlroots sover ``                                          |
| [`f9ba5a05`](https://github.com/hyprwm/Hyprland/commit/f9ba5a0551d2b4581a6b8f20c157d120655c337c) | `` flake.lock: update nixpkgs and xdph ``                                     |
| [`258c83f3`](https://github.com/hyprwm/Hyprland/commit/258c83f3bb08cd5a342f4e437e41df179298b4e1) | `` exec: remove redundant environment variables from spawn (#3923) ``         |
| [`aedcade6`](https://github.com/hyprwm/Hyprland/commit/aedcade68dd0615fd919a7249633a554d0accd81) | `` opengl: better checking for required introspection ``                      |
| [`802ab58f`](https://github.com/hyprwm/Hyprland/commit/802ab58f8a129b42d61ec13898fd978e0920f7d8) | `` renderer: fix inverseOpaque calcs in renderWithBlur ``                     |
| [`af5d0659`](https://github.com/hyprwm/Hyprland/commit/af5d06593f83344e20537ad5ec7a780eda4fce87) | `` cmakelists: fix old wlroots sover ``                                       |
| [`2ebfd0c7`](https://github.com/hyprwm/Hyprland/commit/2ebfd0c7456eff7e9c03d379d1dfbc611dc26672) | `` renderer: Move to a full Hyprland GL rendering pipeline (#3920) ``         |
| [`e40e486f`](https://github.com/hyprwm/Hyprland/commit/e40e486f61f2643578b9977b86f408799dbc75fd) | `` renderer: better checks for special rendering in renderWorkspaceWindows `` |
| [`e55c5a91`](https://github.com/hyprwm/Hyprland/commit/e55c5a916ab942e641339471bc80b6d2efbc2044) | `` renderer: make sure lastWindow has correct ws in renderWorkspaceWindows `` |
| [`45ebe0df`](https://github.com/hyprwm/Hyprland/commit/45ebe0df8fd0fd4b649728266f65aa48ac307e96) | `` config: fix red warn in default config ``                                  |
| [`812a3f6d`](https://github.com/hyprwm/Hyprland/commit/812a3f6d78681abbfbc0b01f3b5956c38ae06c1c) | `` renderer: fix double render of tiled on workspace switch ``                |
| [`44accacf`](https://github.com/hyprwm/Hyprland/commit/44accacff934e798b4ce127b009c39004040385a) | `` config: add nomaximizerequest all to default cfg ``                        |