### PR TITLE
chore(flake/nur): `92780bd2` -> `24bed8be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700896827,
-        "narHash": "sha256-34Ya3sbVR7lJoghlygj8fPImzIj4Y1nN/B+zm/gVjoE=",
+        "lastModified": 1700930741,
+        "narHash": "sha256-it/l+fZ43hA0tG8oyehuLZeVbmrrjwXxCwcMyqtIhNs=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "92780bd20e4fa0526f63e0136fb6f3bbeac6bf9a",
+        "rev": "24bed8be0a3ffb70bf517ae06b35ebf5c8d2fd16",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`24bed8be`](https://github.com/nix-community/NUR/commit/24bed8be0a3ffb70bf517ae06b35ebf5c8d2fd16) | `` automatic update `` |
| [`fb3bc75b`](https://github.com/nix-community/NUR/commit/fb3bc75bb1dc92d0f61ebc3530c8ab8deda83abc) | `` automatic update `` |
| [`981600da`](https://github.com/nix-community/NUR/commit/981600da923af46f6e2f1728b0c167262f25247c) | `` automatic update `` |
| [`2644c4a3`](https://github.com/nix-community/NUR/commit/2644c4a32642a32ea01dc63fd780404c21c82d7a) | `` automatic update `` |
| [`2f972e33`](https://github.com/nix-community/NUR/commit/2f972e33b2323c947f9cbf6538b552d5d9205dc7) | `` automatic update `` |
| [`0ae28dc5`](https://github.com/nix-community/NUR/commit/0ae28dc570682734dc14abbc810fe058e2c0dbbc) | `` automatic update `` |
| [`570366ae`](https://github.com/nix-community/NUR/commit/570366ae78d90bb077ba46873f7ef3515bb4009a) | `` automatic update `` |
| [`f1fd8aa4`](https://github.com/nix-community/NUR/commit/f1fd8aa4751304d1f63ccd8857e3e5dcf6b35f54) | `` automatic update `` |
| [`05ab78f4`](https://github.com/nix-community/NUR/commit/05ab78f4f46c5f6ce3f84ab5e041cf943a22f941) | `` automatic update `` |