### PR TITLE
chore(flake/home-manager): `1aabb0a3` -> `8cedd63e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -298,11 +298,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700553346,
-        "narHash": "sha256-kW7uWsCv/lxuA824Ng6EYD9hlVYRyjuFn0xBbYltAeQ=",
+        "lastModified": 1700847865,
+        "narHash": "sha256-uWaOIemGl9LF813MW0AEgCBpKwFo2t1Wv3BZc6e5Frw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1aabb0a31b25ad83cfaa37c3fe29053417cd9a0f",
+        "rev": "8cedd63eede4c22deb192f1721dd67e7460e1ebe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`8cedd63e`](https://github.com/nix-community/home-manager/commit/8cedd63eede4c22deb192f1721dd67e7460e1ebe) | `` fish: support flexible abbreviations ``        |
| [`e1f3b36a`](https://github.com/nix-community/home-manager/commit/e1f3b36ab01573fd35cae57d21f45d520433df61) | `` home-manager: set unstable release to 24.05 `` |
| [`aeb2232d`](https://github.com/nix-community/home-manager/commit/aeb2232d7a32530d3448318790534d196bf9427a) | `` home-manager: set stable release to 23.11 ``   |
| [`134deb46`](https://github.com/nix-community/home-manager/commit/134deb46abd5d0889d913b8509413f6f38b0811e) | `` bat: support boolean flags in config ``        |
| [`1bd1e864`](https://github.com/nix-community/home-manager/commit/1bd1e8646473235dfe76831812f8662b837cb184) | `` ruff: add module ``                            |