### PR TITLE
chore(flake/master): `86a8472d` -> `e66223d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -455,11 +455,11 @@
     },
     "master": {
       "locked": {
-        "lastModified": 1700894476,
-        "narHash": "sha256-Oso4VcXNBQoAwMKTX5rDMUN54+FE66SOUDcxGYPgFBk=",
+        "lastModified": 1700937935,
+        "narHash": "sha256-6voMDfoNnmTn0cNSuy7T0+V7b/cB5QfuuBak7Ut3fyg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "86a8472db9c125fef4da159e7d0e90dbcb739873",
+        "rev": "e66223d4dbe420e4196dee1ff1993d3e837b6e8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                   |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
| [`68a2749b`](https://github.com/NixOS/nixpkgs/commit/68a2749b5bbdb351b5a07a6a0e9270424898b495) | `` instawow: init at 3.1.0 ``                                             |
| [`679cb8ff`](https://github.com/NixOS/nixpkgs/commit/679cb8ff4db11edf3ac27b188f75a3cc55909cd5) | `` nushellPlugins: update for nu 0.87.1 and build on hydra ``             |
| [`f7263685`](https://github.com/NixOS/nixpkgs/commit/f7263685dfbab3b1f0ea1c7933bf9f225474ad4b) | `` wol: add mainProgram ``                                                |
| [`b7a8d59e`](https://github.com/NixOS/nixpkgs/commit/b7a8d59e3ab68bc6e01ff660e5b8165eb399f443) | `` pyqt6: fix build on darwin ``                                          |
| [`617b9534`](https://github.com/NixOS/nixpkgs/commit/617b95347a4b45c0849933ca917fdee57171c11e) | `` colima: 0.6.0 -> 0.6.5 ``                                              |
| [`fa07aaf5`](https://github.com/NixOS/nixpkgs/commit/fa07aaf5a91f1330a7a130015a5a9098a30812cf) | `` colima: 0.5.6 -> 0.6.0 ``                                              |
| [`0de4a671`](https://github.com/NixOS/nixpkgs/commit/0de4a671c3a18451710c09c8f8408ec4d9c274c7) | `` python311Packages.rotary-embedding-torch: 0.3.5 -> 0.3.6 ``            |
| [`694ddfae`](https://github.com/NixOS/nixpkgs/commit/694ddfae79e82174af41da825193dd9441624854) | `` python311Packages.dash: migrate to prefetch-yarn-deps ``               |
| [`b0a49f1b`](https://github.com/NixOS/nixpkgs/commit/b0a49f1bf173a211702edcbf60a6d27d64ede130) | `` bundix: update homepage ``                                             |
| [`0e0c9a66`](https://github.com/NixOS/nixpkgs/commit/0e0c9a6646a90abba3106fc62a0fdac80f14e821) | `` bundix: fix license attribute ``                                       |
| [`5304b1a4`](https://github.com/NixOS/nixpkgs/commit/5304b1a4eaee5234751103751c93d0d8533950b2) | `` vimPlugins.fidget-nvim: switch branch from legacy to main ``           |
| [`833354eb`](https://github.com/NixOS/nixpkgs/commit/833354eb44a29e921f7c9e8f519fee9cb61785aa) | `` gerrit: 3.8.2 -> 3.8.3 ``                                              |
| [`3ccf35fa`](https://github.com/NixOS/nixpkgs/commit/3ccf35fa5339d4d21f649db625305f1886d12cb9) | `` khronos: 3.7.0 -> 4.0.1 ``                                             |
| [`2fc0b97e`](https://github.com/NixOS/nixpkgs/commit/2fc0b97e57f3a0437a865663fc92452aa23568ca) | `` xmrig-proxy: 6.20.0 -> 6.21.0 ``                                       |
| [`25f1b1f4`](https://github.com/NixOS/nixpkgs/commit/25f1b1f4ac055ddf99b0f8cfda9ba5f1ed449fa2) | `` tilt: migrate to prefetch-yarn-deps ``                                 |
| [`fb1cc4af`](https://github.com/NixOS/nixpkgs/commit/fb1cc4af9c3ff397b0732ddfdeafd826ad54119b) | `` Skip `sqlite3_bind_bug68849.phpt` php unit test on i686 linux ``       |
| [`3e96f75e`](https://github.com/NixOS/nixpkgs/commit/3e96f75e85822d7b643b894eb1d0c4665122f82e) | `` river: 0.2.5 -> 0.2.6 ``                                               |
| [`f6ef3d25`](https://github.com/NixOS/nixpkgs/commit/f6ef3d2527bf033808951d304ab759b3ea08ec9f) | `` exoscale-cli: 1.74.4 -> 1.75.0 ``                                      |
| [`fc235bb0`](https://github.com/NixOS/nixpkgs/commit/fc235bb0fcb324cbce510f4cf1e1e51a6615a195) | `` python/hooks: use python.pythonVersion to support PyPy ``              |
| [`d1941e77`](https://github.com/NixOS/nixpkgs/commit/d1941e77241c3ff1e2008c35130c6e903c75dcf2) | `` gotify-server: migrate to prefetch-yarn-deps ``                        |
| [`5df1bb20`](https://github.com/NixOS/nixpkgs/commit/5df1bb20c8ef1d8c54aed0aa8e43f66ace1e8162) | `` python311Packages.vertica-python: 1.3.6 -> 1.3.7 ``                    |
| [`dd6c677c`](https://github.com/NixOS/nixpkgs/commit/dd6c677c4d49ddb2f8c00e68b542acd48a917c7a) | `` grafana-agent: migrate to prefetch-yarn-deps ``                        |
| [`232bf80b`](https://github.com/NixOS/nixpkgs/commit/232bf80bdc7ed6db0eb70a9b8f9ece3d80afe242) | `` civo: 1.0.68 -> 1.0.69 ``                                              |
| [`ffe74b61`](https://github.com/NixOS/nixpkgs/commit/ffe74b6158287a8730800ae81243f876b4bfef29) | `` pscale: 1.161.0 -> 1.162.0 ``                                          |
| [`11440690`](https://github.com/NixOS/nixpkgs/commit/1144069008696abf9d817cbfb10a97e973b215b6) | `` aiohttp-client-cache: init at 0.10.0 ``                                |
| [`ff7534f1`](https://github.com/NixOS/nixpkgs/commit/ff7534f13b87de1862334b7e9fac0b432471238f) | `` psutils: fix build on darwin by setting -std=c89 ``                    |
| [`9d1029f2`](https://github.com/NixOS/nixpkgs/commit/9d1029f25386649794951d7354b3284ae06adf62) | `` anki: migrate to prefetch-yarn-deps ``                                 |
| [`11e39b43`](https://github.com/NixOS/nixpkgs/commit/11e39b43a0772cc4ead0101646e8fd4fd78f32ea) | `` rocksdb: fix build of versions < 8 ``                                  |
| [`0e4a87f4`](https://github.com/NixOS/nixpkgs/commit/0e4a87f4dd2089d99eb8d3f8a9c094e1d3e037d6) | `` qt6.qtwebengine: set correct platforms ``                              |
| [`e4c1138c`](https://github.com/NixOS/nixpkgs/commit/e4c1138cb75fd8fee16675e05199b7413f853251) | `` karmor: 0.14.2 -> 0.14.3 ``                                            |
| [`1095d893`](https://github.com/NixOS/nixpkgs/commit/1095d8934b11e76de30ff3b2e8d442e470436490) | `` rocksdb: use finalAttrs ``                                             |
| [`7625075f`](https://github.com/NixOS/nixpkgs/commit/7625075fae710416ac4c2228e6e801ad639b97cb) | `` terragrunt: 0.53.5 -> 0.53.6 ``                                        |
| [`20b4687c`](https://github.com/NixOS/nixpkgs/commit/20b4687cf09c4ebee26bf8b9624a0654c52c3ad7) | `` maintainers: add das-g to geospatial team ``                           |
| [`efc80f37`](https://github.com/NixOS/nixpkgs/commit/efc80f379c114f9070a7f2a9433bff40c9e30dde) | `` ddosify: refactor ``                                                   |
| [`4b31fbec`](https://github.com/NixOS/nixpkgs/commit/4b31fbecbb76fd3cc15b09c2d242feb1d2cb8dda) | `` patool: 1.12 -> 2.0.0 ``                                               |
| [`861fb5c0`](https://github.com/NixOS/nixpkgs/commit/861fb5c048f2118d591555b9bf90a2c0f410dabc) | `` python311Packages.pymc: 5.9.2 -> 5.10.0 ``                             |
| [`6568016f`](https://github.com/NixOS/nixpkgs/commit/6568016fa3397dfb07965855f56171a9c55ef7d7) | `` u-boot: ROCK64 RAM init improvements ``                                |
| [`144c241d`](https://github.com/NixOS/nixpkgs/commit/144c241d6a7103d045c295107c81b4cf36fad800) | `` python311Packages.aiolifx: refactor ``                                 |
| [`055b31d6`](https://github.com/NixOS/nixpkgs/commit/055b31d670bcf561890705a8d69e2854561a389e) | `` python311Packages.aiolifx: 0.9.0 -> 1.0.0 ``                           |
| [`65217c32`](https://github.com/NixOS/nixpkgs/commit/65217c32df798138081d5fd724998dfbcdc2dfe7) | `` powerstat: 0.03.03 -> 0.04.01 ``                                       |
| [`9814de50`](https://github.com/NixOS/nixpkgs/commit/9814de5032ed4bb09f6fe0c2468013cc7a1d94a1) | `` python311Packages.pdunehd: add changelog to meta ``                    |
| [`6c3adfb4`](https://github.com/NixOS/nixpkgs/commit/6c3adfb4c3a7ad2f53fbbefceb7399297d51f1b1) | `` python311Packages.pdunehd: 1.3.2 -> 1.3.3 ``                           |
| [`ebffaa5f`](https://github.com/NixOS/nixpkgs/commit/ebffaa5f3aad2f4add9300e7b0bb24c64070ee6d) | `` python311Packages.vulture: refactor ``                                 |
| [`b669aa3f`](https://github.com/NixOS/nixpkgs/commit/b669aa3ffcfce350ce5574fa0f1d125d1865bd22) | `` python311Packages.vulture: 2.9.1 -> 2.10 ``                            |
| [`5719ed68`](https://github.com/NixOS/nixpkgs/commit/5719ed68537d46a8bf0c13b3a2204c0c169fb6be) | `` open-dyslexic: 2016-07-23 -> 0.91.12 ``                                |
| [`bcfbc2e0`](https://github.com/NixOS/nixpkgs/commit/bcfbc2e0f27e965221f8f9212e26d9afc3733cd5) | `` ddosify: 1.0.5 -> 1.0.6 ``                                             |
| [`c08c2809`](https://github.com/NixOS/nixpkgs/commit/c08c2809dd6b063cf526d6e39610fce8c0f139fc) | `` action-validator: 0.5.3 -> 0.5.4 ``                                    |
| [`ae19c0c1`](https://github.com/NixOS/nixpkgs/commit/ae19c0c10568fe0bb447050aa6c08fae6b340668) | `` chart-testing: 3.10.0 -> 3.10.1 ``                                     |
| [`48c747ba`](https://github.com/NixOS/nixpkgs/commit/48c747baa001f671a96acface836d0dec03e88a0) | `` exploitdb: 2023-11-21 -> 2023-11-24 ``                                 |
| [`9f66feaa`](https://github.com/NixOS/nixpkgs/commit/9f66feaae5cc1a8f6700e3e78a01211193b027e8) | `` intel-gmmlib: 22.3.12 -> 22.3.14 ``                                    |
| [`07714f67`](https://github.com/NixOS/nixpkgs/commit/07714f67d5be01250719631262aeb34046a2d01b) | `` vala-lint: unstable-2023-05-25 -> unstable-2023-11-12 ``               |
| [`2456fc60`](https://github.com/NixOS/nixpkgs/commit/2456fc6040719bfb758283d7aa326b167d6c16b2) | `` teensy-udev-rules: correct meta attribute ``                           |
| [`adaf7d67`](https://github.com/NixOS/nixpkgs/commit/adaf7d671e8aeb9de60c2fa92ef8c6e8ac9a54b2) | `` python311Packages.scmrepo: 1.4.1 -> 1.5.0 ``                           |
| [`2bd012f6`](https://github.com/NixOS/nixpkgs/commit/2bd012f68de67258b6093b7448717dead2e210b3) | `` ksmbd-tools: 3.5.0 -> 3.5.1 ``                                         |
| [`7241985b`](https://github.com/NixOS/nixpkgs/commit/7241985bf6e5686c68bd8021ee94bfa7e7a6e74f) | `` gopass: 1.15.8 -> 1.15.9 ``                                            |
| [`224395c2`](https://github.com/NixOS/nixpkgs/commit/224395c2a19bf0009259b3ff681d56a8ae37952d) | `` hugo: 0.120.3 -> 0.120.4 ``                                            |
| [`da90d6d5`](https://github.com/NixOS/nixpkgs/commit/da90d6d5bf3359a950bb8cca53da5d5da09b1125) | `` fulcrum: 1.9.3 -> 1.9.7 ``                                             |
| [`44a4aadb`](https://github.com/NixOS/nixpkgs/commit/44a4aadba935f98df14ef39b4ad36bb6224707f9) | `` android-udev-rules: 20231030 -> 20231104 ``                            |
| [`e265845f`](https://github.com/NixOS/nixpkgs/commit/e265845f6f94ad8f5e1d7529d018cff9714c42d2) | `` mapcidr: 1.1.14 -> 1.1.16 ``                                           |
| [`cdbe51d5`](https://github.com/NixOS/nixpkgs/commit/cdbe51d541d173118273de92e5638cbb885dbcee) | `` lux: 0.21.0 -> 0.22.0 ``                                               |
| [`6cdc0a93`](https://github.com/NixOS/nixpkgs/commit/6cdc0a930bb507e40216d4083a329e6094271479) | `` python311Packages.slack-sdk: 3.24.0 -> 3.26.0 ``                       |
| [`122bb3e6`](https://github.com/NixOS/nixpkgs/commit/122bb3e6daee26ca2368e123bdf84c83adb87ab6) | `` python311Packages.sentry-sdk: 1.36.0 -> 1.37.1 ``                      |
| [`6c79332f`](https://github.com/NixOS/nixpkgs/commit/6c79332fb82683cf72bb9a7d4cb4026bf9ea1f3c) | `` ledfx: refactor ``                                                     |
| [`a6767aba`](https://github.com/NixOS/nixpkgs/commit/a6767abaa12cbd7a4fdb4ff595aa74012eff7d46) | `` ledfx: 2.0.78 -> 2.0.80 ``                                             |
| [`5b9f0527`](https://github.com/NixOS/nixpkgs/commit/5b9f0527a09ec75de69cac709983bcd3becbdde9) | `` python311Packages.google-cloud-speech: 2.21.1 -> 2.22.0 ``             |
| [`6d978c18`](https://github.com/NixOS/nixpkgs/commit/6d978c185121048fa74e7b91cad9bcec6ded948d) | `` python311Packages.aiounifi: 65 -> 66 ``                                |
| [`80887851`](https://github.com/NixOS/nixpkgs/commit/80887851ff201e53740a1fe037a900b4b8aeb9dd) | `` e3-core: init at 22.3.1 ``                                             |
| [`d2c8aab2`](https://github.com/NixOS/nixpkgs/commit/d2c8aab2f4eb9a1f61cef763d676a5d5b5c6c7ba) | `` python311Packages.odp-amsterdam: 5.3.1 -> 6.0.0 ``                     |
| [`a98079cb`](https://github.com/NixOS/nixpkgs/commit/a98079cbc76c915b6fec26446cc003b288b7182f) | `` python311Packages.gridnet: 4.3.0 -> 5.0.0 ``                           |
| [`f9c56732`](https://github.com/NixOS/nixpkgs/commit/f9c56732d411ce1fbcfc57c75bc88bbeabae1a74) | `` python311Packages.p1monitor: 2.3.1 -> 3.0.0 ``                         |
| [`2d5ee0f1`](https://github.com/NixOS/nixpkgs/commit/2d5ee0f1e36af7300b235d5b997f13590ec26ca6) | `` python311Packages.gcal-sync: 6.0.1 -> 6.0.3 ``                         |
| [`a3e3b60a`](https://github.com/NixOS/nixpkgs/commit/a3e3b60abc2b0e3e0754915f3c86ca85dd54d81c) | `` python311Packages.yeelight: 0.7.13 -> 0.7.14 ``                        |
| [`9a32d2c6`](https://github.com/NixOS/nixpkgs/commit/9a32d2c648508c9cf589c91306ea003d6a1a7594) | `` python311Packages.aioshelly: 6.0.0 -> 6.1.0 ``                         |
| [`889760fb`](https://github.com/NixOS/nixpkgs/commit/889760fb2a09045c851b751a133c74fb254527f2) | `` gnomeExtensions.gsconnect: 55 -> 56 ``                                 |
| [`c4e7af74`](https://github.com/NixOS/nixpkgs/commit/c4e7af7473e7ca28dacb9bc89da9587eb469728d) | `` cargo-watch: fix build on darwin ``                                    |
| [`7887d992`](https://github.com/NixOS/nixpkgs/commit/7887d99244b6b7711e93d6e6589615d8790ced9b) | `` uptime-kuma: 1.23.6 -> 1.23.7 ``                                       |
| [`8ae6154b`](https://github.com/NixOS/nixpkgs/commit/8ae6154b2b49aedae4421aefe32494a1e4373de1) | `` root: fix excessive build log size ``                                  |
| [`d11eed57`](https://github.com/NixOS/nixpkgs/commit/d11eed579e1c22c60d01a30e01419f505b67ce77) | `` python311Packages.azure-mgmt-containerservice: 27.0.0 -> 28.0.0 ``     |
| [`23a9597a`](https://github.com/NixOS/nixpkgs/commit/23a9597a0ed8bd4bfef17b6982eefd5603b61b93) | `` nile: fix passthru.updateScript ``                                     |
| [`a47da0a8`](https://github.com/NixOS/nixpkgs/commit/a47da0a88e6f00cafda1a4e3c8749ba57920e630) | `` python311Packages.python-youtube: 0.9.2 -> 0.9.3 ``                    |
| [`0e9d4571`](https://github.com/NixOS/nixpkgs/commit/0e9d457138ea6a511111add743fb755c05b748ff) | `` svd2rust: 0.30.2 -> 0.31.0 ``                                          |
| [`73e68f2e`](https://github.com/NixOS/nixpkgs/commit/73e68f2ed2c26d93af2260b668d5e095b947d9ef) | `` xmrig: 6.20.0 -> 6.21.0 ``                                             |
| [`87a4074d`](https://github.com/NixOS/nixpkgs/commit/87a4074d00226c4cd71c0e25333dfda03a9a4c7b) | `` dssp: 4.4.4.1 -> 4.4.5 ``                                              |
| [`1e48b149`](https://github.com/NixOS/nixpkgs/commit/1e48b14964a9ea1034de3f6c72ac07f93d559004) | `` python311Packages.slackclient: 3.23.0 -> 3.26.0 ``                     |
| [`ba84ea45`](https://github.com/NixOS/nixpkgs/commit/ba84ea45ac49f95c9f4356b486a39f6c636558e1) | `` flexget: 3.9.18 -> 3.10.1 ``                                           |
| [`448c524a`](https://github.com/NixOS/nixpkgs/commit/448c524a5aa3b89d79cf134d1d978d88a07ba707) | `` qtcreator: 11.0.3 -> 12.0.0 ``                                         |
| [`46897044`](https://github.com/NixOS/nixpkgs/commit/46897044724d84702ae5f875760229d7d89385c7) | `` cloud-nuke: 0.32.0 -> 0.33.0 ``                                        |
| [`66c57a66`](https://github.com/NixOS/nixpkgs/commit/66c57a662158b2f03b2dce602c0b47a5011e6b19) | `` storj-uplink: 1.90.2 -> 1.92.1 ``                                      |
| [`4fbb794e`](https://github.com/NixOS/nixpkgs/commit/4fbb794e876264d2fa80757a909ea085a43cba73) | `` postgresqlPackages.pg_auto_failover: 2.0 -> 2.1 ``                     |
| [`77586e5c`](https://github.com/NixOS/nixpkgs/commit/77586e5cf6bebebb85ae70a13b8d2f5fa67e3bb3) | `` DisnixWebService: add meta.{changelog,homepage} ``                     |
| [`05d8b888`](https://github.com/NixOS/nixpkgs/commit/05d8b88821df0d125da47a3b702bfb7457f8a01d) | `` DisnixWebService: fix build for Axis2 1.8.1 ``                         |
| [`91daef01`](https://github.com/NixOS/nixpkgs/commit/91daef01cb815c5b82d3e6bed3850193ac42d4e2) | `` ddns-go: 5.6.4 -> 5.6.6 ``                                             |
| [`2f0937a7`](https://github.com/NixOS/nixpkgs/commit/2f0937a78f764054d09ea1b68c18f37cca821ba3) | `` python3Packages.humanize: 4.8.0 -> 4.9.0 ``                            |
| [`e87e44dc`](https://github.com/NixOS/nixpkgs/commit/e87e44dc1e53cf2f274ae6201a50cb7b76bd9959) | `` peertube: migrate to prefetch-yarn-deps ``                             |
| [`7aabaab3`](https://github.com/NixOS/nixpkgs/commit/7aabaab3c4057e7ff7dc03c7d7f5480ecf2d16b2) | `` vcluster: 0.16.4 -> 0.17.0 ``                                          |
| [`f973683b`](https://github.com/NixOS/nixpkgs/commit/f973683b3861546c87b00268a7698b40b0049a2f) | `` kubesec: 2.13.0 -> 2.14.0 ``                                           |
| [`8f36fa2c`](https://github.com/NixOS/nixpkgs/commit/8f36fa2c0f41d16678dd7af370ea1f9331a26682) | `` celeste: 0.8.0 -> 0.8.1 ``                                             |
| [`841bd4d9`](https://github.com/NixOS/nixpkgs/commit/841bd4d99c51eea4722cbf4022f33ce5de673043) | `` jitsi-videobridge: 2.3-44-g8983b11f -> 2.3-59-g5c48e421 ``             |
| [`73908903`](https://github.com/NixOS/nixpkgs/commit/73908903ec13be6d9274bf94dadacf94ddc5e8f1) | `` jitsi-meet: 1.0.7531 -> 1.0.7629 ``                                    |
| [`0c35c624`](https://github.com/NixOS/nixpkgs/commit/0c35c6248337599311f66c4d041120e8718fcc15) | `` jitsi-meet-prosody: 1.0.7531 -> 1.0.7629 ``                            |
| [`849bbaed`](https://github.com/NixOS/nixpkgs/commit/849bbaedae4915dde1803083fe4a482cd3c1ab51) | `` hyprshot: init at 1.2.3 ``                                             |
| [`a0888000`](https://github.com/NixOS/nixpkgs/commit/a08880000dee157f618dc790ac3093e80cfc2b36) | `` geoserver: add nixos test ``                                           |
| [`3d84496c`](https://github.com/NixOS/nixpkgs/commit/3d84496c930846948fb87bfc3dfce9997d5c713c) | `` geoserver: add geospatial team to maintainers ``                       |
| [`9f98f290`](https://github.com/NixOS/nixpkgs/commit/9f98f2904bb0b3fd80224c491440b6eb5ddcbed7) | `` geoserver: fix startup script ``                                       |
| [`7f9abdcf`](https://github.com/NixOS/nixpkgs/commit/7f9abdcfcb7a44a9e8bbf954adeb6cce8e6800fe) | `` nixos/nextcloud: fix docu of packages ``                               |
| [`b48ec762`](https://github.com/NixOS/nixpkgs/commit/b48ec762e9d32be03454314333ee0344626a996e) | `` petsc: 3.19.2 -> 3.19.4, fix tests, add more options ``                |
| [`92ee7186`](https://github.com/NixOS/nixpkgs/commit/92ee71866ff18a811c46948a13c633ed638d2ae8) | `` nixos/nat: fix nat-nftables ``                                         |
| [`da893e4d`](https://github.com/NixOS/nixpkgs/commit/da893e4d17861e4a716d1d842ea141656e09a663) | `` halide: use preCheck instead of overwriting checkPhase ``              |
| [`6f41e0b9`](https://github.com/NixOS/nixpkgs/commit/6f41e0b9aff319adc25ada9d41a5d8effae5ed79) | `` armagetronad: reproducible build by setting version ``                 |
| [`f5803331`](https://github.com/NixOS/nixpkgs/commit/f5803331cff1674cb36f58a98fcfe750b8433b35) | `` armagetronad: 0.2.9.1.0 -> 0.2.9.1.1 + passthrus for other versions `` |
| [`f6370efd`](https://github.com/NixOS/nixpkgs/commit/f6370efdfbb57b08b5ee1b18a535dea1b2938c52) | `` halide: disable fuzzing tests ``                                       |
| [`cf31acbf`](https://github.com/NixOS/nixpkgs/commit/cf31acbf1551369e645d8d864d44763e16a14cfb) | `` marwaita-ubuntu: 1.7 -> 17.0 ``                                        |
| [`f54d9cdf`](https://github.com/NixOS/nixpkgs/commit/f54d9cdf127ddf4c2f03f21e7e82d3de8a3217a3) | `` marwaita-ubuntu: add update script ``                                  |
| [`d1e23ba8`](https://github.com/NixOS/nixpkgs/commit/d1e23ba84ecc8b3f029ed20fcc062d8cac5d805a) | `` marwaita-pop_os: 10.3 -> 17.0 ``                                       |
| [`76663292`](https://github.com/NixOS/nixpkgs/commit/7666329232ac5f6e2bf3b504569303f4329a06c5) | `` marwaita-pop_os: add update script ``                                  |
| [`8f55e6ca`](https://github.com/NixOS/nixpkgs/commit/8f55e6cae28dc17a94ee0661fa58b6f8690b42c4) | `` lima-bin: 0.17.2 -> 0.18.0 ``                                          |
| [`b2192f0e`](https://github.com/NixOS/nixpkgs/commit/b2192f0e719c1d2e0a10288490bbd3c2070f847b) | `` gns3-gui: fix running on Wayland ``                                    |
| [`db9a5fd2`](https://github.com/NixOS/nixpkgs/commit/db9a5fd280b086864550b348691868c12c838fb4) | `` rasdaemon: 0.7.0 -> 0.8.0 ``                                           |
| [`c841f93d`](https://github.com/NixOS/nixpkgs/commit/c841f93dd98880f5a62c4995a3c9082f4478d2d6) | `` halide: ::aligned_alloc is not available on x86_64-darwin ``           |
| [`b55f063c`](https://github.com/NixOS/nixpkgs/commit/b55f063caf98b12852f33d159d8fbb6b3dfc6646) | `` halide: patch to remove dependency on Apple SDK ``                     |
| [`ed6e240d`](https://github.com/NixOS/nixpkgs/commit/ed6e240d32e6359be3947bdd8c852876e4464e4f) | `` halide: disable float16 support on aarch16-linux ``                    |
| [`77486e6c`](https://github.com/NixOS/nixpkgs/commit/77486e6c93353cdabccb650bc257e270be0cddb1) | `` halide: build against llvmPackages_16 ``                               |
| [`394763b5`](https://github.com/NixOS/nixpkgs/commit/394763b58355aac20f9fe2ba094cce716ef75faa) | `` halide: 15.0.1 -> 16.0.0 ``                                            |