### PR TITLE
chore(flake/unstable): `f974988b` -> `1b99d72c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -930,11 +930,11 @@
     },
     "unstable": {
       "locked": {
-        "lastModified": 1700775652,
-        "narHash": "sha256-877vMwiT+6G1bHLBW0sv0yJo8SET/5E8da2xB4WZUm8=",
+        "lastModified": 1700867874,
+        "narHash": "sha256-0Dk63BLiG9rmfBf8LxFpz8KgpUkepehVzhhVDgfxWSo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f974988b730c68f9c19de534dd832985776d3044",
+        "rev": "1b99d72c8b7468def0c633635c469bf828db33a0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                   |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
| [`ac12ef04`](https://github.com/NixOS/nixpkgs/commit/ac12ef04f77369c53cac744fb5d9fe729f9a9989) | `` lefthook: migrate to by-name ``                                                                        |
| [`144f5dcb`](https://github.com/NixOS/nixpkgs/commit/144f5dcb198ecbd8e03bd3192fd3d550cbb717df) | `` libpkgconf: migrate to by-name ``                                                                      |
| [`8ed9ed74`](https://github.com/NixOS/nixpkgs/commit/8ed9ed7459b0c8b19bf22541db2bfc176e77b92b) | `` meilisearch: 1.3.1 -> 1.5.0 ``                                                                         |
| [`644b234e`](https://github.com/NixOS/nixpkgs/commit/644b234e1c17aad539c03ac8020f831e20241d50) | `` sapling: migrate to prefetch-yarn-deps ``                                                              |
| [`d002cef8`](https://github.com/NixOS/nixpkgs/commit/d002cef82fb3d9506fb8d0993e05cf3cd64a24bb) | `` limesuite: 23.10.0 -> 23.11.0 ``                                                                       |
| [`b7f2ff8e`](https://github.com/NixOS/nixpkgs/commit/b7f2ff8e68993dc64707fa88db973291336f9338) | `` ugrep: 4.3.3 -> 4.3.4 ``                                                                               |
| [`12315f53`](https://github.com/NixOS/nixpkgs/commit/12315f53ff6afad470ece13a666c21dd8aad770f) | `` treewide: add mainProgram ``                                                                           |
| [`14caf2eb`](https://github.com/NixOS/nixpkgs/commit/14caf2eb45eebce6a8b6289882546bea6beba321) | `` conan: 2.0.5 -> 2.0.14 ``                                                                              |
| [`fc23c760`](https://github.com/NixOS/nixpkgs/commit/fc23c7607944ec7b419d03aa24a8e686ac11a64b) | `` wg-friendly-peer-names: unstable-2021-11-08 -> unstable-2021-12-10 ``                                  |
| [`371f4951`](https://github.com/NixOS/nixpkgs/commit/371f49512e8d091913105b8acba46111aa83f21a) | `` netbird: 0.24.2 -> 0.24.3 ``                                                                           |
| [`2db2f446`](https://github.com/NixOS/nixpkgs/commit/2db2f446c27b7be976822cf4d502857a0f522b2f) | `` nixos/git: add prompt.enable ``                                                                        |
| [`8de1ab61`](https://github.com/NixOS/nixpkgs/commit/8de1ab61a6b089cc0fa708adc2d9361a5b46890f) | `` presenterm: 0.2.1 -> 0.3.0 ``                                                                          |
| [`2b2e00ca`](https://github.com/NixOS/nixpkgs/commit/2b2e00caecac8799bb03bbc76da63833606ecfb2) | `` gnomeExtensions.pano: refresh patch ``                                                                 |
| [`d2f4d3b7`](https://github.com/NixOS/nixpkgs/commit/d2f4d3b7aff7efd236f0651bbb7f21fa395ca7af) | `` apt: 2.7.6 -> 2.7.7 ``                                                                                 |
| [`2ef00f3e`](https://github.com/NixOS/nixpkgs/commit/2ef00f3e0babd0200e6d01c1948e96a6926241e7) | `` libpkgconf: 2.0.3 -> 2.1.0 ``                                                                          |
| [`7351284f`](https://github.com/NixOS/nixpkgs/commit/7351284f4ca77e370c98e2cd56ae31b12f9c8aa8) | `` lefthook: 1.5.2 -> 1.5.3 ``                                                                            |
| [`e6a195fd`](https://github.com/NixOS/nixpkgs/commit/e6a195fdc85d25d1a9d3a9f3f3fd0819dbc0b5ae) | `` qpaeq: remove myself as maintainer ``                                                                  |
| [`b026c45b`](https://github.com/NixOS/nixpkgs/commit/b026c45bf62b0c14836e8f30ce870336456218ee) | `` zfs: improve description and long description ``                                                       |
| [`e04c0b0d`](https://github.com/NixOS/nixpkgs/commit/e04c0b0d99fb66e4ab52dc47840f237f92242c4f) | `` zfs_2_1: init at 2.1.13 ``                                                                             |
| [`bd8f78d1`](https://github.com/NixOS/nixpkgs/commit/bd8f78d18cb408bc8c507f26a7cde453793129bd) | `` qt6Packages: fix mistake ``                                                                            |
| [`f3be7d1c`](https://github.com/NixOS/nixpkgs/commit/f3be7d1c46ce9c7d4935c15f19d77208eaeb219c) | `` skopeo: 1.13.3 -> 1.14.0 ``                                                                            |
| [`487ac169`](https://github.com/NixOS/nixpkgs/commit/487ac1690933f316413cd3f649c1b8a953b81c16) | `` envfs: 1.0.1 -> 1.0.2 ``                                                                               |
| [`445c59a3`](https://github.com/NixOS/nixpkgs/commit/445c59a389711c5a43995cc376de80c3d4e63f86) | `` vimPlugins.nvim-treesitter: update grammars ``                                                         |
| [`6a702bfc`](https://github.com/NixOS/nixpkgs/commit/6a702bfc1a610fd3ef2586b37e854bb65059a01f) | `` python311Packages.types-redis: 4.6.0.10 -> 4.6.0.11 ``                                                 |
| [`3975e4e2`](https://github.com/NixOS/nixpkgs/commit/3975e4e2e4b04621da5a5e7505b60e54b9ff75e2) | `` vimPlugins: update on 2023-11-24 ``                                                                    |
| [`a5a9e209`](https://github.com/NixOS/nixpkgs/commit/a5a9e209d947b0164b03ff88bfcbf2bd2cee6273) | `` python311Packages.types-mock: 5.1.0.2 -> 5.1.0.3 ``                                                    |
| [`7e2206c2`](https://github.com/NixOS/nixpkgs/commit/7e2206c2971ca6dcf56fe7fa8b6be8feb75185d3) | `` rpm: declare darwin as badPlatform ``                                                                  |
| [`92f6a583`](https://github.com/NixOS/nixpkgs/commit/92f6a5833841b991412acc784a1088d416c2d75e) | `` rivercarro: 0.1.4 -> 0.3.0 ``                                                                          |
| [`a297f17c`](https://github.com/NixOS/nixpkgs/commit/a297f17c13d345978406dc4ceef508ba9610df7c) | `` river: 0.2.4 -> 0.2.5 ``                                                                               |
| [`6182b0bd`](https://github.com/NixOS/nixpkgs/commit/6182b0bde8d4a16f5470fa2ee77c07ad3b7088a1) | `` nixos/xscreensaver: add module tests ``                                                                |
| [`54020c36`](https://github.com/NixOS/nixpkgs/commit/54020c36a22db2dff3ed39e569c94a2e7857e8e9) | `` nixos/xscreensaver: init module ``                                                                     |
| [`2034ea01`](https://github.com/NixOS/nixpkgs/commit/2034ea01b9edb411ed5f08acf8a2e4f8af763734) | `` xscreensaver: add suid wrapper patch ``                                                                |
| [`45c70262`](https://github.com/NixOS/nixpkgs/commit/45c702624754d2fa8d7367c181ed0f6cd9f1cf8e) | `` maintainers: add vancluever ``                                                                         |
| [`102bbc25`](https://github.com/NixOS/nixpkgs/commit/102bbc2515ce635de9e06024bd2bfc3736563f47) | `` asn: refactor ``                                                                                       |
| [`da426647`](https://github.com/NixOS/nixpkgs/commit/da426647c434045527a18807ee882213d28cb02e) | `` checkov: 3.1.10 -> 3.1.11 ``                                                                           |
| [`052be0f9`](https://github.com/NixOS/nixpkgs/commit/052be0f9f4399ee8a2cd94fd4a1a7f53a94c81ea) | `` python311Packages.toml-adapt: 0.2.11 -> 0.2.12 ``                                                      |
| [`b7deec8b`](https://github.com/NixOS/nixpkgs/commit/b7deec8b381459048d0d182456bbdfcb69427a53) | `` python311Packages.sqlalchemy-jsonfield: 1.0.1.post0+2023-04-24 -> 1.0.2 ``                             |
| [`c9b74e49`](https://github.com/NixOS/nixpkgs/commit/c9b74e4908d3714c22ffaefb7dfe355e3f5c9494) | `` rustc-wasm32: fix targetPlatform ``                                                                    |
| [`62f7a6dc`](https://github.com/NixOS/nixpkgs/commit/62f7a6dcc1a2baf50e757a6a0bce1083692e0e56) | `` lib.systems.elaborate: fix passing `rust` ``                                                           |
| [`aa73cc02`](https://github.com/NixOS/nixpkgs/commit/aa73cc02bbcbb8111fff4387798edf96e63f42af) | `` python311Packages.reolink-aio: 0.8.0 -> 0.8.1 ``                                                       |
| [`a1163912`](https://github.com/NixOS/nixpkgs/commit/a1163912c2ec5ff9f063689c07d09a4a032a80b5) | `` nixos/caddy: Fixed RestartSec typo. ``                                                                 |
| [`ebb4c66c`](https://github.com/NixOS/nixpkgs/commit/ebb4c66cd56827ca292b2884d432ba963cad08e8) | `` python311Packages.prometheus-pandas: 0.3.2 -> 0.3.3 ``                                                 |
| [`977d1dc3`](https://github.com/NixOS/nixpkgs/commit/977d1dc3744a41b32a7cf37b1bb3dcce0720433c) | `` python311Packages.oauthenticator: 16.1.1 -> 16.2.0 ``                                                  |
| [`8f3f6a2a`](https://github.com/NixOS/nixpkgs/commit/8f3f6a2a77c1908a6e0d66cb81e6f8077777afe6) | `` nixos/invoiceplane: Add settings option ``                                                             |
| [`be61ae09`](https://github.com/NixOS/nixpkgs/commit/be61ae09c5b794a1ec5e6b0118353603b0af51f4) | `` difftastic: 0.52.0 -> 0.53.0 ``                                                                        |
| [`c7f0179e`](https://github.com/NixOS/nixpkgs/commit/c7f0179ef55dd661a980fc4a1e47dda6a8897ef2) | `` asn: 0.74 -> 0.75 ``                                                                                   |
| [`e5b0b761`](https://github.com/NixOS/nixpkgs/commit/e5b0b76105f4a29c9dc2cffebd5af4085ece4340) | `` nixos/clamav: add fangfrisch updater ``                                                                |
| [`8fd6ce40`](https://github.com/NixOS/nixpkgs/commit/8fd6ce402133658e8315fd6bda078989ee53248f) | `` telegram-desktop: restore build on Hydra ``                                                            |
| [`e51f34ed`](https://github.com/NixOS/nixpkgs/commit/e51f34ed9e75673579e5fe5d80b6b91d3df71dbb) | `` qbittorrent: add the `wrapGAppsHook` ``                                                                |
| [`aa92c1f3`](https://github.com/NixOS/nixpkgs/commit/aa92c1f317470a8729361ac740a974d3ea426290) | `` satty: init at 0.7.0 ``                                                                                |
| [`369c508f`](https://github.com/NixOS/nixpkgs/commit/369c508fae6ab9909c943e5e078e524ea58cb227) | `` crun: 1.11.1 -> 1.12 ``                                                                                |
| [`8d81d0a4`](https://github.com/NixOS/nixpkgs/commit/8d81d0a43fe555aca6d5bd95529cab67b3263ffc) | `` kyverno: 1.10.4 -> 1.10.5 ``                                                                           |
| [`d03e0345`](https://github.com/NixOS/nixpkgs/commit/d03e03451410db28f49d7e0ca903166b1c76f5cc) | `` x2goserver: remove myself as maintainer ``                                                             |
| [`e1b34c3e`](https://github.com/NixOS/nixpkgs/commit/e1b34c3e79aaa40b3d6c9c7b7ccc12e6e302a706) | `` x2goclient: remove myself as maintainer ``                                                             |
| [`73f9b84e`](https://github.com/NixOS/nixpkgs/commit/73f9b84ea674d7f915351fad5d8c734e4e89ae58) | `` libnl-tiny: build only on linux ``                                                                     |
| [`2e5eaaa6`](https://github.com/NixOS/nixpkgs/commit/2e5eaaa6f52e20b1ce4023f1a972be4111c33859) | `` ocamlPackages.atd: 2.11.0 → 2.15.0 ``                                                                  |
| [`56336308`](https://github.com/NixOS/nixpkgs/commit/563363087b8dbcc8ca7935a0f23040bc8d02a17b) | `` aliyun-cli: 3.0.184 -> 3.0.186 ``                                                                      |
| [`4ae56bce`](https://github.com/NixOS/nixpkgs/commit/4ae56bced4076586d986eefd021c7def4858fb84) | `` *: add myself to all openwrt packages as maintainer ``                                                 |
| [`8a66f36b`](https://github.com/NixOS/nixpkgs/commit/8a66f36bc598f7d87fed153ff1da017a8a84ef79) | `` swaylock-fancy: unstable-2021-10-11 -> unstable-2023-11-21 ``                                          |
| [`410cd595`](https://github.com/NixOS/nixpkgs/commit/410cd59546a8705457a72e6d868e2d065ede9567) | `` libsForQt5: change comment ``                                                                          |
| [`6e2e3255`](https://github.com/NixOS/nixpkgs/commit/6e2e32556e01189e6a2f17ad1fac3049ee94b435) | `` qt6Packages: use makeScopeWithSplicing ``                                                              |
| [`65874cc8`](https://github.com/NixOS/nixpkgs/commit/65874cc847b3210092aa43fe6de79dd190d9b2a3) | `` qt6: dont use `with self` ``                                                                           |
| [`1231b72e`](https://github.com/NixOS/nixpkgs/commit/1231b72e01bff56b07c7b0626df6f00df0beaeeb) | `` qt6: use `makeScopeWithSplicing` ``                                                                    |
| [`95469bd3`](https://github.com/NixOS/nixpkgs/commit/95469bd3e6d1ba088996a2aae89a490cfb963ff4) | `` miniflux: fix http user agent regression ``                                                            |
| [`221acc91`](https://github.com/NixOS/nixpkgs/commit/221acc9183af496a813b1811f9c66b63c2d9677d) | `` esphome: 2023.11.2 -> 2023.11.3 (#269179) ``                                                           |
| [`9b2b4ee6`](https://github.com/NixOS/nixpkgs/commit/9b2b4ee621619d34167f17b7f396495855ac6067) | `` lilypond: 2.24.2 -> 2.24.3 ``                                                                          |
| [`caddd19e`](https://github.com/NixOS/nixpkgs/commit/caddd19e69e37470f6d3fa31067e112ae6c67982) | `` vimPlugins.nvim-treesitter: update grammars ``                                                         |
| [`e7e619d7`](https://github.com/NixOS/nixpkgs/commit/e7e619d7835e5d053e45715ae073711c9e7a4e56) | `` cosmic-osd: init at unstable-2023-11-15 ``                                                             |
| [`98925cfb`](https://github.com/NixOS/nixpkgs/commit/98925cfb42e512e1809fa61eebee61b5618a9eb4) | `` vimPlugins: update on 2023-11-24 ``                                                                    |
| [`ee2d9390`](https://github.com/NixOS/nixpkgs/commit/ee2d9390c3494a01041adb401fb583ef25d5755e) | `` cosmic-workspaces-epoch: init at unstable-2023-11-21 ``                                                |
| [`b5c7ad4e`](https://github.com/NixOS/nixpkgs/commit/b5c7ad4ea30e32538dd515e61a86f2833b88e76a) | `` vimPlugins.vim-lark-syntax: init at 2023-10-10 ``                                                      |
| [`57fad0db`](https://github.com/NixOS/nixpkgs/commit/57fad0dbec2cb99494e8cd260da32f51dfd4716f) | `` gnomeExtensions.ddterm: unbreak ``                                                                     |
| [`6d53a0c0`](https://github.com/NixOS/nixpkgs/commit/6d53a0c0d04f702ea6df1c0138d89396bcbd38d6) | `` terraform-providers: drop outdated alias ``                                                            |
| [`6d16bca7`](https://github.com/NixOS/nixpkgs/commit/6d16bca71cdfed5e6bcb96447d36c721b0737e04) | `` terraform-providers.vault: drop proxyVendor ``                                                         |
| [`9d229925`](https://github.com/NixOS/nixpkgs/commit/9d229925e132ebec8b62e8c37bb724dd34d942c6) | `` terraform-providers.tailscale: drop go override ``                                                     |
| [`a8f227bc`](https://github.com/NixOS/nixpkgs/commit/a8f227bcf2dd0c21b1b22d788f911cb752115b8e) | `` terraform-providers.avi: drop proxyVendor ``                                                           |
| [`1a6f28cb`](https://github.com/NixOS/nixpkgs/commit/1a6f28cbd85187f5a64ef36c1d1ca77f80594bde) | `` nextcloud-notify_push: 0.6.3 -> 0.6.5 ``                                                               |
| [`773778c1`](https://github.com/NixOS/nixpkgs/commit/773778c16eb851bc26f4bb83f31bea0bbfd9e540) | `` wrapFirefox: fix error message ``                                                                      |
| [`e03c9c3f`](https://github.com/NixOS/nixpkgs/commit/e03c9c3f1be4994c63b27ce60d41f13ebfeb3cad) | `` buildLuarocksPackage: save luarocks config as derivation (#269402) ``                                  |
| [`c40aa4e0`](https://github.com/NixOS/nixpkgs/commit/c40aa4e0c410903b39a24e82e1b1ddf2821d1bdd) | `` invidious: unstable-2023-11-08 -> unstable-2023-11-21 ``                                               |
| [`8ac4d38a`](https://github.com/NixOS/nixpkgs/commit/8ac4d38ad99f9b1c7205951b5f19864c87aff3b8) | `` buildGraalvmNativeImage: Set maximum page size to 64K on aarch64-linux ``                              |
| [`63a81d98`](https://github.com/NixOS/nixpkgs/commit/63a81d98a51fa56bce338b1de7b94aba04862a99) | `` minify: 2.20.5 -> 2.20.7 ``                                                                            |
| [`f6831587`](https://github.com/NixOS/nixpkgs/commit/f6831587785ac414e3af4e1dbdcdba7291194336) | `` checkov: 3.1.9 -> 3.1.10 ``                                                                            |
| [`abe6cf9c`](https://github.com/NixOS/nixpkgs/commit/abe6cf9c602570b8764176cc10922f1500c28b86) | `` cudatext-qt: 1.201.0.2 -> 1.202.1 ``                                                                   |
| [`8538abf6`](https://github.com/NixOS/nixpkgs/commit/8538abf6708494703d9e6c859779a0dc82972b37) | `` cnspec: 9.6.1 -> 9.8.0 ``                                                                              |
| [`6816f28c`](https://github.com/NixOS/nixpkgs/commit/6816f28c960c523e6a30f2ad4a1cc812251f5ffb) | `` lib.fileset.fileFilter: Predicate attribute for file extension ``                                      |
| [`e33a6455`](https://github.com/NixOS/nixpkgs/commit/e33a6455871efa1dfe139fcb01222bf966f1f7f8) | `` zuo: unstable-2023-11-10 -> unstable-2023-11-23 ``                                                     |
| [`746e3946`](https://github.com/NixOS/nixpkgs/commit/746e394638e28f254a8c2afa9ab66acd2893268a) | `` bazel_4: fix CLang 16 Werror-s on darwin ``                                                            |
| [`781538c5`](https://github.com/NixOS/nixpkgs/commit/781538c5ed90dd702a6b976ef6d6235f85869ff3) | `` bazel_5: fix CLang 16 Werror-s on darwin ``                                                            |
| [`3cf18074`](https://github.com/NixOS/nixpkgs/commit/3cf18074db2e7d967d908efbcda49ada694573c0) | `` kodiPackages.radioparadise: 1.0.5 -> 2.0.0 ``                                                          |
| [`afa5ac22`](https://github.com/NixOS/nixpkgs/commit/afa5ac226a0b4b446c116af76b7b61c3daaf8b7d) | `` ubus: unstable-2023-06-05 -> unstable-2023-11-14 ``                                                    |
| [`1a73ff52`](https://github.com/NixOS/nixpkgs/commit/1a73ff52d3c536fcc6b585b36c2fc8adefaef466) | `` libubox: unstable-2023-05-23 -> unstable-2023-11-03 ``                                                 |
| [`b6d4be13`](https://github.com/NixOS/nixpkgs/commit/b6d4be13d055408c55651f45f1142aba0c26dd87) | `` postgresqlPackages.postgis: fix build on clang 12+ ``                                                  |
| [`8c249313`](https://github.com/NixOS/nixpkgs/commit/8c24931339fef54406757ec3e8c7080ce0cfed72) | `` mautrix-discord: 0.6.3 -> 0.6.4 ``                                                                     |
| [`fbbff51a`](https://github.com/NixOS/nixpkgs/commit/fbbff51a1c67c2fd679bae777073fde8045ac58a) | `` hare: unstable-2023-04-23 -> unstable-2023-10-22; harec: unstable-2023-04-23 -> unstable-2023-10-23 `` |
| [`0818809e`](https://github.com/NixOS/nixpkgs/commit/0818809eae890a28372057835bde8f11b9173975) | `` python313: 3.13.0a1 -> 3.13.0a2 ``                                                                     |
| [`68c2c3d5`](https://github.com/NixOS/nixpkgs/commit/68c2c3d58fde250550f9aa285ae9677bddfeeb42) | `` python311Packages.labelbox: 3.52.0 -> 3.56.0 ``                                                        |
| [`78f17a3a`](https://github.com/NixOS/nixpkgs/commit/78f17a3aaa292cb65b6141f8ee9e07a0ccf9976f) | `` nixos/tests/lxd-ui: add a basic selenium test to check the UI is functioning ``                        |
| [`d834d97b`](https://github.com/NixOS/nixpkgs/commit/d834d97b92a3006bd647bd7f099a9c85264a5771) | `` lxd-ui: 0.2 -> 0.4 ``                                                                                  |
| [`349b052f`](https://github.com/NixOS/nixpkgs/commit/349b052f908075ebff0a0383ebd0941657259fac) | `` hysteria: 2.2.1 -> 2.2.2 ``                                                                            |
| [`e64951ca`](https://github.com/NixOS/nixpkgs/commit/e64951cae483d4ca5b0530fd9f0e7d93330d2359) | `` python311Packages.nbconvert: update meta ``                                                            |
| [`6c5041bc`](https://github.com/NixOS/nixpkgs/commit/6c5041bc0aed2f1b774c9f88025ff570d1a61159) | `` python311Packages.nbconvert: 7.8.0 -> 7.11.0 ``                                                        |
| [`ec3fa8c2`](https://github.com/NixOS/nixpkgs/commit/ec3fa8c281769a25d5cc2f0b9f2ea51ddb614db1) | `` python311Packages.jupyter-core: update meta ``                                                         |
| [`19362a61`](https://github.com/NixOS/nixpkgs/commit/19362a61944170678aa208e8a9cdefb15fdc31f7) | `` python311Packages.jupyter-core: 5.3.1 -> 5.5.0 ``                                                      |
| [`3f86ee22`](https://github.com/NixOS/nixpkgs/commit/3f86ee22eb3baeb5d4147b64ccdfa2f354f0c7db) | `` emacsPackages.xapian-lite: init at 2.0.0 ``                                                            |
| [`120a67bb`](https://github.com/NixOS/nixpkgs/commit/120a67bbfa93d9fd830310344cae0291068318bd) | `` nodejs_20: 20.9.0 -> 20.10.0 ``                                                                        |
| [`b9a67f73`](https://github.com/NixOS/nixpkgs/commit/b9a67f73176d44ff1b293a7ac9b241e919065b07) | `` lean4: fix build on darwin ``                                                                          |
| [`28f3249a`](https://github.com/NixOS/nixpkgs/commit/28f3249a7675186552acb51e26e562fcaae2fd68) | `` eza: 0.16.0 -> 0.16.1 ``                                                                               |
| [`e52004d0`](https://github.com/NixOS/nixpkgs/commit/e52004d08ef6d035a5a6aa3858887f324043c28d) | `` librem: 2.10.0 -> 2.12.0 ``                                                                            |
| [`d1898d52`](https://github.com/NixOS/nixpkgs/commit/d1898d521ef0c4b16ea3fe58e9b3edf1d833cb9b) | `` libre: 3.6.0 -> 3.6.2 ``                                                                               |
| [`46b793f1`](https://github.com/NixOS/nixpkgs/commit/46b793f1d14e35c59e5c91ab35cbfbef0020a682) | `` darling: unstable-2023-05-02 -> unstable-2023-11-07 ``                                                 |
| [`01c4a493`](https://github.com/NixOS/nixpkgs/commit/01c4a493c843e4f68ab62177adba84ce0c8e36cc) | `` gatekeeper: 3.13.3 -> 3.13.4 ``                                                                        |
| [`81d4190c`](https://github.com/NixOS/nixpkgs/commit/81d4190c484a187964c009414ebaaf2cff3ae2db) | `` beekeeper-studio: 3.6.2 -> 4.0.3, refactor ``                                                          |
| [`f54615a1`](https://github.com/NixOS/nixpkgs/commit/f54615a134ea34cad87d9fd09192de8b4758dcba) | `` nagios: 4.4.14 -> 4.5.0 ``                                                                             |
| [`bf0c4339`](https://github.com/NixOS/nixpkgs/commit/bf0c43399701ec3ba3fb6183716547ff2bfd71db) | `` hydrus: 552 -> 553 ``                                                                                  |
| [`25e6e027`](https://github.com/NixOS/nixpkgs/commit/25e6e0273ee50dad1a7fb664d9797905549bb055) | `` apptainer: 1.2.4 -> 1.2.5 ``                                                                           |
| [`324a22d0`](https://github.com/NixOS/nixpkgs/commit/324a22d0ba13ed10a6d9782d93f7e1d107dbe479) | `` i3status-rust: 0.32.2 -> 0.32.3 ``                                                                     |
| [`123143a8`](https://github.com/NixOS/nixpkgs/commit/123143a848ecc9b7886f649d951fc773d7a7a277) | `` tandoor-recipes: migrate to prefetch-yarn-deps ``                                                      |
| [`ee7fac08`](https://github.com/NixOS/nixpkgs/commit/ee7fac08b2e22ada5fd4fb6c7c0631696c96eecb) | `` podman-desktop: migrate to prefetch-yarn-deps ``                                                       |
| [`2d757563`](https://github.com/NixOS/nixpkgs/commit/2d757563ae7d8694f2d227231e9aa78554609f0c) | `` mergerfs-tools: 20190411 -> 20230912, add makefu as maintainer ``                                      |
| [`97ac308e`](https://github.com/NixOS/nixpkgs/commit/97ac308ed1d3c786a559d040e91bb3e6efd2b98f) | `` zxtune: init at r5055 ``                                                                               |
| [`1a2b332b`](https://github.com/NixOS/nixpkgs/commit/1a2b332bcb62ff77181e5ec43a7fe7f00f52a9b1) | `` nushell: 0.87.0 -> 0.87.1 ``                                                                           |
| [`3cd0e6f2`](https://github.com/NixOS/nixpkgs/commit/3cd0e6f2d380bdb2a4f4ccc0f0260fba9bc9f11b) | `` corretto{11,17,19}: init at 11.0.20.9.1/17.0.8.8.1/19.0.2.7.1 ``                                       |
| [`e3df0bff`](https://github.com/NixOS/nixpkgs/commit/e3df0bff988062da39d42fafb9b840c2756509cc) | `` cmospwd: restrict platform to x86_64-linux ``                                                          |
| [`b751c28f`](https://github.com/NixOS/nixpkgs/commit/b751c28f670ad3ff64beae6a26f06d1485224798) | `` protege-distribution: 5.5.0 -> 5.6.3 ``                                                                |
| [`d2bfc759`](https://github.com/NixOS/nixpkgs/commit/d2bfc759361a9ae946cd19c47573e2227a7505d5) | `` maintainers: add EBADBEEF ``                                                                           |
| [`daff2bb0`](https://github.com/NixOS/nixpkgs/commit/daff2bb01d16586ac9cc34d9cecca51590a75750) | `` maintainers/lxd: fix double modules ``                                                                 |
| [`eff5176f`](https://github.com/NixOS/nixpkgs/commit/eff5176f704d270c58944e7f375bbdca6bbe99b5) | `` hplip: 3.23.3 -> 3.23.8 ``                                                                             |
| [`e0753b85`](https://github.com/NixOS/nixpkgs/commit/e0753b85cb8df97016bf793a5dcd425b5db1b6da) | `` monetdb: 11.47.11 -> 11.47.17 ``                                                                       |
| [`408323d6`](https://github.com/NixOS/nixpkgs/commit/408323d697677c4abed0e010e7dd769f8597db9e) | `` asap: 6.0.0 -> 6.0.1 ``                                                                                |
| [`b021130d`](https://github.com/NixOS/nixpkgs/commit/b021130d477f90e7ad42bf27ca311f586368f3ab) | `` cyanrip: 0.9.0 -> 0.9.2 ``                                                                             |
| [`6790c4da`](https://github.com/NixOS/nixpkgs/commit/6790c4da9bb7618fe63f86169e1b453d94c3c4b0) | `` Add rollf as maintainer. ``                                                                            |
| [`4bd758c9`](https://github.com/NixOS/nixpkgs/commit/4bd758c9634eef2d58822b4aaa424051f613da0d) | `` qutebrowser: use spliced qt6Packages ``                                                                |
| [`d248a1e7`](https://github.com/NixOS/nixpkgs/commit/d248a1e7f7a3e839ec06cbb7776bcdb5fab67451) | `` qutebrowser-qt5: replace qt5.qutebrowser ``                                                            |
| [`4b67d1a2`](https://github.com/NixOS/nixpkgs/commit/4b67d1a286c60c0906ec3e9c16486fefbcdd3f21) | `` below: 0.6.3 -> 0.7.1 ``                                                                               |
| [`44729300`](https://github.com/NixOS/nixpkgs/commit/44729300662727d30ff0a36f0637a7cecedf1bbf) | `` rdma-core: 48.0 -> 49.0 ``                                                                             |
| [`e2f87ab3`](https://github.com/NixOS/nixpkgs/commit/e2f87ab3855762556297f0de4186e5c40958e0f0) | `` touchosc: 1.2.4.180 -> 1.2.5.183 ``                                                                    |
| [`0dcfabb9`](https://github.com/NixOS/nixpkgs/commit/0dcfabb9e0b0f36b30e104198b490b903f69e2cd) | `` fzf: fix perl detection ``                                                                             |
| [`ae963d4c`](https://github.com/NixOS/nixpkgs/commit/ae963d4c93d0bfd057b43ddfaa5a1a308c3617ff) | `` python3Packages.taskw: support relative paths in taskrc ``                                             |