### PR TITLE
chore(flake/lanzaboote): `2123d3a0` -> `cbafc8f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -408,11 +408,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1699973284,
-        "narHash": "sha256-eqic6t1+yd3JXqByexLdZiuyLBzy9KSAOvDBet6yr5Q=",
+        "lastModified": 1700811440,
+        "narHash": "sha256-wrJpW3JCJ9egZpYUMne4c3PFEp+vmkTj5VFpPAT4xdY=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "2123d3a0e1ae16d0a9d1858464edfd34db653653",
+        "rev": "cbafc8f8fe388fba6f2c27224276f5f984f9ae47",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                            |
| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`dd18daae`](https://github.com/nix-community/lanzaboote/commit/dd18daae09eef95695e31546ed91713273434384) | `` tool: parse systemd rc versions ``              |
| [`e8ba04aa`](https://github.com/nix-community/lanzaboote/commit/e8ba04aab70186c48adf78f0f88eeaeea25989ea) | `` tool: extend SystemdVersion with patch level `` |