### PR TITLE
chore(flake/hyprland): `512a5973` -> `b281d864`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1700876704,
-        "narHash": "sha256-V3Z1SYEpi5baifNxvIOgBWWy9J0m0hZ8arAMS4XpbZk=",
+        "lastModified": 1700934998,
+        "narHash": "sha256-85TggoP7zfZJfo7nN6n9IxsS4XXS7XSJRVCQOtfS88Q=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "512a59731b2e579b66325d0e9ce770919eecd685",
+        "rev": "b281d8647a557f51977c25cb6c0d2f818fe4e4e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                     |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
| [`b281d864`](https://github.com/hyprwm/Hyprland/commit/b281d8647a557f51977c25cb6c0d2f818fe4e4e4) | `` screencopy: use new isNvidia() for format ``             |
| [`15b282ee`](https://github.com/hyprwm/Hyprland/commit/15b282ee0c8b48724b7d068aa95bb1133fdda2d7) | `` opengl: fix window introspection check ``                |
| [`6f733292`](https://github.com/hyprwm/Hyprland/commit/6f733292bf2dae2adf1e7524546e140a93824033) | `` renderer: nvidia checks and use glFinish on nvidia ``    |
| [`3fe6162a`](https://github.com/hyprwm/Hyprland/commit/3fe6162af1904f15fc5526c179c06a48265bdbff) | `` opengl: fix xray modes in introspection checks for ls `` |
| [`2ce4b94a`](https://github.com/hyprwm/Hyprland/commit/2ce4b94a22242ae77f6a2899d389dcb56d0e5fa8) | `` input: Fix custom acceleration profile config (#3948) `` |
| [`de95e956`](https://github.com/hyprwm/Hyprland/commit/de95e956a0dc9d837cde8eb714a7fd3fa5e47673) | `` meson: Update wlroots-meson-build.patch (#3950) ``       |
| [`929c44e3`](https://github.com/hyprwm/Hyprland/commit/929c44e361fe5cc535a9226b05fba21a0e317d69) | `` input: pass mouse input to IME popups (#3922) ``         |