### PR TITLE
chore(flake/nur): `e51798a8` -> `a4842789`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700874374,
-        "narHash": "sha256-aJlAjLZfmXAUvdksPDWXKfUTeqtu0xwTsCyCw8z7N40=",
+        "lastModified": 1700885377,
+        "narHash": "sha256-iULLmi/wp0QBpmKMBLeB+OtEpXoCAymuTkGGbLzaGrM=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "e51798a838e6e49a8c3f0a58054c973829e2f806",
+        "rev": "a484278909b1360587e1053e5b2cbb55ac343778",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a4842789`](https://github.com/nix-community/NUR/commit/a484278909b1360587e1053e5b2cbb55ac343778) | `` automatic update `` |
| [`d754bccc`](https://github.com/nix-community/NUR/commit/d754bccc0094ac3267aaa41f96b243ab9d0cf8e8) | `` automatic update `` |