### PR TITLE
chore(flake/stable): `53127ebc` -> `1216a5ba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -836,11 +836,11 @@
     },
     "stable": {
       "locked": {
-        "lastModified": 1700655232,
-        "narHash": "sha256-cr9w7Co6qLP2wuRIOszjrWxVAljUeEOxjZ08RQps0Xg=",
+        "lastModified": 1700851152,
+        "narHash": "sha256-3PWITNJZyA3jz5IGREJRfSykM6xSLmD8u5A3WpBCyDM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "53127ebc35f86437506288d19b0ff9f702cef35c",
+        "rev": "1216a5ba22a93a4a3a3bfdb4bff0f4727c576fcc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`7c37839a`](https://github.com/NixOS/nixpkgs/commit/7c37839a447a5754af6fe060c70ca52a7a12db1b) | `` buildMozillaMach: fix crashes due to statically linked libstdc++ ``       |
| [`4aab9009`](https://github.com/NixOS/nixpkgs/commit/4aab9009126c82084e4541d0a72d0acc5ad2ef04) | `` php80: 8.0.29 -> 8.0.30 ``                                                |
| [`95911a6e`](https://github.com/NixOS/nixpkgs/commit/95911a6e13de135754bfe8d917509e105212e2ab) | `` php82: 8.2.12 -> 8.2.13 ``                                                |
| [`f8000dee`](https://github.com/NixOS/nixpkgs/commit/f8000dee3a3e3ed96d13a90273b08dd7eb8ff3c0) | `` php81: 8.1.25 -> 8.1.26 ``                                                |
| [`153161bb`](https://github.com/NixOS/nixpkgs/commit/153161bb480e204d5611f8e27ec29743ad636919) | `` buildNpmPackage: add forceEmptyCache option ``                            |
| [`96518719`](https://github.com/NixOS/nixpkgs/commit/965187197ea6b5de13f9e133eb3e7f57029984b0) | `` fetchNpmDeps: add forceEmptyCache option ``                               |
| [`681c59d3`](https://github.com/NixOS/nixpkgs/commit/681c59d31bd842530137a59f32d7e5812c4cf501) | `` prefetch-npm-deps: detect and error out when generating an empty cache `` |
| [`1650b090`](https://github.com/NixOS/nixpkgs/commit/1650b09009ec91f85e2222ac482d255e9ded197c) | `` vault-bin: 1.13.3 -> 1.13.7 ``                                            |
| [`ee42a4f7`](https://github.com/NixOS/nixpkgs/commit/ee42a4f70f391fb782840a899d72d63729e28fa6) | `` vault: 1.13.3 -> 1.13.7 ``                                                |
| [`71e76da8`](https://github.com/NixOS/nixpkgs/commit/71e76da869d86ed9fd2103d0b00e528d78050e46) | `` mjolnir: 1.6.4 -> 1.6.5 ``                                                |
| [`40ff0325`](https://github.com/NixOS/nixpkgs/commit/40ff0325b7ec944b4aa52b2d198ad712f8b028e1) | `` nix: Fix build now that rapidcheck is a shared library ``                 |
| [`f99aec67`](https://github.com/NixOS/nixpkgs/commit/f99aec67dff57ac17a955b6b9cfd43f32fb97c39) | `` rapidcheck: Build shared/static following defaults ``                     |
| [`b5b0910a`](https://github.com/NixOS/nixpkgs/commit/b5b0910a8bf33e5cbad20f8a0bab152bdf967328) | `` redmine: 5.0.5 -> 5.0.6 ``                                                |
| [`9cbfb316`](https://github.com/NixOS/nixpkgs/commit/9cbfb316d20ddfd58346003e151e5aa543247519) | `` gitlab-runner: 16.5.0 -> 16.6.0 ``                                        |
| [`1246a40f`](https://github.com/NixOS/nixpkgs/commit/1246a40f5e6a8f6c66ca31999362a51452a0533f) | `` teleport: 12.4.20 -> 12.4.23 ``                                           |