### PR TITLE
chore(flake/master): `9456f455` -> `9a525f85`

### DIFF
--- a/.github/workflows/flake-update.yml
+++ b/.github/workflows/flake-update.yml
@@ -6,28 +6,49 @@ on:
     - cron: "0 12 * * SAT,TUE" # At 12:00 on Saturday & Tuesday (UTC)
 
 jobs:
-  update-multiple-inputs:
+  get-flakes:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.get-flakes.outputs.matrix }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install Nix
-        uses: cachix/install-nix-action@v23
+      - uses: actions/checkout@v4.1.1
+      - uses: cachix/install-nix-action@v23
         with:
           install_url: "https://releases.nixos.org/nix/nix-2.18.1/install"
-
-      - name: Update flake.lock
-        id: update
-        uses: DeterminateSystems/update-flake-lock@v20
-        with:
-          pr-title: "Update flake.lock" # Title of PR to be created
-          pr-labels: | # Labels to be set on the PR
-            dependencies
-            automated
-
-      - name: merge
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GH_TOKEN }}
+            experimental-features = nix-command flakes recursive-nix
+      - name: generate flake matrix
+        id: get-flakes
         run: |
-          gh pr merge ${{ steps.update.outputs.pull-request-number }} --squash --delete-branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          set -euo pipefail
+
+          flakes="$(nix flake metadata --json | jq -rcM '.locks.nodes.root.inputs | {flake: keys}')"
+          echo "matrix=$flakes" >> "$GITHUB_OUTPUT"
+
+  update-flake:
+    name: update-${{ matrix.flake }}
+    runs-on: ubuntu-latest
+    needs: get-flakes
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.get-flakes.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - uses: cachix/install-nix-action@v23
+        with:
+          install_url: "https://releases.nixos.org/nix/nix-2.18.1/install"
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GH_TOKEN }}
+            experimental-features = nix-command flakes recursive-nix
+      - run: git config --global user.email "lewdovico@gnuweeb.org"
+      - run: git config --global user.name "Ludovico Piero"
+      - uses: cpcloud/flake-update-action@v1.0.4
+        with:
+          dependency: ${{ matrix.flake }}
+          pull-request-token: ${{ secrets.GH_TOKEN }}
+          pull-request-author: Ludovico Piero <lewdovico@gnuweeb.org>
+          github-token: ${{ secrets.GH_TOKEN }}
+          delete-branch: true
+          pull-request-branch-prefix: "flake/update-"
+          automerge: true

