### PR TITLE
chore(flake/hyprland): `b281d864` -> `99ca26d4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1700934998,
-        "narHash": "sha256-85TggoP7zfZJfo7nN6n9IxsS4XXS7XSJRVCQOtfS88Q=",
+        "lastModified": 1701023633,
+        "narHash": "sha256-lX/PsZrKEtdk/cUIET/UYhQKPJRkNq2hlbLH6VQSpWc=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "b281d8647a557f51977c25cb6c0d2f818fe4e4e4",
+        "rev": "99ca26d4eb84e0071264713902e5b287fcab392e",
         "type": "github"
       },
       "original": {
@@ -948,18 +948,18 @@
       "flake": false,
       "locked": {
         "host": "gitlab.freedesktop.org",
-        "lastModified": 1700736101,
-        "narHash": "sha256-1Fh1xf/JX5zFbGIF9LDaffaleG6JDwwwnKby0LyiXEA=",
+        "lastModified": 1700734054,
+        "narHash": "sha256-SBu1y01WjCSrcCKvgfCDDckrZjU/OmCJT8Xc+hPow7E=",
         "owner": "wlroots",
         "repo": "wlroots",
-        "rev": "f1762f428b0ef2989c81f57ea9e810403d34d946",
+        "rev": "2eb225236eb72f27beec921e9f37ddf58e874fba",
         "type": "gitlab"
       },
       "original": {
         "host": "gitlab.freedesktop.org",
         "owner": "wlroots",
         "repo": "wlroots",
-        "rev": "f1762f428b0ef2989c81f57ea9e810403d34d946",
+        "rev": "2eb225236eb72f27beec921e9f37ddf58e874fba",
         "type": "gitlab"
       }
     },


### PR DESCRIPTION
| Commit                                                                                           | Message                                                               |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
| [`99ca26d4`](https://github.com/hyprwm/Hyprland/commit/99ca26d4eb84e0071264713902e5b287fcab392e) | `` hooksystem: fix missed log include ``                              |
| [`e416ab74`](https://github.com/hyprwm/Hyprland/commit/e416ab740d224bddb865191a028ea1016d7be31e) | `` config: log info about logs before loading vars ``                 |
| [`7a0a5666`](https://github.com/hyprwm/Hyprland/commit/7a0a5666d565a3ef892a7ab433a5007dd1cc72dd) | `` groupbar: allow reload and fix locked groupbar gradient (#3546) `` |
| [`1778fb77`](https://github.com/hyprwm/Hyprland/commit/1778fb77e20a7ff0c9fc20bb139b2e63fa41c7ef) | `` functionhooks: throw an exception on unsupported %rip usage ``     |
| [`adeb20ea`](https://github.com/hyprwm/Hyprland/commit/adeb20ea114ff56d78804697e9ba8328f684b7b1) | `` opengl: tiled special require introspection ``                     |
| [`68e57b7e`](https://github.com/hyprwm/Hyprland/commit/68e57b7ee36f015d99988f38cb3a8b83c23ae7c3) | `` renderer: proper full occlusion checks for back layer ``           |
| [`408d9666`](https://github.com/hyprwm/Hyprland/commit/408d96668d57fdd1a713e56f1d40a9befd51bd4a) | `` renderer: use occlusion checks for buffer clear ``                 |
| [`75e57993`](https://github.com/hyprwm/Hyprland/commit/75e579931088671fb333efd2a3923ff96b868fe9) | `` layer-shell: simulate mouse movement on unmap ``                   |
| [`9e2b9390`](https://github.com/hyprwm/Hyprland/commit/9e2b939024448d64df6af1f5d2ea5ceee078a539) | `` surface: avoid infinite pointer image resets ``                    |
| [`cd96ceec`](https://github.com/hyprwm/Hyprland/commit/cd96ceecc551c25631783499bd92c6662c5d3616) | `` build: remove nv patches (#3957) ``                                |
| [`ad3f6886`](https://github.com/hyprwm/Hyprland/commit/ad3f6886484e9adbab532de125e69a70c54fa13e) | `` opengl: check for introspection on special_blur ``                 |
| [`98c7ba47`](https://github.com/hyprwm/Hyprland/commit/98c7ba4782476c10e5854a7e520c47bb10353607) | `` [gha] Nix: update wlroots ``                                       |
| [`a5f64b48`](https://github.com/hyprwm/Hyprland/commit/a5f64b48ca23edfba807c8842ff12e3d96494f5f) | `` deps: downgrade wlroots to fix crashes ``                          |