### PR TITLE
chore(flake/stable): `3b8ca944` -> `1216a5ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -853,11 +853,11 @@
     },
     "stable": {
       "locked": {
-        "lastModified": 1700790289,
-        "narHash": "sha256-9i4C64NALHmLzSXQ01a5sESslCp0H/Eyxg8HtO8KkNc=",
+        "lastModified": 1700851152,
+        "narHash": "sha256-3PWITNJZyA3jz5IGREJRfSykM6xSLmD8u5A3WpBCyDM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3b8ca944ce5c089daf2bd739d0ae8e0849e88197",
+        "rev": "1216a5ba22a93a4a3a3bfdb4bff0f4727c576fcc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`7c37839a`](https://github.com/NixOS/nixpkgs/commit/7c37839a447a5754af6fe060c70ca52a7a12db1b) | `` buildMozillaMach: fix crashes due to statically linked libstdc++ `` |