### PR TITLE
chore(flake/master): `d2f4d3b7` -> `fdbeeb35`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -455,11 +455,11 @@
     },
     "master": {
       "locked": {
-        "lastModified": 1700850403,
-        "narHash": "sha256-cKMxuXoj44zfvbCGuatdrB6O7Cy58yg4b+mPwVFBmJY=",
+        "lastModified": 1700851271,
+        "narHash": "sha256-glNV14NrwbuxJ53kWU5HM7dPKeyuZOOV+Bnwz/iI8HI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d2f4d3b7aff7efd236f0651bbb7f21fa395ca7af",
+        "rev": "fdbeeb3547695bb01c638f2c95368eb59c86961c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------- |
| [`25e6e027`](https://github.com/NixOS/nixpkgs/commit/25e6e0273ee50dad1a7fb664d9797905549bb055) | `` apptainer: 1.2.4 -> 1.2.5 `` |