### PR TITLE
chore(flake/chaotic): `61cdc7fb` -> `1bca2465`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1700918394,
-        "narHash": "sha256-INcgTLn6MUAfZMGoAR2KbTStrf9+515Dq1ID2hf8CZY=",
+        "lastModified": 1701281948,
+        "narHash": "sha256-l18n5B1DG6o63Sugtcdwapp91q2lhUzMjjR4SfuFYBc=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "61cdc7fbcf5678d50913b4888f50b9affc068e9d",
+        "rev": "1bca2465c2d9b5c3daa530e0f97761fb60803480",
         "type": "github"
       },
       "original": {
@@ -279,12 +279,12 @@
         ]
       },
       "locked": {
-        "lastModified": 1700847865,
-        "narHash": "sha256-uWaOIemGl9LF813MW0AEgCBpKwFo2t1Wv3BZc6e5Frw=",
-        "rev": "8cedd63eede4c22deb192f1721dd67e7460e1ebe",
-        "revCount": 3139,
+        "lastModified": 1701071203,
+        "narHash": "sha256-lQywA7QU/vzTdZ1apI0PfgCWNyQobXUYghVrR5zuIeM=",
+        "rev": "db1878f013b52ba5e4034db7c1b63e8d04173a86",
+        "revCount": 3143,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/home-manager/0.1.3139%2Brev-8cedd63eede4c22deb192f1721dd67e7460e1ebe/018c026f-8acb-7143-9324-178aeddbb51d/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/nix-community/home-manager/0.1.3143%2Brev-db1878f013b52ba5e4034db7c1b63e8d04173a86/018c0fc0-4040-75d8-9a92-046db53b783d/source.tar.gz"
       },
       "original": {
         "type": "tarball",
@@ -568,12 +568,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700612854,
-        "narHash": "sha256-yrQ8osMD+vDLGFX7pcwsY/Qr5PUd6OmDMYJZzZi0+zc=",
-        "rev": "19cbff58383a4ae384dea4d1d0c823d72b49d614",
-        "revCount": 551719,
+        "lastModified": 1701068326,
+        "narHash": "sha256-vmMceA+q6hG1yrjb+MP8T0YFDQIrW3bl45e7z24IEts=",
+        "rev": "8cfef6986adfb599ba379ae53c9f5631ecd2fd9c",
+        "revCount": 553283,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.551719%2Brev-19cbff58383a4ae384dea4d1d0c823d72b49d614/018bfdb3-08a8-7c17-b64e-5653b6d4c279/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.553283%2Brev-8cfef6986adfb599ba379ae53c9f5631ecd2fd9c/018c18d1-b364-7bfd-aced-a123b87538af/source.tar.gz"
       },
       "original": {
         "type": "tarball",


### PR DESCRIPTION
| Commit                                                                                          | Message                                                    |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`1bca2465`](https://github.com/chaotic-cx/nyx/commit/1bca2465c2d9b5c3daa530e0f97761fb60803480) | `` mesa32_git: no need to revert patch anymore (#459) ``   |
| [`99533bf5`](https://github.com/chaotic-cx/nyx/commit/99533bf57b7233691bb6991ecf45401dda3bff36) | `` Bump 20231129-2 (#458) ``                               |
| [`e97a5e22`](https://github.com/chaotic-cx/nyx/commit/e97a5e22c5d309017461861e9d7e6a1df6daea30) | `` Bump 20231129-1 (#457) ``                               |
| [`4f0220d9`](https://github.com/chaotic-cx/nyx/commit/4f0220d944e316f0b9bdc559490979be0a1faaff) | `` river_git: fix inputs ``                                |
| [`26c8a232`](https://github.com/chaotic-cx/nyx/commit/26c8a2321362f5422da1726ae124fd1372cb4100) | `` nixpkgs: bump to 20231129 ``                            |
| [`fce12bb6`](https://github.com/chaotic-cx/nyx/commit/fce12bb67cd43513c9e8961c193de3030dc21ee7) | `` Bump 20231128-1 (#455) ``                               |
| [`2066ea26`](https://github.com/chaotic-cx/nyx/commit/2066ea26c1d046679980fec10909159744c01217) | `` Bump 20231127-1 (#454) ``                               |
| [`d5a85eaa`](https://github.com/chaotic-cx/nyx/commit/d5a85eaa65272a945062bf6cbf9f6b19f41db487) | `` git-update: fix updater eval ``                         |
| [`e3617def`](https://github.com/chaotic-cx/nyx/commit/e3617def527abfe8326e44dec66941a182fc68b6) | `` fractal_git: drop ``                                    |
| [`ed3b72a4`](https://github.com/chaotic-cx/nyx/commit/ed3b72a47db118b80ae4635af039805346d12a23) | `` docs: short description only ``                         |
| [`d94a2af6`](https://github.com/chaotic-cx/nyx/commit/d94a2af671a9fe0e5d726ed603229a586ff4ecf9) | `` fractal_git: fix hash (oops) ``                         |
| [`6dc7018f`](https://github.com/chaotic-cx/nyx/commit/6dc7018f30b83f4b6476daa2af87c11f7aaf65ac) | ``  fractal_git: init at 20231126134753-a4bd482  (#453) `` |
| [`a3ac3990`](https://github.com/chaotic-cx/nyx/commit/a3ac399082dd938b2960a16cb712e77522c06d6e) | `` nixfmt_rfc166: init at 20231118225354-4ef4c39 ``        |
| [`fb4c4a90`](https://github.com/chaotic-cx/nyx/commit/fb4c4a9069f736acb29f2bf2c193481d9ba4d168) | `` Bump 20231126-1 (#452) ``                               |
| [`a154361f`](https://github.com/chaotic-cx/nyx/commit/a154361f69d8eb9ef62df2a4e3ecea7fafa4d0a8) | `` nixpkgs: bump to 20231125 ``                            |