### PR TITLE
chore(flake/hyprland): `d79cf0af` -> `512a5973`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1700833656,
-        "narHash": "sha256-2961vctd4vybU+Nr1mEIxAyu7/wy4/U3NohQG6lQvWU=",
+        "lastModified": 1700876704,
+        "narHash": "sha256-V3Z1SYEpi5baifNxvIOgBWWy9J0m0hZ8arAMS4XpbZk=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "d79cf0afe26fd6503a47c17a524d45742bf2461a",
+        "rev": "512a59731b2e579b66325d0e9ce770919eecd685",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                    |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
| [`512a5973`](https://github.com/hyprwm/Hyprland/commit/512a59731b2e579b66325d0e9ce770919eecd685) | `` config: default special_scale_factor to 1 ``                            |
| [`a6eba919`](https://github.com/hyprwm/Hyprland/commit/a6eba919356b08a2a403a52c1e5e020734411668) | `` opengl: require introspection on mirroring ``                           |
| [`745b9985`](https://github.com/hyprwm/Hyprland/commit/745b998587fc39db6e3f77caa54074da618cd509) | `` renderer: Adding an option to disable first launch animation (#3933) `` |
| [`1a2a2da6`](https://github.com/hyprwm/Hyprland/commit/1a2a2da6aa1b8ee0ff6b85112d088dcc5c93862f) | `` renderer: fixup cursor scaling ``                                       |
| [`822775aa`](https://github.com/hyprwm/Hyprland/commit/822775aa8c0134e66cbf09b7dfd785fad13f329a) | `` renderer: Fixup double rendering cases with special (#3928) ``          |