### PR TITLE
chore(flake/master): `dc584735` -> `86a8472d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -455,11 +455,11 @@
     },
     "master": {
       "locked": {
-        "lastModified": 1700883623,
-        "narHash": "sha256-L0VAwMUuJctNW94qLsF9nMDQ2CjM1evo9sLJm0p6N/g=",
+        "lastModified": 1700894476,
+        "narHash": "sha256-Oso4VcXNBQoAwMKTX5rDMUN54+FE66SOUDcxGYPgFBk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "dc584735fc80a6fb657cc260136d85a9d6f61121",
+        "rev": "86a8472db9c125fef4da159e7d0e90dbcb739873",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                  |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`e705fd12`](https://github.com/NixOS/nixpkgs/commit/e705fd12d20a6e2ec97d8a94ffd8886dd90a8954) | `` Revert "python311Packages.pikepdf: 8.4.0 -> 8.7.1" `` |
| [`1a804fb5`](https://github.com/NixOS/nixpkgs/commit/1a804fb5139501993045e20fe7d65ab9520d19ea) | `` sqlc: 1.23.0 -> 1.24.0 ``                             |
| [`96ca1291`](https://github.com/NixOS/nixpkgs/commit/96ca129160463ac44cf385a7a2070b037f686494) | `` emacsPackages.hotfuzz: build dynamic library ``       |
| [`98aae7c0`](https://github.com/NixOS/nixpkgs/commit/98aae7c031b8bb24d54cc4fe2ffda98e0bee2007) | `` python311Packages.ocrmypdf: 15.4.0 -> 15.4.3 ``       |
| [`dc25d174`](https://github.com/NixOS/nixpkgs/commit/dc25d1744f59e438240867a5cfdd929cea256153) | `` python311Packages.pikepdf: 8.4.0 -> 8.7.1 ``          |