### PR TITLE
chore(flake/nur): `e51798a8` -> `145de74c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700874374,
-        "narHash": "sha256-aJlAjLZfmXAUvdksPDWXKfUTeqtu0xwTsCyCw8z7N40=",
+        "lastModified": 1700895159,
+        "narHash": "sha256-J9myEMY9C/BmarDu/7JYsH2Tq8wodA29jD1IhJWfEZc=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "e51798a838e6e49a8c3f0a58054c973829e2f806",
+        "rev": "145de74c6f8ccbd62c6ea4d9b9d8e45ee8382f23",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`145de74c`](https://github.com/nix-community/NUR/commit/145de74c6f8ccbd62c6ea4d9b9d8e45ee8382f23) | `` automatic update `` |
| [`1e4badf8`](https://github.com/nix-community/NUR/commit/1e4badf8f18a90273efbca61061851a508a9ac18) | `` automatic update `` |
| [`fc44d5d4`](https://github.com/nix-community/NUR/commit/fc44d5d4a552505f0b585d861512b3ae3365688b) | `` automatic update `` |
| [`a4842789`](https://github.com/nix-community/NUR/commit/a484278909b1360587e1053e5b2cbb55ac343778) | `` automatic update `` |
| [`d754bccc`](https://github.com/nix-community/NUR/commit/d754bccc0094ac3267aaa41f96b243ab9d0cf8e8) | `` automatic update `` |