### PR TITLE
chore(flake/nur): `2bd179e3` -> `6a73c040`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -694,11 +694,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700653534,
-        "narHash": "sha256-Q6DeqqLbBV8XJoYKD8bbS/s6p8IGQDoLiftU1bnKy4k=",
+        "lastModified": 1700847898,
+        "narHash": "sha256-TDZlLBNL6mNP0y+fQ0beDsnlRPRK/ziHWJ5e588kJCw=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "2bd179e349e8ae99fef5dbcbf1d636104582d55e",
+        "rev": "6a73c040a4b9cf6c8c2a11dddd3d98e8f56a7b70",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6a73c040`](https://github.com/nix-community/NUR/commit/6a73c040a4b9cf6c8c2a11dddd3d98e8f56a7b70) | `` automatic update `` |
| [`3b34dcf5`](https://github.com/nix-community/NUR/commit/3b34dcf501cf8490dd94c7b8303aae0260d280be) | `` automatic update `` |
| [`f14d91bf`](https://github.com/nix-community/NUR/commit/f14d91bf1ba6d86dfb96543ff450785b08842b7a) | `` automatic update `` |
| [`72ffcf71`](https://github.com/nix-community/NUR/commit/72ffcf71bf98be49a626d870395be6a8d9e632a8) | `` automatic update `` |
| [`88d1b011`](https://github.com/nix-community/NUR/commit/88d1b0111ee5b76fdbf86b79b955e6158de19cc2) | `` automatic update `` |
| [`19a07aa8`](https://github.com/nix-community/NUR/commit/19a07aa81c698fb0875365114c615aafb6b31260) | `` automatic update `` |
| [`9cacc3c0`](https://github.com/nix-community/NUR/commit/9cacc3c0579aa53d75725d300ff17ae055191c6c) | `` automatic update `` |
| [`49ab578b`](https://github.com/nix-community/NUR/commit/49ab578b491c550ac99dafee3ab8a72eddfd2d66) | `` automatic update `` |
| [`3669296c`](https://github.com/nix-community/NUR/commit/3669296c327aaab19178a6f5dbc6002b2c992980) | `` automatic update `` |
| [`1f36f949`](https://github.com/nix-community/NUR/commit/1f36f94999fa2ff3b224d94f0fc751057cbc8a6e) | `` automatic update `` |
| [`05bbd118`](https://github.com/nix-community/NUR/commit/05bbd118ce31b9b37445526bb553dbfa48402845) | `` automatic update `` |
| [`77a15238`](https://github.com/nix-community/NUR/commit/77a1523886994d58eca71572e994f4cda7b3457a) | `` automatic update `` |
| [`a3730be8`](https://github.com/nix-community/NUR/commit/a3730be8de9efcd74ae604cf7479a818f7b8df41) | `` automatic update `` |
| [`97725a22`](https://github.com/nix-community/NUR/commit/97725a22f2446e4033d1e336ab0d3197335d9927) | `` automatic update `` |
| [`fd1a4f8b`](https://github.com/nix-community/NUR/commit/fd1a4f8bec4d8533081380fc69bbb1dc967671ae) | `` automatic update `` |
| [`893061c4`](https://github.com/nix-community/NUR/commit/893061c4f8d65b5527e63cab6740b546816b9add) | `` automatic update `` |
| [`303e9654`](https://github.com/nix-community/NUR/commit/303e965454cf3390a3c6093c695e52bc196e31ac) | `` automatic update `` |
| [`11c9f0fa`](https://github.com/nix-community/NUR/commit/11c9f0fa9e875325b772e7b758066ca2128a5605) | `` automatic update `` |
| [`5bea2af2`](https://github.com/nix-community/NUR/commit/5bea2af2a3fc7170032493b97af414bc0bcfa8d9) | `` automatic update `` |
| [`51550286`](https://github.com/nix-community/NUR/commit/51550286889673bab46f823306d2aa36fe7bffb4) | `` automatic update `` |
| [`c1e3ad81`](https://github.com/nix-community/NUR/commit/c1e3ad81377ef60f2572d0319aa41a604c03f700) | `` automatic update `` |
| [`b92a4232`](https://github.com/nix-community/NUR/commit/b92a42322b956b5d0cbcc4d7173517d5771f7d40) | `` automatic update `` |
| [`e2af1e4f`](https://github.com/nix-community/NUR/commit/e2af1e4fff08f6e9356a60a47e4207efaa2ef839) | `` automatic update `` |
| [`002f5d73`](https://github.com/nix-community/NUR/commit/002f5d738bfea6272d286678868de7693414362b) | `` automatic update `` |
| [`f6c75b9f`](https://github.com/nix-community/NUR/commit/f6c75b9f136dce133bf97ea254410511c478a912) | `` automatic update `` |
| [`f5958970`](https://github.com/nix-community/NUR/commit/f59589704acf8e8d441c04ad1aa519bf4ca12033) | `` automatic update `` |
| [`0a442e5d`](https://github.com/nix-community/NUR/commit/0a442e5d4e79f9b70deb909d0cae4e735ec70df3) | `` automatic update `` |
| [`8f73b413`](https://github.com/nix-community/NUR/commit/8f73b4136a35d5071ed0434046f401c6ae335b3b) | `` automatic update `` |
| [`d0d22888`](https://github.com/nix-community/NUR/commit/d0d22888151ba6ab7c4d5c0dcf69bbcc8858dc0f) | `` automatic update `` |
| [`2cbe8a17`](https://github.com/nix-community/NUR/commit/2cbe8a174bb45236eee9c268b4b30417842336df) | `` automatic update `` |
| [`dad08828`](https://github.com/nix-community/NUR/commit/dad0882851733400fa35fe14ba6b3fb4c99c5df9) | `` automatic update `` |
| [`3a537496`](https://github.com/nix-community/NUR/commit/3a537496997f80f0457a92ee17a58638296f5db6) | `` automatic update `` |
| [`10e9c427`](https://github.com/nix-community/NUR/commit/10e9c4271fb7a2cb458236217371184e06294ed4) | `` automatic update `` |
| [`f5ae63c5`](https://github.com/nix-community/NUR/commit/f5ae63c5a722e387aa82f781c84cb03a78dc295b) | `` automatic update `` |
| [`bfde44eb`](https://github.com/nix-community/NUR/commit/bfde44eb22da27541fc986fef31e2514468cf615) | `` automatic update `` |
| [`dde12658`](https://github.com/nix-community/NUR/commit/dde1265896e26b818ed4077d8d8dc9e534459d48) | `` automatic update `` |
| [`68f4dc1c`](https://github.com/nix-community/NUR/commit/68f4dc1c03f6fbd2849cdd9779c870940b0077c6) | `` automatic update `` |
| [`1f6e5cdf`](https://github.com/nix-community/NUR/commit/1f6e5cdfd39c57a1e240d46cee3bc91567c97a7a) | `` automatic update `` |
| [`cb2ae869`](https://github.com/nix-community/NUR/commit/cb2ae8692d2de442ace6ea871d16dc98d0a78c4b) | `` automatic update `` |
| [`ee40cb22`](https://github.com/nix-community/NUR/commit/ee40cb22a5c59aceec4d8792e7a7a8073b6d207e) | `` automatic update `` |
| [`af3f6533`](https://github.com/nix-community/NUR/commit/af3f65338fe6a3fcb641c5978a7561d3440e7816) | `` automatic update `` |
| [`c3b91288`](https://github.com/nix-community/NUR/commit/c3b91288a4ee84ca3032c5e9b6c4d93b56bec3b9) | `` automatic update `` |
| [`7f3b35cf`](https://github.com/nix-community/NUR/commit/7f3b35cfdd903926f2d928abd6dfeee49ce5e24f) | `` automatic update `` |
| [`9e74bf0d`](https://github.com/nix-community/NUR/commit/9e74bf0dc3167149e484519440359a347c5b68f4) | `` automatic update `` |
| [`36f67620`](https://github.com/nix-community/NUR/commit/36f6762053dcc282923bda47de2582e2b7c5c878) | `` automatic update `` |
| [`a528bf70`](https://github.com/nix-community/NUR/commit/a528bf7058faa967511785ec9967b661f07255aa) | `` automatic update `` |
| [`7fdd8013`](https://github.com/nix-community/NUR/commit/7fdd8013975a458ed6a81e0368757ff56b2f4df6) | `` automatic update `` |
| [`0b44c1ac`](https://github.com/nix-community/NUR/commit/0b44c1ac9ae6105b4c57123913fb2a969305c75a) | `` automatic update `` |
| [`0707dd06`](https://github.com/nix-community/NUR/commit/0707dd061f4fb82393f3c96c6ed10c60396d7f9c) | `` automatic update `` |
| [`0a618d23`](https://github.com/nix-community/NUR/commit/0a618d2328f9100bc713a4d4a59a83acd98c9a2d) | `` automatic update `` |