### PR TITLE
chore(flake/nur): `6a73c040` -> `e51798a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700847898,
-        "narHash": "sha256-TDZlLBNL6mNP0y+fQ0beDsnlRPRK/ziHWJ5e588kJCw=",
+        "lastModified": 1700874374,
+        "narHash": "sha256-aJlAjLZfmXAUvdksPDWXKfUTeqtu0xwTsCyCw8z7N40=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "6a73c040a4b9cf6c8c2a11dddd3d98e8f56a7b70",
+        "rev": "e51798a838e6e49a8c3f0a58054c973829e2f806",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e51798a8`](https://github.com/nix-community/NUR/commit/e51798a838e6e49a8c3f0a58054c973829e2f806) | `` automatic update `` |
| [`7ddd84ac`](https://github.com/nix-community/NUR/commit/7ddd84acfc35469739ebddbaa2f58f9eebd60869) | `` automatic update `` |
| [`ebf2c682`](https://github.com/nix-community/NUR/commit/ebf2c68214f10ee5b9372ae4960a7b54af514bd3) | `` automatic update `` |