### PR TITLE
chore(flake/nur): `24bed8be` -> `f69fe2f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1700930741,
-        "narHash": "sha256-it/l+fZ43hA0tG8oyehuLZeVbmrrjwXxCwcMyqtIhNs=",
+        "lastModified": 1701047095,
+        "narHash": "sha256-Au/U65SGDH4jtrD9Btv63t8X7MbaSLKcEVPtpKGhvAA=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "24bed8be0a3ffb70bf517ae06b35ebf5c8d2fd16",
+        "rev": "f69fe2f32f963f16b2abeeb941866a0273142af7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                      |
| -------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`f69fe2f3`](https://github.com/nix-community/NUR/commit/f69fe2f32f963f16b2abeeb941866a0273142af7) | `` automatic update ``       |
| [`764f0e8f`](https://github.com/nix-community/NUR/commit/764f0e8fee3edcc6c8a6b3f6bfa21b105365a5bf) | `` automatic update ``       |
| [`734c11c4`](https://github.com/nix-community/NUR/commit/734c11c46ead41333c95b789774a88c0854af521) | `` automatic update ``       |
| [`a122c9db`](https://github.com/nix-community/NUR/commit/a122c9db8f724bbe8fd90ac3970ce1b75d929d19) | `` automatic update ``       |
| [`f393a1d1`](https://github.com/nix-community/NUR/commit/f393a1d1972accabcaca7d4443b32ced35a5bde2) | `` automatic update ``       |
| [`0f09c575`](https://github.com/nix-community/NUR/commit/0f09c5753c8804f98d8b9ec6ba7c3026c878b5a5) | `` automatic update ``       |
| [`905c680b`](https://github.com/nix-community/NUR/commit/905c680b20414c91fdfba54728383664a950c8b0) | `` automatic update ``       |
| [`68ce8f77`](https://github.com/nix-community/NUR/commit/68ce8f77d521cb4e7dd127d993f80fd2e842f52f) | `` automatic update ``       |
| [`815c5c12`](https://github.com/nix-community/NUR/commit/815c5c12fc40e3fe3267a6107cbf28e9ed05695a) | `` add procyon repository `` |
| [`35aa8b6a`](https://github.com/nix-community/NUR/commit/35aa8b6a66479d577067300adfe323406724c467) | `` automatic update ``       |
| [`09920ba9`](https://github.com/nix-community/NUR/commit/09920ba97be4d52fbd850cb4bad4f3840760db19) | `` automatic update ``       |
| [`1f1a69f3`](https://github.com/nix-community/NUR/commit/1f1a69f3dbc9b711f3490156dd686c822fc4b0ae) | `` automatic update ``       |
| [`4663f337`](https://github.com/nix-community/NUR/commit/4663f337fea6a45fc0fe82e63da1e0dcb5cfd2fb) | `` automatic update ``       |
| [`8685d16d`](https://github.com/nix-community/NUR/commit/8685d16d14bbe586a46192ae9c672de3105317ac) | `` automatic update ``       |
| [`e02a78d6`](https://github.com/nix-community/NUR/commit/e02a78d67b50894533340e80efe3ad9ab5c0325a) | `` add chen repository ``    |
| [`35e1f313`](https://github.com/nix-community/NUR/commit/35e1f3133c549ee9833a92a42330569070b2ad5d) | `` automatic update ``       |
| [`59303699`](https://github.com/nix-community/NUR/commit/59303699fb59181462b0d3fb76de7205799975f1) | `` automatic update ``       |
| [`61db677a`](https://github.com/nix-community/NUR/commit/61db677ad39c3a922735f664f4d23834a0580a3e) | `` automatic update ``       |
| [`95f618e3`](https://github.com/nix-community/NUR/commit/95f618e3eaf6156578985fb5d14da500b811c52e) | `` automatic update ``       |
| [`cf99dd7d`](https://github.com/nix-community/NUR/commit/cf99dd7d8a4162724d111117425f319289432cd1) | `` automatic update ``       |
| [`af1b4aca`](https://github.com/nix-community/NUR/commit/af1b4acac79c5d0457920a4441031f4278c5afd3) | `` automatic update ``       |
| [`b51dbb62`](https://github.com/nix-community/NUR/commit/b51dbb62003aeae301c75a56ec3e92a748f7d565) | `` automatic update ``       |
| [`8e03b974`](https://github.com/nix-community/NUR/commit/8e03b9749c6490c602688ac4efb63cab31212156) | `` automatic update ``       |
| [`3ae8d2d1`](https://github.com/nix-community/NUR/commit/3ae8d2d1acdb1b4bb2b07ec2780e3be7e5aa24bd) | `` automatic update ``       |
| [`67ffd6ff`](https://github.com/nix-community/NUR/commit/67ffd6ff0b060fed7181334878a0dd302df15180) | `` automatic update ``       |
| [`245d3aaf`](https://github.com/nix-community/NUR/commit/245d3aaf5f7c690b78aef8ef645bab4be19af1d1) | `` automatic update ``       |
| [`3252372b`](https://github.com/nix-community/NUR/commit/3252372bffefdd35d976d7b51058f2e99a7b4a7f) | `` automatic update ``       |
| [`ed62b1ec`](https://github.com/nix-community/NUR/commit/ed62b1ecf8943fbd295b3320f049aba932d88886) | `` automatic update ``       |
| [`f3e9bac6`](https://github.com/nix-community/NUR/commit/f3e9bac6b7cc491a052ff255d80226e3faa74bfb) | `` automatic update ``       |
| [`9a5c43cf`](https://github.com/nix-community/NUR/commit/9a5c43cffc04beb342e4f0299b5b31c87db39b38) | `` automatic update ``       |
| [`41baba34`](https://github.com/nix-community/NUR/commit/41baba347708b140c1dde7dc387ae1b16a396448) | `` automatic update ``       |
| [`6d06cec4`](https://github.com/nix-community/NUR/commit/6d06cec40da7895c8e5278be921c785ffcb6e2ea) | `` automatic update ``       |
| [`8100f837`](https://github.com/nix-community/NUR/commit/8100f837eec48bc910f2f11529e982fbc0ad057a) | `` automatic update ``       |
| [`c21bb3ca`](https://github.com/nix-community/NUR/commit/c21bb3cafbc37346254c67f2c755f6f28016fb13) | `` automatic update ``       |