### PR TITLE
chore(flake/unstable): `37e6adc9` -> `f974988b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -930,11 +930,11 @@
     },
     "unstable": {
       "locked": {
-        "lastModified": 1700553648,
-        "narHash": "sha256-UhENpRvTgaLlfqcRNeLB0FOEhxHRvVOhRi/f9g8F3UI=",
+        "lastModified": 1700775652,
+        "narHash": "sha256-877vMwiT+6G1bHLBW0sv0yJo8SET/5E8da2xB4WZUm8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "37e6adc926fc74e270e86a544a41aecabb0effb1",
+        "rev": "f974988b730c68f9c19de534dd832985776d3044",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`38664f70`](https://github.com/NixOS/nixpkgs/commit/38664f70d14626d7bc44a159a075ce5202824665) | `` rl-2311: Add release notes on lib ``                                                    |
| [`0b59886c`](https://github.com/NixOS/nixpkgs/commit/0b59886c20b7a5ad4f8da5809b9f4ef93bff0d9a) | `` global: 6.6.10 -> 6.6.11 ``                                                             |
| [`b8054ecd`](https://github.com/NixOS/nixpkgs/commit/b8054ecd8af39fdd2631d2b921024fc39ce2212c) | `` treewide: add mainProgram ``                                                            |
| [`1088b405`](https://github.com/NixOS/nixpkgs/commit/1088b405d142b599132d20b6019ed965a9f4ad44) | `` besu: 23.10.0 -> 23.10.2 ``                                                             |
| [`9940847c`](https://github.com/NixOS/nixpkgs/commit/9940847ce7f9eea460f46e97b74f370d4ea69c72) | `` chezmoi: 2.40.4 -> 2.41.0 ``                                                            |
| [`e7ca2d56`](https://github.com/NixOS/nixpkgs/commit/e7ca2d56238bf6b31bbd7c4428a3efe82d5a5e33) | `` riemann: 0.3.9 -> 0.3.10 ``                                                             |
| [`2f10bac4`](https://github.com/NixOS/nixpkgs/commit/2f10bac416370bc4977c5cb135c9f76a5645cd85) | `` chkrootkit: 0.55 -> 0.58b ``                                                            |
| [`a6779efb`](https://github.com/NixOS/nixpkgs/commit/a6779efbbc4fb77355b59c31555b61ba413f09de) | `` javacc: 7.0.12 -> 7.0.13 ``                                                             |
| [`d8daf1cb`](https://github.com/NixOS/nixpkgs/commit/d8daf1cb1bf8321aa0882673e29b2d895ccf4241) | `` signal-desktop: 6.39.0 -> 6.39.1, 6.40.0-beta.1 -> 6.40.0-beta.2 ``                     |
| [`61c87b12`](https://github.com/NixOS/nixpkgs/commit/61c87b12fe053b514ba6d4998ef2e40b245f7576) | `` mimir: 2.10.3 -> 2.10.4 ``                                                              |
| [`359d5776`](https://github.com/NixOS/nixpkgs/commit/359d577687ea3eb033590cf1259f0355e30b9c6f) | `` figlet: ignore implicit-function-declaration; fix build ``                              |
| [`631766b8`](https://github.com/NixOS/nixpkgs/commit/631766b842cf735a1b6548a6bb389b103dbe3b82) | `` gitlab: migrate to prefetch-yarn-deps (#269307) ``                                      |
| [`1d7ee9ff`](https://github.com/NixOS/nixpkgs/commit/1d7ee9ff0901b780f0d9398735307933ac518d77) | `` doc: consolidate info on manual linux kernel configs ``                                 |
| [`7b6ec1bc`](https://github.com/NixOS/nixpkgs/commit/7b6ec1bc82d0eae4f628b6301fd3b03d19c23d94) | `` wio: init at unstable-2023-05-28 ``                                                     |
| [`932441c8`](https://github.com/NixOS/nixpkgs/commit/932441c86d7918f1033f651db3637021d87fa3f5) | `` nixos/nvidia: load `nvidia-uvm` kernel module via `softdep` (#267335) ``                |
| [`f4e8ce58`](https://github.com/NixOS/nixpkgs/commit/f4e8ce5877464d7422376bd702913f77f4bf2024) | `` nix-your-shell: 1.3.0 -> 1.4.0 ``                                                       |
| [`dc2ac086`](https://github.com/NixOS/nixpkgs/commit/dc2ac086bbd31b081183e89dbe7259f9767200e8) | `` teams-for-linux: 1.3.19 -> 1.3.22 ``                                                    |
| [`8fcfb1d9`](https://github.com/NixOS/nixpkgs/commit/8fcfb1d95c419a9e02ec75ff8ddc25ec623723cb) | `` clj-kondo: Remove references to GraalVM derivation ``                                   |
| [`f880f6ba`](https://github.com/NixOS/nixpkgs/commit/f880f6ba3ba60cfed126fe70a998c64a8cc75239) | `` mastodon: migrate to prefetch-yarn-deps ``                                              |
| [`5310b5cd`](https://github.com/NixOS/nixpkgs/commit/5310b5cd4155a56725e3bcdd12c437d5db5c7a77) | `` drawio: 22.0.3 -> 22.1.2 ``                                                             |
| [`ffab8d1a`](https://github.com/NixOS/nixpkgs/commit/ffab8d1a3715d748986f84d0b5ae0d8d4e179a40) | `` drawio: migrate to prefetch-yarn-deps ``                                                |
| [`471655e8`](https://github.com/NixOS/nixpkgs/commit/471655e878b33f1482c8136db7fedb7ff60b92f8) | `` python311Packages.mdformat-mkdocs: enable tests ``                                      |
| [`512a00af`](https://github.com/NixOS/nixpkgs/commit/512a00af9f403a462bc554e9a84e3ea24cdc955b) | `` python311Packages.can: 4.2.2 -> 4.3.0 ``                                                |
| [`295a5ac5`](https://github.com/NixOS/nixpkgs/commit/295a5ac532e7a18f2aedf7aaa620761551cceaba) | `` ospd-openvas: 22.6.1 -> 22.6.2 ``                                                       |
| [`c7879bcd`](https://github.com/NixOS/nixpkgs/commit/c7879bcd0d70563a4b52503cdfc83b60d6b73e1b) | `` gvm-libs: 22.7.2 -> 22.7.3 ``                                                           |
| [`fa094c6d`](https://github.com/NixOS/nixpkgs/commit/fa094c6dd42f8e62334a146e463e3e4684d405c0) | `` chromium: add rpath to libGLESv2.so from libANGLE (#269345) ``                          |
| [`3ff36ca6`](https://github.com/NixOS/nixpkgs/commit/3ff36ca61ece26bc9383bfb32a2effb7dc6663ce) | `` nixos/tests/containers-ip: don't include channel sources ``                             |
| [`7333ef5b`](https://github.com/NixOS/nixpkgs/commit/7333ef5b8f736bd54d45995be917ccf4db488193) | `` edid-generator: 2018-03-15 -> 2023-11-20 ``                                             |
| [`4c8ece56`](https://github.com/NixOS/nixpkgs/commit/4c8ece563ec65526b54501a854b4980da96c2d38) | `` Revert "chromium: add libglvnd to rpath" (#269308) ``                                   |
| [`79245fc3`](https://github.com/NixOS/nixpkgs/commit/79245fc3e789355942929e53bd06093f3a116c95) | `` lua: use finalAttrs for interpreters (#264381) ``                                       |
| [`1468c674`](https://github.com/NixOS/nixpkgs/commit/1468c67491091ac5a98611a5e7194ce6d9637278) | `` alice-lg: add passthru.tests ``                                                         |
| [`aa7c4d71`](https://github.com/NixOS/nixpkgs/commit/aa7c4d71483f2080bea910e8231035bf9c02de1a) | `` python311Packages.mdformat-mkdocs: 1.0.6 -> 1.1.0 ``                                    |
| [`169a3091`](https://github.com/NixOS/nixpkgs/commit/169a3091446d6b3ee60f54a8bf1c1a2753c79c5e) | `` php83: 8.3.0RC6 -> 8.3.0 ``                                                             |
| [`4b8b0fb9`](https://github.com/NixOS/nixpkgs/commit/4b8b0fb9e6e2fa1e983812083d8189de913faa2b) | `` php82: 8.2.12 -> 8.2.13 ``                                                              |
| [`ca7ec92f`](https://github.com/NixOS/nixpkgs/commit/ca7ec92f3d24432580a7964d1a0f5da57e08ba76) | `` php81: 8.1.25 -> 8.1.26 ``                                                              |
| [`8a9ae79e`](https://github.com/NixOS/nixpkgs/commit/8a9ae79e6922a12a114a92c0df8a496bb687a999) | `` paho-mqtt-cpp: 1.2.0 -> 1.3.0 ``                                                        |
| [`a51ea9ca`](https://github.com/NixOS/nixpkgs/commit/a51ea9ca17622486ba0d44a68f8bf65eb5b47b33) | `` nixos: fix bcachefs filesystem with symlinks ``                                         |
| [`80dff67e`](https://github.com/NixOS/nixpkgs/commit/80dff67e7bcd6ab5a4a2533b8f2f4d00455acb29) | `` wireplumber: 0.4.15 -> 0.4.16 ``                                                        |
| [`34a58ce8`](https://github.com/NixOS/nixpkgs/commit/34a58ce86ff61f35c839f8f776036259d59e3c84) | `` bcachefs: fix lib.kernel.option miss use. ``                                            |
| [`c06cd5bf`](https://github.com/NixOS/nixpkgs/commit/c06cd5bfe25c58cda4cc9601e54394c7ee83546a) | `` ocamlPackages.syslog: 1.5 → 2.0.2 ``                                                    |
| [`f1df2acd`](https://github.com/NixOS/nixpkgs/commit/f1df2acd4134c269a7754a44373d77d066bebea5) | `` python3Packages.trimesh: 4.0.1 -> 4.0.4 ``                                              |
| [`9c050375`](https://github.com/NixOS/nixpkgs/commit/9c05037545a6a9774dc9e2fce54ebb6d5aa7934f) | `` python311Packages.polars: remove patch for rustc < 1.73; fix build ``                   |
| [`da35c07d`](https://github.com/NixOS/nixpkgs/commit/da35c07d235521ab19aa5f6fd83edd23f1aad134) | `` nixos/seatd: add readiness notification ``                                              |
| [`aa0b9d27`](https://github.com/NixOS/nixpkgs/commit/aa0b9d27801654dd3ff1e0cb50d34aefd651c799) | `` nixos/tests/seatd: init ``                                                              |
| [`9796cbb0`](https://github.com/NixOS/nixpkgs/commit/9796cbb02175622a5576d53cd340d8e25a6944bc) | `` nixos/seatd: init ``                                                                    |
| [`8be0176e`](https://github.com/NixOS/nixpkgs/commit/8be0176e7c5b41595e7d9f3e5df50226dcba8521) | `` maintainers: add sinanmohd ``                                                           |
| [`e7af27fd`](https://github.com/NixOS/nixpkgs/commit/e7af27fd21ad18e8d5a408f026973399fa4bf1d2) | `` seatd: update meta.description ``                                                       |
| [`35d3f524`](https://github.com/NixOS/nixpkgs/commit/35d3f5241c1c5dd67894dc6ca8f080629a538acf) | `` python311Packages.homeassistant-stubs: 2023.11.2 -> 2023.11.3 (#269348) ``              |
| [`c31544b3`](https://github.com/NixOS/nixpkgs/commit/c31544b31046e9831800b583acb31ad9e9677411) | `` aws2cli: fix urllib3 build (#268590) ``                                                 |
| [`7b1d4601`](https://github.com/NixOS/nixpkgs/commit/7b1d46017ddd3698cbddb8cfff769e53a54b2792) | `` python3Packages.lpc-checksum: init at 3.0.0 ``                                          |
| [`b8fd83df`](https://github.com/NixOS/nixpkgs/commit/b8fd83df7cb00b1cc6c78dcd46eed9d8b25142ae) | `` broot: 1.27.0 -> 1.28.1 ``                                                              |
| [`fc6af54b`](https://github.com/NixOS/nixpkgs/commit/fc6af54bb4a91fe28df26d9161944b7982b0b704) | `` python311Packages.chex: 0.1.84 -> 0.1.85 ``                                             |
| [`183a4ceb`](https://github.com/NixOS/nixpkgs/commit/183a4ceba7ff7f3992ed6184c18d7b33e2edf40e) | `` mpvScripts.simple-mpv-ui: 2.1.0 → 3.0.0 ``                                              |
| [`65b81db7`](https://github.com/NixOS/nixpkgs/commit/65b81db7bb98de7ac3ae7e4faa40089895f8370d) | `` mpvScripts.simple-mpv-webui: Refactor with `buildLua` ``                                |
| [`8438431b`](https://github.com/NixOS/nixpkgs/commit/8438431b9f87e36df21da4ab4d025ba8b4eff937) | `` mpvScripts.buildLua: Handle scripts packaged as directories ``                          |
| [`b4f1587b`](https://github.com/NixOS/nixpkgs/commit/b4f1587b2759c7c6e83f8a2e2bfce7f10fb3c9d2) | `` inshellisense: init at 0.0.1-rc.4 ``                                                    |
| [`862514ab`](https://github.com/NixOS/nixpkgs/commit/862514ab2f906d0ea49318209e68493115c9a337) | `` muzika: migrate to prefetch-yarn-deps ``                                                |
| [`4df54803`](https://github.com/NixOS/nixpkgs/commit/4df54803189c5f150b6a3fdbe8a40e11f7b5b765) | `` element-desktop: migrate to prefetch-yarn-deps ``                                       |
| [`09b9b740`](https://github.com/NixOS/nixpkgs/commit/09b9b7404a212b0302e8b25aaf816595c6fd8b9d) | `` element-web: migrate to prefetch-yarn-deps ``                                           |
| [`51fe2a71`](https://github.com/NixOS/nixpkgs/commit/51fe2a7113153f627a93ed7141c7971354141d72) | `` schildichat-desktop: migrate to prefetch-yarn-deps ``                                   |
| [`9c72a1eb`](https://github.com/NixOS/nixpkgs/commit/9c72a1eb7111e34eab992c7f61ad4c3c3c2cc14e) | `` schildichat-web: migrate to prefetch-yarn-deps ``                                       |
| [`18cc6774`](https://github.com/NixOS/nixpkgs/commit/18cc67740ee61574b4b984f7926a804ad96c0a88) | `` teams-for-linux: migrate to prefetch-yarn-deps ``                                       |
| [`d868cb9c`](https://github.com/NixOS/nixpkgs/commit/d868cb9cb2e4fa474c0ad97e7f2f29c5ddd03a90) | `` alice-lg: migrate to prefetch-yarn-deps ``                                              |
| [`ed175a63`](https://github.com/NixOS/nixpkgs/commit/ed175a635e0fe5e30121c104ef8327614484a610) | `` bazel_6: fix CLang 16 Werror-s on darwin ``                                             |
| [`e7d2400c`](https://github.com/NixOS/nixpkgs/commit/e7d2400cd75aaca7d201145d57c80c25c956b213) | `` maestral-qt: fix qt6 usage and crash on wayland ``                                      |
| [`20a73f36`](https://github.com/NixOS/nixpkgs/commit/20a73f36fa616bfda0c515e6081d6e0769aa4a14) | `` sssd: add adcli path ``                                                                 |
| [`39505338`](https://github.com/NixOS/nixpkgs/commit/39505338e1fc5b02d08d93b379d630b0bc7daedd) | `` teleport: migrate to prefetch-yarn-deps ``                                              |
| [`b2f67d3f`](https://github.com/NixOS/nixpkgs/commit/b2f67d3f4847c61bf0b3fc4c41796c87df9f92b3) | `` nixos/nix-serve: fix module compatibility with unflaked Nix ``                          |
| [`be6349fd`](https://github.com/NixOS/nixpkgs/commit/be6349fdee1e4622e442b665d929cafaeadbc42a) | `` Revert "23.11 beta release" ``                                                          |
| [`af3fe785`](https://github.com/NixOS/nixpkgs/commit/af3fe78509c6df2dad1fbaec0cb90f2558b5211b) | `` git-cola: fix package version ``                                                        |
| [`34aee8e6`](https://github.com/NixOS/nixpkgs/commit/34aee8e6404e2ab34c49f33616fdcf7789e71ff2) | `` git-cola: 4.2.1 -> 4.4.0 ``                                                             |
| [`bb09d4e2`](https://github.com/NixOS/nixpkgs/commit/bb09d4e2972725960339d4a004b6da2d87a33e8b) | `` git-cola: add updateScript ``                                                           |
| [`f77f6bcd`](https://github.com/NixOS/nixpkgs/commit/f77f6bcd9640c7fc7aa5116237279dd6abbf22b3) | `` element-{web,desktop}: 1.11.47 -> 1.11.50 ``                                            |
| [`f16843cb`](https://github.com/NixOS/nixpkgs/commit/f16843cb3132944db30896992d319a693fa050c6) | `` fetch-yarn-deps: fix missing cert when fetching packages ``                             |
| [`c7916a50`](https://github.com/NixOS/nixpkgs/commit/c7916a507b6657f82a42741790a86e66f7783480) | `` beets-minimal: fix building with no plugins ``                                          |
| [`7bdddc83`](https://github.com/NixOS/nixpkgs/commit/7bdddc83b2292e1e8b0931f1fe8b2e82cd61a53c) | `` beets: fix build with Sphinx 6 ``                                                       |
| [`8e3009d9`](https://github.com/NixOS/nixpkgs/commit/8e3009d95c3334369a59ac9b02dab4393bb7c1c7) | `` buildNpmPackage: add forceEmptyCache option ``                                          |
| [`05dc145e`](https://github.com/NixOS/nixpkgs/commit/05dc145e807dd0f04c7057c2f433ab4abc105e0a) | `` fetchNpmDeps: add forceEmptyCache option ``                                             |
| [`ec51a56d`](https://github.com/NixOS/nixpkgs/commit/ec51a56dfc26f29b6ae3183b5e3132d529e01678) | `` prefetch-npm-deps: detect and error out when generating an empty cache ``               |
| [`54b7a396`](https://github.com/NixOS/nixpkgs/commit/54b7a396467dda279a5d2471b46900a75d5113db) | `` peertube: Clarify option descriptions of `listenHttp`, `listenWeb`, `enableWebHttps` `` |
| [`7f281ee2`](https://github.com/NixOS/nixpkgs/commit/7f281ee2f0b49ee6e7cdefa8fad38750b499fcd1) | `` python311Packages.adguardhome: update disabled ``                                       |
| [`8b68c650`](https://github.com/NixOS/nixpkgs/commit/8b68c650d882f0935f1c7e184f0a2a7e339d4a6d) | `` llvmPackages_16.libclc: fix cross eval ``                                               |
| [`8d7ea3a6`](https://github.com/NixOS/nixpkgs/commit/8d7ea3a6fb02a1a0248ce7f1e0a080e3d9f5d431) | `` python311Packages.hahomematic: 2023.11.3 -> 2023.11.4 ``                                |
| [`0dd3d668`](https://github.com/NixOS/nixpkgs/commit/0dd3d66819dffaab1de615fc1da53af333b1e7de) | `` python311Packages.hahomematic: 2023.11.1 -> 2023.11.3 ``                                |
| [`1da41aa7`](https://github.com/NixOS/nixpkgs/commit/1da41aa7904d7ad3697d33d8c3cee0d769ab07c1) | `` python311Packages.ha-mqtt-discoverable: 0.10.0 -> 0.11.0 ``                             |
| [`418cbc31`](https://github.com/NixOS/nixpkgs/commit/418cbc31ed7db53ac0c575e7e1756ef62da1d367) | `` python311Packages.elasticsearch8: 8.10.1 -> 8.11.0 ``                                   |
| [`2bb2b3ae`](https://github.com/NixOS/nixpkgs/commit/2bb2b3ae1da43cc09950ef7f0b004ad5c2e156db) | `` gosec: 2.18.0 -> 2.18.2 ``                                                              |
| [`3832b75e`](https://github.com/NixOS/nixpkgs/commit/3832b75e4e37be74c0311b4f03191c6e221966f0) | `` cmake: fix risc-v build failure ``                                                      |
| [`48dc37ae`](https://github.com/NixOS/nixpkgs/commit/48dc37ae96adf8bb4a952712aadb7c236d39ca02) | `` apt-offline: 1.8.4 -> 1.8.5 ``                                                          |
| [`1751247c`](https://github.com/NixOS/nixpkgs/commit/1751247c95441716d5ba9b263be0928ce1d1c8a2) | `` apt-offline: adopt and refactor ``                                                      |
| [`18c71e75`](https://github.com/NixOS/nixpkgs/commit/18c71e751b43f0554149e22dcdc2c15abb4fc45e) | `` apt: adopt and refactor ``                                                              |
| [`0e858267`](https://github.com/NixOS/nixpkgs/commit/0e858267b37884abc8721c49acfd172f53b04893) | `` git-machete: unbreak by disabling shell completion tests ``                             |
| [`672ca196`](https://github.com/NixOS/nixpkgs/commit/672ca196a99026a9880272acb8fdc279721e1e97) | `` git-machete: 3.17.9 -> 3.20.0 ``                                                        |
| [`0e23cb37`](https://github.com/NixOS/nixpkgs/commit/0e23cb377f88f4d1eeddf3b1c1e544d3d0525db8) | `` ollama: 0.1.7 -> 0.1.11 ``                                                              |
| [`d3cf1524`](https://github.com/NixOS/nixpkgs/commit/d3cf1524beafc333cffe7a85765b5d7510603fe9) | `` python3Packages.aw-client: 0.5.12 -> 0.5.13 ``                                          |
| [`d0923422`](https://github.com/NixOS/nixpkgs/commit/d09234229f514b2ff4965ae8369ca07c29ef8e64) | `` sequoia-chameleon-gnupg: 0.3.2 -> unstable-2023-11-22 ``                                |
| [`63bba56e`](https://github.com/NixOS/nixpkgs/commit/63bba56eebc7b9878bf582fb666684c1f93067cf) | `` linuxKernel.kernels.linux_lqx: 6.5.11-lqx2 -> 6.6.2-lqx1 ``                             |
| [`11eec02a`](https://github.com/NixOS/nixpkgs/commit/11eec02a710d81d6325c26ece439ca5a5522b479) | `` localsend: don't move binary to bin/localsend ``                                        |
| [`d35a9536`](https://github.com/NixOS/nixpkgs/commit/d35a9536907c7ebca6b575c1dd5b788748ad2b72) | `` commitmsgfmt: init at 1.6.0 ``                                                          |
| [`688ae465`](https://github.com/NixOS/nixpkgs/commit/688ae46559b9d93cc129e92a9937f4e71ab127c0) | `` linuxKernel.kernels.linux_zen: 6.6.1-zen1 -> 6.6.2-zen1 ``                              |
| [`827232d6`](https://github.com/NixOS/nixpkgs/commit/827232d6dd2b7787749afdfef614fbea8d88ebe9) | `` lib.fileset: Document decision for strict existence checks ``                           |
| [`9df167ee`](https://github.com/NixOS/nixpkgs/commit/9df167eebb604af911e7a6cddd8e8d6160fbad50) | `` python311Packages.pytorch-lightning: 2.1.1 -> 2.1.2 ``                                  |
| [`bef55841`](https://github.com/NixOS/nixpkgs/commit/bef55841a27cd41710bf52e6d6de41bd8733a1fc) | `` boogie: 3.0.5 -> 3.0.6 ``                                                               |
| [`3184225f`](https://github.com/NixOS/nixpkgs/commit/3184225f603eb81c63fde6c955fa34216192ae6f) | `` corosync: 3.1.7 -> 3.1.8 ``                                                             |
| [`766f6aee`](https://github.com/NixOS/nixpkgs/commit/766f6aee79c875eec9d983ba512c0dcd09b0a917) | `` python311Packages.symengine: 0.10.0 -> 0.11.0 ``                                        |
| [`4beadb0c`](https://github.com/NixOS/nixpkgs/commit/4beadb0c19a22a5433329e349f29a4a2fc40c512) | `` grafana-agent: 0.37.4 -> 0.38.0 ``                                                      |
| [`612493c6`](https://github.com/NixOS/nixpkgs/commit/612493c63d4e8af96b9747b70f86d83b8b73937a) | `` gnatcoll-python3: use python 3.9 ``                                                     |
| [`6a096e14`](https://github.com/NixOS/nixpkgs/commit/6a096e149947697d8f343fce1fe5aba86966e388) | `` emacs.pkgs.ada-mode: fix installPhase ``                                                |
| [`7db5b159`](https://github.com/NixOS/nixpkgs/commit/7db5b159eb84f9e439a30ec106fbe3fa0af3a566) | `` gnatcoll-*: 23.0.0 -> 24.0.0 ``                                                         |
| [`5c221559`](https://github.com/NixOS/nixpkgs/commit/5c2215595fd7a22f47be7da732b40183472b44e3) | `` gprbuild: 23.0.0 -> 24.0.0 ``                                                           |
| [`0d88bf2a`](https://github.com/NixOS/nixpkgs/commit/0d88bf2ae5cdfb714f3b85263673f1510ae32977) | `` xmlada: 23.0.0 -> 24.0.0 ``                                                             |
| [`9952892c`](https://github.com/NixOS/nixpkgs/commit/9952892cb68c376738d1b18ffbe1099139483864) | `` home-assistant: 2023.11.2 -> 2023.11.3 ``                                               |
| [`ce47f8f7`](https://github.com/NixOS/nixpkgs/commit/ce47f8f7ae07e2edcff8212cb5ea2eacb5742578) | `` python311Packages.zwave-js-server-python: 0.53.1 -> 0.54.0 ``                           |
| [`9191cc98`](https://github.com/NixOS/nixpkgs/commit/9191cc9865bfe4840888edf9c2b03c1fbaca0e71) | `` jmol: 16.1.43 -> 16.1.45 ``                                                             |
| [`39da31db`](https://github.com/NixOS/nixpkgs/commit/39da31dbb9d13c35092f76bd2bb9788a8dcb419e) | `` oh-my-posh: 18.22.0 -> 18.26.1 ``                                                       |
| [`f99f9ced`](https://github.com/NixOS/nixpkgs/commit/f99f9ced56cdae53acaef68991787693316c6c02) | `` rustpython: 0.2.0 -> 0.3.0 ``                                                           |
| [`c8208d43`](https://github.com/NixOS/nixpkgs/commit/c8208d43fd136f49604bfc616945b60943b6f080) | `` gama: 2.26 -> 2.27 ``                                                                   |
| [`11450d22`](https://github.com/NixOS/nixpkgs/commit/11450d22ff86e2d27f4a84b351bbcdc0252fe970) | `` python311Packages.velbus-aio: 2023.10.2 -> 2023.11.0 ``                                 |
| [`043f41a7`](https://github.com/NixOS/nixpkgs/commit/043f41a7b9cc4b30e6c17b329d1c76e3a07e034b) | `` python311Packages.qasync: 0.26.1 -> 0.27.0 ``                                           |
| [`ad5f1cc7`](https://github.com/NixOS/nixpkgs/commit/ad5f1cc7e6419e50df50c2420a285699a21ed1ad) | `` zim-tools: 3.2.0 -> 3.3.0 ``                                                            |
| [`afead8e4`](https://github.com/NixOS/nixpkgs/commit/afead8e42f0025e19b69a5c1e64132a4e87835f4) | `` python311Packages.pytapo: 3.3.6 -> 3.3.16 ``                                            |
| [`4121a13b`](https://github.com/NixOS/nixpkgs/commit/4121a13bd7d8e43ce0c55546acb452919db17ede) | `` hyperrogue: 12.1x -> 12.1y ``                                                           |
| [`77e4936b`](https://github.com/NixOS/nixpkgs/commit/77e4936b37429df3138ae7de4791f4f1f775f4f6) | `` spleen: 2.0.0 -> 2.0.1 ``                                                               |
| [`e9fda01c`](https://github.com/NixOS/nixpkgs/commit/e9fda01ca9779be81a049124db2bb9330181e675) | `` python311Packages.bqscales: fix build ``                                                |
| [`dff07904`](https://github.com/NixOS/nixpkgs/commit/dff079046dc66cbf84ac2df982181a8cf9465a93) | `` python311Packages.python-matter-server: 4.0.1 -> 4.0.2 ``                               |
| [`be884b15`](https://github.com/NixOS/nixpkgs/commit/be884b15c483ca7b1cdda519352b92bda8510c41) | `` python311Packages.gcal-sync: 5.0.0 -> 6.0.1 ``                                          |
| [`5614bbae`](https://github.com/NixOS/nixpkgs/commit/5614bbae90face6f6b2195c7be1361ed65ed60f6) | `` python311Packages.ical: 5.1.1 -> 6.1.0 ``                                               |
| [`d26a220d`](https://github.com/NixOS/nixpkgs/commit/d26a220d3b33680c6117186ebadb0d0d1ea0fc8d) | `` python311Packages.aiocomelit: 0.5.0 -> 0.6.0 ``                                         |
| [`ef1a9550`](https://github.com/NixOS/nixpkgs/commit/ef1a9550bd0ca56456fdca538bfe81408e97ec37) | `` consul-template: add meta.mainProgram ``                                                |
| [`e6b3ab57`](https://github.com/NixOS/nixpkgs/commit/e6b3ab57037727b70f69bd1784911f722eb8e26f) | `` jellyfin-web: 10.8.11 -> 10.8.12 ``                                                     |
| [`764502a2`](https://github.com/NixOS/nixpkgs/commit/764502a27545ec382a3e84e53c55dcba7a0fbe18) | `` python311Packages.pyatag: refactor ``                                                   |
| [`9b8808af`](https://github.com/NixOS/nixpkgs/commit/9b8808af31202c33ed35349ebdef08ed65ad84d9) | `` python311Packages.pyatag: 3.5.1 -> 0.3.7.1 ``                                           |
| [`45236fe8`](https://github.com/NixOS/nixpkgs/commit/45236fe8e0e32074f2aab3374123afa5abd0eff2) | `` kodiPackages.arrow: 1.0.3.1 -> 1.2.3 ``                                                 |
| [`3cb52cd7`](https://github.com/NixOS/nixpkgs/commit/3cb52cd725667cd4005e35946bf4fb31eb78477e) | `` kics: 1.7.10 -> 1.7.11 ``                                                               |
| [`27e3c237`](https://github.com/NixOS/nixpkgs/commit/27e3c237aae8c1054f14b1cfc6cc97b2f9e7dff9) | `` python311Packages.total-connect-client: 2023.11 -> 2023.11.1 ``                         |
| [`2ccae776`](https://github.com/NixOS/nixpkgs/commit/2ccae77687d587c98eb0d2c5c873f83e0aa6400c) | `` gnomeExtensions.freon: fix patch ``                                                     |
| [`8bfe8944`](https://github.com/NixOS/nixpkgs/commit/8bfe8944cf48f7d2c0e9af812d551340e09e6cd2) | `` mako: add mainProgram ``                                                                |
| [`ef1e0644`](https://github.com/NixOS/nixpkgs/commit/ef1e06441eb06fd11070b19d0a1fbb36f1ee04d3) | `` .github/labeler.yml: autolabel jupyter stuff ``                                         |
| [`90c76737`](https://github.com/NixOS/nixpkgs/commit/90c7673764462fb6c66358d4103f3ed8adbd8720) | `` lunar-client: add mainProgram ``                                                        |
| [`c23d39e1`](https://github.com/NixOS/nixpkgs/commit/c23d39e10321d9fd8aa913b0f8b744fb946a74a3) | `` lunar-client: 3.1.0 -> 3.1.3 ``                                                         |