--- a/flake.lock
+++ b/flake.lock
@@ -439,11 +439,11 @@
     },
     "master": {
       "locked": {
-        "lastModified": 1700656788,
-        "narHash": "sha256-PoLq+d0yIeJn8uDro3ymysIIjDSsYsXzUxhrJDi6nAo=",
+        "lastModified": 1700849916,
+        "narHash": "sha256-aWj87yUHW1yuyuNzl1aVMgQS8jKJaPbQqW0M79mQqdw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9456f455b4f3f89ddb28baadad95f35f7946bb52",
+        "rev": "9a525f854f54d4ac89e9d2fadd1dc5b18e8fa6a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`e6a195fd`](https://github.com/NixOS/nixpkgs/commit/e6a195fdc85d25d1a9d3a9f3f3fd0819dbc0b5ae) | `` qpaeq: remove myself as maintainer ``                                      |
| [`b026c45b`](https://github.com/NixOS/nixpkgs/commit/b026c45bf62b0c14836e8f30ce870336456218ee) | `` zfs: improve description and long description ``                           |
| [`e04c0b0d`](https://github.com/NixOS/nixpkgs/commit/e04c0b0d99fb66e4ab52dc47840f237f92242c4f) | `` zfs_2_1: init at 2.1.13 ``                                                 |
| [`bd8f78d1`](https://github.com/NixOS/nixpkgs/commit/bd8f78d18cb408bc8c507f26a7cde453793129bd) | `` qt6Packages: fix mistake ``                                                |
| [`f3be7d1c`](https://github.com/NixOS/nixpkgs/commit/f3be7d1c46ce9c7d4935c15f19d77208eaeb219c) | `` skopeo: 1.13.3 -> 1.14.0 ``                                                |
| [`487ac169`](https://github.com/NixOS/nixpkgs/commit/487ac1690933f316413cd3f649c1b8a953b81c16) | `` envfs: 1.0.1 -> 1.0.2 ``                                                   |
| [`445c59a3`](https://github.com/NixOS/nixpkgs/commit/445c59a389711c5a43995cc376de80c3d4e63f86) | `` vimPlugins.nvim-treesitter: update grammars ``                             |
| [`6a702bfc`](https://github.com/NixOS/nixpkgs/commit/6a702bfc1a610fd3ef2586b37e854bb65059a01f) | `` python311Packages.types-redis: 4.6.0.10 -> 4.6.0.11 ``                     |
| [`3975e4e2`](https://github.com/NixOS/nixpkgs/commit/3975e4e2e4b04621da5a5e7505b60e54b9ff75e2) | `` vimPlugins: update on 2023-11-24 ``                                        |
| [`a5a9e209`](https://github.com/NixOS/nixpkgs/commit/a5a9e209d947b0164b03ff88bfcbf2bd2cee6273) | `` python311Packages.types-mock: 5.1.0.2 -> 5.1.0.3 ``                        |
| [`92f6a583`](https://github.com/NixOS/nixpkgs/commit/92f6a5833841b991412acc784a1088d416c2d75e) | `` rivercarro: 0.1.4 -> 0.3.0 ``                                              |
| [`a297f17c`](https://github.com/NixOS/nixpkgs/commit/a297f17c13d345978406dc4ceef508ba9610df7c) | `` river: 0.2.4 -> 0.2.5 ``                                                   |
| [`6182b0bd`](https://github.com/NixOS/nixpkgs/commit/6182b0bde8d4a16f5470fa2ee77c07ad3b7088a1) | `` nixos/xscreensaver: add module tests ``                                    |
| [`54020c36`](https://github.com/NixOS/nixpkgs/commit/54020c36a22db2dff3ed39e569c94a2e7857e8e9) | `` nixos/xscreensaver: init module ``                                         |
| [`2034ea01`](https://github.com/NixOS/nixpkgs/commit/2034ea01b9edb411ed5f08acf8a2e4f8af763734) | `` xscreensaver: add suid wrapper patch ``                                    |
| [`45c70262`](https://github.com/NixOS/nixpkgs/commit/45c702624754d2fa8d7367c181ed0f6cd9f1cf8e) | `` maintainers: add vancluever ``                                             |
| [`da426647`](https://github.com/NixOS/nixpkgs/commit/da426647c434045527a18807ee882213d28cb02e) | `` checkov: 3.1.10 -> 3.1.11 ``                                               |
| [`052be0f9`](https://github.com/NixOS/nixpkgs/commit/052be0f9f4399ee8a2cd94fd4a1a7f53a94c81ea) | `` python311Packages.toml-adapt: 0.2.11 -> 0.2.12 ``                          |
| [`b7deec8b`](https://github.com/NixOS/nixpkgs/commit/b7deec8b381459048d0d182456bbdfcb69427a53) | `` python311Packages.sqlalchemy-jsonfield: 1.0.1.post0+2023-04-24 -> 1.0.2 `` |
| [`c9b74e49`](https://github.com/NixOS/nixpkgs/commit/c9b74e4908d3714c22ffaefb7dfe355e3f5c9494) | `` rustc-wasm32: fix targetPlatform ``                                        |
| [`62f7a6dc`](https://github.com/NixOS/nixpkgs/commit/62f7a6dcc1a2baf50e757a6a0bce1083692e0e56) | `` lib.systems.elaborate: fix passing `rust` ``                               |
| [`aa73cc02`](https://github.com/NixOS/nixpkgs/commit/aa73cc02bbcbb8111fff4387798edf96e63f42af) | `` python311Packages.reolink-aio: 0.8.0 -> 0.8.1 ``                           |
| [`a1163912`](https://github.com/NixOS/nixpkgs/commit/a1163912c2ec5ff9f063689c07d09a4a032a80b5) | `` nixos/caddy: Fixed RestartSec typo. ``                                     |
| [`ebb4c66c`](https://github.com/NixOS/nixpkgs/commit/ebb4c66cd56827ca292b2884d432ba963cad08e8) | `` python311Packages.prometheus-pandas: 0.3.2 -> 0.3.3 ``                     |
| [`977d1dc3`](https://github.com/NixOS/nixpkgs/commit/977d1dc3744a41b32a7cf37b1bb3dcce0720433c) | `` python311Packages.oauthenticator: 16.1.1 -> 16.2.0 ``                      |
| [`8f3f6a2a`](https://github.com/NixOS/nixpkgs/commit/8f3f6a2a77c1908a6e0d66cb81e6f8077777afe6) | `` nixos/invoiceplane: Add settings option ``                                 |
| [`be61ae09`](https://github.com/NixOS/nixpkgs/commit/be61ae09c5b794a1ec5e6b0118353603b0af51f4) | `` difftastic: 0.52.0 -> 0.53.0 ``                                            |
| [`e5b0b761`](https://github.com/NixOS/nixpkgs/commit/e5b0b76105f4a29c9dc2cffebd5af4085ece4340) | `` nixos/clamav: add fangfrisch updater ``                                    |
| [`8fd6ce40`](https://github.com/NixOS/nixpkgs/commit/8fd6ce402133658e8315fd6bda078989ee53248f) | `` telegram-desktop: restore build on Hydra ``                                |
| [`e51f34ed`](https://github.com/NixOS/nixpkgs/commit/e51f34ed9e75673579e5fe5d80b6b91d3df71dbb) | `` qbittorrent: add the `wrapGAppsHook` ``                                    |
| [`aa92c1f3`](https://github.com/NixOS/nixpkgs/commit/aa92c1f317470a8729361ac740a974d3ea426290) | `` satty: init at 0.7.0 ``                                                    |
| [`369c508f`](https://github.com/NixOS/nixpkgs/commit/369c508fae6ab9909c943e5e078e524ea58cb227) | `` crun: 1.11.1 -> 1.12 ``                                                    |
| [`8d81d0a4`](https://github.com/NixOS/nixpkgs/commit/8d81d0a43fe555aca6d5bd95529cab67b3263ffc) | `` kyverno: 1.10.4 -> 1.10.5 ``                                               |
| [`d03e0345`](https://github.com/NixOS/nixpkgs/commit/d03e03451410db28f49d7e0ca903166b1c76f5cc) | `` x2goserver: remove myself as maintainer ``                                 |
| [`e1b34c3e`](https://github.com/NixOS/nixpkgs/commit/e1b34c3e79aaa40b3d6c9c7b7ccc12e6e302a706) | `` x2goclient: remove myself as maintainer ``                                 |
| [`73f9b84e`](https://github.com/NixOS/nixpkgs/commit/73f9b84ea674d7f915351fad5d8c734e4e89ae58) | `` libnl-tiny: build only on linux ``                                         |
| [`2e5eaaa6`](https://github.com/NixOS/nixpkgs/commit/2e5eaaa6f52e20b1ce4023f1a972be4111c33859) | `` ocamlPackages.atd: 2.11.0 → 2.15.0 ``                                      |
| [`56336308`](https://github.com/NixOS/nixpkgs/commit/563363087b8dbcc8ca7935a0f23040bc8d02a17b) | `` aliyun-cli: 3.0.184 -> 3.0.186 ``                                          |
| [`4ae56bce`](https://github.com/NixOS/nixpkgs/commit/4ae56bced4076586d986eefd021c7def4858fb84) | `` *: add myself to all openwrt packages as maintainer ``                     |
| [`8a66f36b`](https://github.com/NixOS/nixpkgs/commit/8a66f36bc598f7d87fed153ff1da017a8a84ef79) | `` swaylock-fancy: unstable-2021-10-11 -> unstable-2023-11-21 ``              |
| [`410cd595`](https://github.com/NixOS/nixpkgs/commit/410cd59546a8705457a72e6d868e2d065ede9567) | `` libsForQt5: change comment ``                                              |
| [`6e2e3255`](https://github.com/NixOS/nixpkgs/commit/6e2e32556e01189e6a2f17ad1fac3049ee94b435) | `` qt6Packages: use makeScopeWithSplicing ``                                  |
| [`65874cc8`](https://github.com/NixOS/nixpkgs/commit/65874cc847b3210092aa43fe6de79dd190d9b2a3) | `` qt6: dont use `with self` ``                                               |
| [`1231b72e`](https://github.com/NixOS/nixpkgs/commit/1231b72e01bff56b07c7b0626df6f00df0beaeeb) | `` qt6: use `makeScopeWithSplicing` ``                                        |
| [`95469bd3`](https://github.com/NixOS/nixpkgs/commit/95469bd3e6d1ba088996a2aae89a490cfb963ff4) | `` miniflux: fix http user agent regression ``                                |
| [`221acc91`](https://github.com/NixOS/nixpkgs/commit/221acc9183af496a813b1811f9c66b63c2d9677d) | `` esphome: 2023.11.2 -> 2023.11.3 (#269179) ``                               |
| [`9b2b4ee6`](https://github.com/NixOS/nixpkgs/commit/9b2b4ee621619d34167f17b7f396495855ac6067) | `` lilypond: 2.24.2 -> 2.24.3 ``                                              |
| [`caddd19e`](https://github.com/NixOS/nixpkgs/commit/caddd19e69e37470f6d3fa31067e112ae6c67982) | `` vimPlugins.nvim-treesitter: update grammars ``                             |
| [`e7e619d7`](https://github.com/NixOS/nixpkgs/commit/e7e619d7835e5d053e45715ae073711c9e7a4e56) | `` cosmic-osd: init at unstable-2023-11-15 ``                                 |
| [`98925cfb`](https://github.com/NixOS/nixpkgs/commit/98925cfb42e512e1809fa61eebee61b5618a9eb4) | `` vimPlugins: update on 2023-11-24 ``                                        |
| [`ee2d9390`](https://github.com/NixOS/nixpkgs/commit/ee2d9390c3494a01041adb401fb583ef25d5755e) | `` cosmic-workspaces-epoch: init at unstable-2023-11-21 ``                    |
| [`b5c7ad4e`](https://github.com/NixOS/nixpkgs/commit/b5c7ad4ea30e32538dd515e61a86f2833b88e76a) | `` vimPlugins.vim-lark-syntax: init at 2023-10-10 ``                          |
| [`57fad0db`](https://github.com/NixOS/nixpkgs/commit/57fad0dbec2cb99494e8cd260da32f51dfd4716f) | `` gnomeExtensions.ddterm: unbreak ``                                         |
| [`6d53a0c0`](https://github.com/NixOS/nixpkgs/commit/6d53a0c0d04f702ea6df1c0138d89396bcbd38d6) | `` terraform-providers: drop outdated alias ``                                |
| [`6d16bca7`](https://github.com/NixOS/nixpkgs/commit/6d16bca71cdfed5e6bcb96447d36c721b0737e04) | `` terraform-providers.vault: drop proxyVendor ``                             |
| [`9d229925`](https://github.com/NixOS/nixpkgs/commit/9d229925e132ebec8b62e8c37bb724dd34d942c6) | `` terraform-providers.tailscale: drop go override ``                         |
| [`a8f227bc`](https://github.com/NixOS/nixpkgs/commit/a8f227bcf2dd0c21b1b22d788f911cb752115b8e) | `` terraform-providers.avi: drop proxyVendor ``                               |
| [`1a6f28cb`](https://github.com/NixOS/nixpkgs/commit/1a6f28cbd85187f5a64ef36c1d1ca77f80594bde) | `` nextcloud-notify_push: 0.6.3 -> 0.6.5 ``                                   |
| [`773778c1`](https://github.com/NixOS/nixpkgs/commit/773778c16eb851bc26f4bb83f31bea0bbfd9e540) | `` wrapFirefox: fix error message ``                                          |
| [`e03c9c3f`](https://github.com/NixOS/nixpkgs/commit/e03c9c3f1be4994c63b27ce60d41f13ebfeb3cad) | `` buildLuarocksPackage: save luarocks config as derivation (#269402) ``      |
| [`c40aa4e0`](https://github.com/NixOS/nixpkgs/commit/c40aa4e0c410903b39a24e82e1b1ddf2821d1bdd) | `` invidious: unstable-2023-11-08 -> unstable-2023-11-21 ``                   |
| [`8ac4d38a`](https://github.com/NixOS/nixpkgs/commit/8ac4d38ad99f9b1c7205951b5f19864c87aff3b8) | `` buildGraalvmNativeImage: Set maximum page size to 64K on aarch64-linux ``  |
| [`63a81d98`](https://github.com/NixOS/nixpkgs/commit/63a81d98a51fa56bce338b1de7b94aba04862a99) | `` minify: 2.20.5 -> 2.20.7 ``                                                |
| [`f6831587`](https://github.com/NixOS/nixpkgs/commit/f6831587785ac414e3af4e1dbdcdba7291194336) | `` checkov: 3.1.9 -> 3.1.10 ``                                                |
| [`abe6cf9c`](https://github.com/NixOS/nixpkgs/commit/abe6cf9c602570b8764176cc10922f1500c28b86) | `` cudatext-qt: 1.201.0.2 -> 1.202.1 ``                                       |
| [`8538abf6`](https://github.com/NixOS/nixpkgs/commit/8538abf6708494703d9e6c859779a0dc82972b37) | `` cnspec: 9.6.1 -> 9.8.0 ``                                                  |
| [`38664f70`](https://github.com/NixOS/nixpkgs/commit/38664f70d14626d7bc44a159a075ce5202824665) | `` rl-2311: Add release notes on lib ``                                       |
| [`6816f28c`](https://github.com/NixOS/nixpkgs/commit/6816f28c960c523e6a30f2ad4a1cc812251f5ffb) | `` lib.fileset.fileFilter: Predicate attribute for file extension ``          |
| [`0b59886c`](https://github.com/NixOS/nixpkgs/commit/0b59886c20b7a5ad4f8da5809b9f4ef93bff0d9a) | `` global: 6.6.10 -> 6.6.11 ``                                                |
| [`b8054ecd`](https://github.com/NixOS/nixpkgs/commit/b8054ecd8af39fdd2631d2b921024fc39ce2212c) | `` treewide: add mainProgram ``                                               |
| [`1088b405`](https://github.com/NixOS/nixpkgs/commit/1088b405d142b599132d20b6019ed965a9f4ad44) | `` besu: 23.10.0 -> 23.10.2 ``                                                |
| [`9940847c`](https://github.com/NixOS/nixpkgs/commit/9940847ce7f9eea460f46e97b74f370d4ea69c72) | `` chezmoi: 2.40.4 -> 2.41.0 ``                                               |
| [`e7ca2d56`](https://github.com/NixOS/nixpkgs/commit/e7ca2d56238bf6b31bbd7c4428a3efe82d5a5e33) | `` riemann: 0.3.9 -> 0.3.10 ``                                                |
| [`2f10bac4`](https://github.com/NixOS/nixpkgs/commit/2f10bac416370bc4977c5cb135c9f76a5645cd85) | `` chkrootkit: 0.55 -> 0.58b ``                                               |
| [`a6779efb`](https://github.com/NixOS/nixpkgs/commit/a6779efbbc4fb77355b59c31555b61ba413f09de) | `` javacc: 7.0.12 -> 7.0.13 ``                                                |
| [`d8daf1cb`](https://github.com/NixOS/nixpkgs/commit/d8daf1cb1bf8321aa0882673e29b2d895ccf4241) | `` signal-desktop: 6.39.0 -> 6.39.1, 6.40.0-beta.1 -> 6.40.0-beta.2 ``        |
| [`e33a6455`](https://github.com/NixOS/nixpkgs/commit/e33a6455871efa1dfe139fcb01222bf966f1f7f8) | `` zuo: unstable-2023-11-10 -> unstable-2023-11-23 ``                         |
| [`746e3946`](https://github.com/NixOS/nixpkgs/commit/746e394638e28f254a8c2afa9ab66acd2893268a) | `` bazel_4: fix CLang 16 Werror-s on darwin ``                                |
| [`781538c5`](https://github.com/NixOS/nixpkgs/commit/781538c5ed90dd702a6b976ef6d6235f85869ff3) | `` bazel_5: fix CLang 16 Werror-s on darwin ``                                |
| [`61c87b12`](https://github.com/NixOS/nixpkgs/commit/61c87b12fe053b514ba6d4998ef2e40b245f7576) | `` mimir: 2.10.3 -> 2.10.4 ``                                                 |
| [`3cf18074`](https://github.com/NixOS/nixpkgs/commit/3cf18074db2e7d967d908efbcda49ada694573c0) | `` kodiPackages.radioparadise: 1.0.5 -> 2.0.0 ``                              |
| [`359d5776`](https://github.com/NixOS/nixpkgs/commit/359d577687ea3eb033590cf1259f0355e30b9c6f) | `` figlet: ignore implicit-function-declaration; fix build ``                 |
| [`631766b8`](https://github.com/NixOS/nixpkgs/commit/631766b842cf735a1b6548a6bb389b103dbe3b82) | `` gitlab: migrate to prefetch-yarn-deps (#269307) ``                         |
| [`1d7ee9ff`](https://github.com/NixOS/nixpkgs/commit/1d7ee9ff0901b780f0d9398735307933ac518d77) | `` doc: consolidate info on manual linux kernel configs ``                    |
| [`afa5ac22`](https://github.com/NixOS/nixpkgs/commit/afa5ac226a0b4b446c116af76b7b61c3daaf8b7d) | `` ubus: unstable-2023-06-05 -> unstable-2023-11-14 ``                        |
| [`1a73ff52`](https://github.com/NixOS/nixpkgs/commit/1a73ff52d3c536fcc6b585b36c2fc8adefaef466) | `` libubox: unstable-2023-05-23 -> unstable-2023-11-03 ``                     |
| [`b6d4be13`](https://github.com/NixOS/nixpkgs/commit/b6d4be13d055408c55651f45f1142aba0c26dd87) | `` postgresqlPackages.postgis: fix build on clang 12+ ``                      |
| [`8c249313`](https://github.com/NixOS/nixpkgs/commit/8c24931339fef54406757ec3e8c7080ce0cfed72) | `` mautrix-discord: 0.6.3 -> 0.6.4 ``                                         |
| [`7b6ec1bc`](https://github.com/NixOS/nixpkgs/commit/7b6ec1bc82d0eae4f628b6301fd3b03d19c23d94) | `` wio: init at unstable-2023-05-28 ``                                        |
| [`932441c8`](https://github.com/NixOS/nixpkgs/commit/932441c86d7918f1033f651db3637021d87fa3f5) | `` nixos/nvidia: load `nvidia-uvm` kernel module via `softdep` (#267335) ``   |
| [`f4e8ce58`](https://github.com/NixOS/nixpkgs/commit/f4e8ce5877464d7422376bd702913f77f4bf2024) | `` nix-your-shell: 1.3.0 -> 1.4.0 ``                                          |
| [`dc2ac086`](https://github.com/NixOS/nixpkgs/commit/dc2ac086bbd31b081183e89dbe7259f9767200e8) | `` teams-for-linux: 1.3.19 -> 1.3.22 ``                                       |
| [`8fcfb1d9`](https://github.com/NixOS/nixpkgs/commit/8fcfb1d95c419a9e02ec75ff8ddc25ec623723cb) | `` clj-kondo: Remove references to GraalVM derivation ``                      |
| [`0818809e`](https://github.com/NixOS/nixpkgs/commit/0818809eae890a28372057835bde8f11b9173975) | `` python313: 3.13.0a1 -> 3.13.0a2 ``                                         |
| [`f880f6ba`](https://github.com/NixOS/nixpkgs/commit/f880f6ba3ba60cfed126fe70a998c64a8cc75239) | `` mastodon: migrate to prefetch-yarn-deps ``                                 |
| [`5310b5cd`](https://github.com/NixOS/nixpkgs/commit/5310b5cd4155a56725e3bcdd12c437d5db5c7a77) | `` drawio: 22.0.3 -> 22.1.2 ``                                                |
| [`ffab8d1a`](https://github.com/NixOS/nixpkgs/commit/ffab8d1a3715d748986f84d0b5ae0d8d4e179a40) | `` drawio: migrate to prefetch-yarn-deps ``                                   |
| [`68c2c3d5`](https://github.com/NixOS/nixpkgs/commit/68c2c3d58fde250550f9aa285ae9677bddfeeb42) | `` python311Packages.labelbox: 3.52.0 -> 3.56.0 ``                            |
| [`471655e8`](https://github.com/NixOS/nixpkgs/commit/471655e878b33f1482c8136db7fedb7ff60b92f8) | `` python311Packages.mdformat-mkdocs: enable tests ``                         |
| [`512a00af`](https://github.com/NixOS/nixpkgs/commit/512a00af9f403a462bc554e9a84e3ea24cdc955b) | `` python311Packages.can: 4.2.2 -> 4.3.0 ``                                   |
| [`295a5ac5`](https://github.com/NixOS/nixpkgs/commit/295a5ac532e7a18f2aedf7aaa620761551cceaba) | `` ospd-openvas: 22.6.1 -> 22.6.2 ``                                          |
| [`c7879bcd`](https://github.com/NixOS/nixpkgs/commit/c7879bcd0d70563a4b52503cdfc83b60d6b73e1b) | `` gvm-libs: 22.7.2 -> 22.7.3 ``                                              |
| [`fa094c6d`](https://github.com/NixOS/nixpkgs/commit/fa094c6dd42f8e62334a146e463e3e4684d405c0) | `` chromium: add rpath to libGLESv2.so from libANGLE (#269345) ``             |
| [`3ff36ca6`](https://github.com/NixOS/nixpkgs/commit/3ff36ca61ece26bc9383bfb32a2effb7dc6663ce) | `` nixos/tests/containers-ip: don't include channel sources ``                |
| [`7333ef5b`](https://github.com/NixOS/nixpkgs/commit/7333ef5b8f736bd54d45995be917ccf4db488193) | `` edid-generator: 2018-03-15 -> 2023-11-20 ``                                |
| [`4c8ece56`](https://github.com/NixOS/nixpkgs/commit/4c8ece563ec65526b54501a854b4980da96c2d38) | `` Revert "chromium: add libglvnd to rpath" (#269308) ``                      |
| [`79245fc3`](https://github.com/NixOS/nixpkgs/commit/79245fc3e789355942929e53bd06093f3a116c95) | `` lua: use finalAttrs for interpreters (#264381) ``                          |
| [`1468c674`](https://github.com/NixOS/nixpkgs/commit/1468c67491091ac5a98611a5e7194ce6d9637278) | `` alice-lg: add passthru.tests ``                                            |
| [`aa7c4d71`](https://github.com/NixOS/nixpkgs/commit/aa7c4d71483f2080bea910e8231035bf9c02de1a) | `` python311Packages.mdformat-mkdocs: 1.0.6 -> 1.1.0 ``                       |
| [`169a3091`](https://github.com/NixOS/nixpkgs/commit/169a3091446d6b3ee60f54a8bf1c1a2753c79c5e) | `` php83: 8.3.0RC6 -> 8.3.0 ``                                                |
| [`4b8b0fb9`](https://github.com/NixOS/nixpkgs/commit/4b8b0fb9e6e2fa1e983812083d8189de913faa2b) | `` php82: 8.2.12 -> 8.2.13 ``                                                 |
| [`ca7ec92f`](https://github.com/NixOS/nixpkgs/commit/ca7ec92f3d24432580a7964d1a0f5da57e08ba76) | `` php81: 8.1.25 -> 8.1.26 ``                                                 |
| [`8a9ae79e`](https://github.com/NixOS/nixpkgs/commit/8a9ae79e6922a12a114a92c0df8a496bb687a999) | `` paho-mqtt-cpp: 1.2.0 -> 1.3.0 ``                                           |
| [`349b052f`](https://github.com/NixOS/nixpkgs/commit/349b052f908075ebff0a0383ebd0941657259fac) | `` hysteria: 2.2.1 -> 2.2.2 ``                                                |
| [`a51ea9ca`](https://github.com/NixOS/nixpkgs/commit/a51ea9ca17622486ba0d44a68f8bf65eb5b47b33) | `` nixos: fix bcachefs filesystem with symlinks ``                            |
| [`80dff67e`](https://github.com/NixOS/nixpkgs/commit/80dff67e7bcd6ab5a4a2533b8f2f4d00455acb29) | `` wireplumber: 0.4.15 -> 0.4.16 ``                                           |
| [`e64951ca`](https://github.com/NixOS/nixpkgs/commit/e64951cae483d4ca5b0530fd9f0e7d93330d2359) | `` python311Packages.nbconvert: update meta ``                                |
| [`6c5041bc`](https://github.com/NixOS/nixpkgs/commit/6c5041bc0aed2f1b774c9f88025ff570d1a61159) | `` python311Packages.nbconvert: 7.8.0 -> 7.11.0 ``                            |
| [`34a58ce8`](https://github.com/NixOS/nixpkgs/commit/34a58ce86ff61f35c839f8f776036259d59e3c84) | `` bcachefs: fix lib.kernel.option miss use. ``                               |
| [`ec3fa8c2`](https://github.com/NixOS/nixpkgs/commit/ec3fa8c281769a25d5cc2f0b9f2ea51ddb614db1) | `` python311Packages.jupyter-core: update meta ``                             |
| [`19362a61`](https://github.com/NixOS/nixpkgs/commit/19362a61944170678aa208e8a9cdefb15fdc31f7) | `` python311Packages.jupyter-core: 5.3.1 -> 5.5.0 ``                          |