### PR TITLE
chore(flake/master): `e66223d4` -> `3f83e9f1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -455,11 +455,11 @@
     },
     "master": {
       "locked": {
-        "lastModified": 1700937935,
-        "narHash": "sha256-6voMDfoNnmTn0cNSuy7T0+V7b/cB5QfuuBak7Ut3fyg=",
+        "lastModified": 1701219481,
+        "narHash": "sha256-p+d+K4PMi/A5eCPmcPQBVJPVyRUY/AA55QhCHgRO7M0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e66223d4dbe420e4196dee1ff1993d3e837b6e8b",
+        "rev": "3f83e9f16dcb04116e1564b1928e12252e0c1c8e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`10ee18ca`](https://github.com/NixOS/nixpkgs/commit/10ee18ca9265cada45acfc7a6d7644cd22b82465) | `` certbot: 2.6.0 -> 2.7.4 (#267710) ``                                     |
| [`21672ccd`](https://github.com/NixOS/nixpkgs/commit/21672ccd691ebd2f18fa6b41446389c069adfdbb) | `` firefox-devedition-unwrapped: 121.0b3 -> 121.0b4 ``                      |
| [`2438f55f`](https://github.com/NixOS/nixpkgs/commit/2438f55f0989f1be60b292ef82fa1568b1b8967b) | `` firefox-beta-unwrapped: 121.0b3 -> 121.0b4 ``                            |
| [`395c3204`](https://github.com/NixOS/nixpkgs/commit/395c32048e786ea4ff756ea6fd46cdb28b85c19a) | `` firefox: Adds patch for systems without a default page size (#270722) `` |
| [`b5869682`](https://github.com/NixOS/nixpkgs/commit/b5869682246c587aa19ab0c9f4141217f7940f98) | `` nix-direnv: 2.4.0 -> 2.5.1 ``                                            |
| [`7071bf24`](https://github.com/NixOS/nixpkgs/commit/7071bf24d415cf025c42eb6b60ff04d880905001) | `` mus: change upstream src; migrate to by-name ``                          |
| [`2a3d97bc`](https://github.com/NixOS/nixpkgs/commit/2a3d97bcb08324c14a06c0861e05673a16690015) | `` maintainers: sfr -> nbsp ``                                              |
| [`60bd6ad8`](https://github.com/NixOS/nixpkgs/commit/60bd6ad87f351fe9305f9c5420f71caee34148c5) | `` ipinfo: 3.1.2 -> 3.2.0 ``                                                |
| [`0864e05d`](https://github.com/NixOS/nixpkgs/commit/0864e05d727dc04acd6b3ba2aed89a4a607df3c8) | `` .github/CODEOWNERS: Add roberth to module system ``                      |
| [`f9abf151`](https://github.com/NixOS/nixpkgs/commit/f9abf151855f04e2f35bf9c22f307f7e788d2ac7) | `` dnf5: tag was moved, fix hash ``                                         |
| [`acab2ad0`](https://github.com/NixOS/nixpkgs/commit/acab2ad0e77f1b9e27cd3217e69a004959487353) | `` release-notes: mention Nim changes ``                                    |
| [`1753744b`](https://github.com/NixOS/nixpkgs/commit/1753744b35ade75f329bd487d4397c7cb69e8f71) | `` nim_lk: wrap with nix-prefetch, nix-prefetch-git ``                      |
| [`8effb983`](https://github.com/NixOS/nixpkgs/commit/8effb98377496b3d17d34136cc494428d32b8a2e) | `` nim: 1.6.14 -> 2.0.0 ``                                                  |
| [`8672b5ca`](https://github.com/NixOS/nixpkgs/commit/8672b5cabdc10359cc6e9bc2c04fd281618ae2c5) | `` Remove nimPackages and nim2Packages ``                                   |
| [`7bd3fa9f`](https://github.com/NixOS/nixpkgs/commit/7bd3fa9faf6581a6167c63f721db0112245a0872) | `` emocli: use top-level buildNimPackage ``                                 |
| [`5dd13314`](https://github.com/NixOS/nixpkgs/commit/5dd133142ff17e74594eb6369b983e1c47bd540e) | `` snekim: build with lockfile ``                                           |
| [`6240432c`](https://github.com/NixOS/nixpkgs/commit/6240432c4490fe941f65947930056dd4e011300b) | `` nimlsp: build with lockfile ``                                           |
| [`862b9061`](https://github.com/NixOS/nixpkgs/commit/862b90618926848cc04b4d0061f0a45f1a237592) | `` nimmm: build with lockfile ``                                            |
| [`607c5fdb`](https://github.com/NixOS/nixpkgs/commit/607c5fdb0433d316f24b756cbad7afca94d05b8f) | `` nim-atlas: migrate from nimPackages.atlas ``                             |
| [`6f8f9a92`](https://github.com/NixOS/nixpkgs/commit/6f8f9a9254d9942d2e6b606ba6e2b506cefdda27) | `` nimble: migrate from nimPackages ``                                      |
| [`53c5ce37`](https://github.com/NixOS/nixpkgs/commit/53c5ce37bd39270f98bed6a9a8b87f869f521484) | `` base45: migrate from nimPackages ``                                      |
| [`3d5455ac`](https://github.com/NixOS/nixpkgs/commit/3d5455ac3b609bbdca913a523a94a327a00936f3) | `` eriscmd: migrate from nimPackages.eris ``                                |
| [`6df86cc6`](https://github.com/NixOS/nixpkgs/commit/6df86cc655a99e9db0569b53054b20404b4eacba) | `` c2nim: move out of nimPackages ``                                        |
| [`0f2dc695`](https://github.com/NixOS/nixpkgs/commit/0f2dc695198d4bdaaecf1b29d878a390b7eb3646) | `` nrpl: use new buildNimPackage ``                                         |
| [`146947ca`](https://github.com/NixOS/nixpkgs/commit/146947ca3b1d703eac5f93803d442f25a8567820) | `` promexplorer: build with lockfile ``                                     |
| [`29b30270`](https://github.com/NixOS/nixpkgs/commit/29b302705b282bedde66f1fe7f199e4a46be842f) | `` swaycwd: use new buildNimPackage ``                                      |
| [`48840e17`](https://github.com/NixOS/nixpkgs/commit/48840e17625420eb9ab9a165a368379e600b3714) | `` nitch: use new buildNimPackage ``                                        |
| [`a7758d7d`](https://github.com/NixOS/nixpkgs/commit/a7758d7dd8222ae1e0187b41aa38b412d446d6dc) | `` tridactyl-native: build with lockfile ``                                 |
| [`dce1f58e`](https://github.com/NixOS/nixpkgs/commit/dce1f58e63342945dfedaf1fb1752ef422caad13) | `` nimdow: build with lockfile ``                                           |
| [`0f089515`](https://github.com/NixOS/nixpkgs/commit/0f089515b15af25212c404ced278fa3e8e178270) | `` mosdepth: build with a lockfile ``                                       |
| [`cab3fd4d`](https://github.com/NixOS/nixpkgs/commit/cab3fd4d50a05becce0e4df3779c8d1b3e23586f) | `` nitter: build with buildNimPackage ``                                    |
| [`ee21b616`](https://github.com/NixOS/nixpkgs/commit/ee21b61658dd195be61e93b0937ad65d6e41fb6a) | `` ttop: build with lockfile ``                                             |
| [`35f108c7`](https://github.com/NixOS/nixpkgs/commit/35f108c7d7742fc9119a03783f40dd44cf7f6251) | `` buildNimPackage: load lockfiles and overrides ``                         |
| [`39d4eace`](https://github.com/NixOS/nixpkgs/commit/39d4eace911f9e838df023ad80f52132380e01c2) | `` nimPackages.buildNimPackage: move to top-level ``                        |
| [`89153ceb`](https://github.com/NixOS/nixpkgs/commit/89153ceb44198bba7b6fc74451a7dbf38d0193dd) | `` nimPackages.nim_builder: move out to pkgs/by-name ``                     |
| [`9e00db7b`](https://github.com/NixOS/nixpkgs/commit/9e00db7b79b2deadab0dd056f117b339b9e19b63) | `` nim: invert nim1 to be a definition of nim2 ``                           |
| [`9c24e11f`](https://github.com/NixOS/nixpkgs/commit/9c24e11f3a9c2eed56792e6288b7feabce265fe1) | `` nvidiaPackages.(settings|persistened): add fallback cdn ``               |
| [`c953c85b`](https://github.com/NixOS/nixpkgs/commit/c953c85b9ebdd2773f95180254ec9429cb1426f8) | `` nix-unit: init at 2.18.0 ``                                              |
| [`d97d2fb2`](https://github.com/NixOS/nixpkgs/commit/d97d2fb271e4d9d0f86cf704c6d9fb3aa851d80d) | `` nixos/clamav: ensure freshclam starts before clamav (if enabled) ``      |
| [`7afbfd38`](https://github.com/NixOS/nixpkgs/commit/7afbfd384d51cbb01230bc3ae3b2b88ee4713d44) | `` fbvnc: cleanup, fix cross compilation ``                                 |
| [`3281455a`](https://github.com/NixOS/nixpkgs/commit/3281455a2613ceb321e97e6560312b72214214ed) | `` nvidiaPackages: format generic.nix ``                                    |
| [`e9d43e61`](https://github.com/NixOS/nixpkgs/commit/e9d43e61bf3d1de31fdcccb8fd3cf74819282399) | `` exploitdb: 2023-11-25 -> 2023-11-28 ``                                   |
| [`e3c83148`](https://github.com/NixOS/nixpkgs/commit/e3c831487b871207aeeddb74618f6907eb5394af) | `` checkov: 3.1.15 -> 3.1.18 ``                                             |
| [`352d3a3a`](https://github.com/NixOS/nixpkgs/commit/352d3a3ad9345a0d9864c3923904b81a0e1f4ef7) | `` maubot: switch to ensureNewerSourcesForZipFilesHook ``                   |
| [`00070cf8`](https://github.com/NixOS/nixpkgs/commit/00070cf866af5945cefdb59803005de8a47abaf2) | `` nixos/maubot: init ``                                                    |
| [`e96b8fd9`](https://github.com/NixOS/nixpkgs/commit/e96b8fd970b947c71e559a5ddc89d64a829ab615) | `` maubot: add plugins & plugins update script ``                           |
| [`ec54fee3`](https://github.com/NixOS/nixpkgs/commit/ec54fee3b5c9d4ec0f635f6b63689742fc8b4bcc) | `` rl-2311: Link to blog post on the file set library ``                    |
| [`8b713aa6`](https://github.com/NixOS/nixpkgs/commit/8b713aa68935f0d582de79921f35e672a65c2756) | `` gcal: fix build in darwin ``                                             |
| [`024e4447`](https://github.com/NixOS/nixpkgs/commit/024e4447a42868b4c8f3ac8b3e6a2da83c682de1) | `` paraview: fix strlcat symbol provided by glibc 2.38 ``                   |
| [`9d53f93b`](https://github.com/NixOS/nixpkgs/commit/9d53f93b88a9fe0ccad3123a5c46996cae16b722) | `` postgresqlPackages.pgrouting: add geospatial team to maintainers ``      |
| [`9fa73548`](https://github.com/NixOS/nixpkgs/commit/9fa735486088c53760608c2d8cea514f47150e7f) | `` tile38: add geospatial team to maintainers ``                            |
| [`8ae2bf1e`](https://github.com/NixOS/nixpkgs/commit/8ae2bf1e607cbdbb5cef93d9ebe8cbc55ff2bdd3) | `` dconf2nix: 0.0.12 -> 0.1.1 ``                                            |
| [`1536d9f3`](https://github.com/NixOS/nixpkgs/commit/1536d9f3aeac7d7ee7eac630aef4d6154a534501) | `` mbtileserver: add geospatial team to maintainers ``                      |
| [`c11bc06f`](https://github.com/NixOS/nixpkgs/commit/c11bc06f5326a2d5ab8058677d978957d4d03868) | `` mapcache: add geospatial team to maintainers ``                          |
| [`64205f60`](https://github.com/NixOS/nixpkgs/commit/64205f60aff5a90ab8a0ac4afcddfbc9fa52486c) | `` pg_featureserv: add geospatial team to maintainers ``                    |
| [`5d3a53c0`](https://github.com/NixOS/nixpkgs/commit/5d3a53c02e7edd269ee1d87764685829e10da6c8) | `` pg_tileserv: add geospatial team to maintainers ``                       |
| [`214fb088`](https://github.com/NixOS/nixpkgs/commit/214fb08814596bdf2ed70f93a1fa25731f10f6fd) | `` mapserver: add geospatial team to maintainers ``                         |
| [`04e31b72`](https://github.com/NixOS/nixpkgs/commit/04e31b72c4eae5cd277982fd9a03c2a8cb675af0) | `` audiobookshelf: 2.5.0 -> 2.6.0 ``                                        |
| [`a9a14d5f`](https://github.com/NixOS/nixpkgs/commit/a9a14d5fe48bd9260fc6cc6dd91ad7724865ba06) | `` python310Packages.clickhouse-connect: 0.6.18 -> 0.6.21 ``                |
| [`3a3cd401`](https://github.com/NixOS/nixpkgs/commit/3a3cd401810fadbd2d2a99a0ba8676060082f92f) | `` soft-serve: 0.7.2 -> 0.7.3 ``                                            |
| [`eb198e32`](https://github.com/NixOS/nixpkgs/commit/eb198e32f042ad37c7204e745d93c18cfbc5b032) | `` kotlin-native: update darwin hashes; fix build ``                        |
| [`f3c44905`](https://github.com/NixOS/nixpkgs/commit/f3c44905d8f10582ca81dfff509705e3c961c796) | `` python311Packages.gentools: adjust inputs ``                             |
| [`2a5388a5`](https://github.com/NixOS/nixpkgs/commit/2a5388a54e6dad4828647c53c180d69df7683605) | `` python311Packages.gentools: add changelog to meta ``                     |
| [`6d2cb963`](https://github.com/NixOS/nixpkgs/commit/6d2cb963287f8bca8c1f5b6feaa2669372fb9d7d) | `` python311Packages.gentools: switch to pyproject; fix build ``            |
| [`627dda7f`](https://github.com/NixOS/nixpkgs/commit/627dda7f87a1a6ec2a39be3ac11c009c3f759524) | `` tiledb: 2.8.3 -> 2.18.0 (#268876) ``                                     |
| [`2a8d6aee`](https://github.com/NixOS/nixpkgs/commit/2a8d6aeea56478423e3a20f865d9540255756c56) | `` python311Packages.rpcq: disable failing tests ``                         |
| [`e5391840`](https://github.com/NixOS/nixpkgs/commit/e539184044cefe093e4cc196c9eab883b866de0b) | `` python311Packages.aiohttp-fast-url-dispatcher: init at 0.3.0 ``          |
| [`26a7b7b1`](https://github.com/NixOS/nixpkgs/commit/26a7b7b1723efe6598ce2a39cb4633260a358470) | `` python311Packages.gios: 3.2.1 -> 3.2.2 ``                                |
| [`b5f8a5b8`](https://github.com/NixOS/nixpkgs/commit/b5f8a5b808584e68772783681f8ec304a46e0b32) | `` python311Packages.sfrbox-api: 0.0.6 -> 0.0.8 ``                          |
| [`50d4ec0e`](https://github.com/NixOS/nixpkgs/commit/50d4ec0e5d1f4064f5d175c8301fc9dac05339f6) | `` python311Packages.ring-doorbell: 0.8.1 -> 0.8.3 ``                       |
| [`1b845bc1`](https://github.com/NixOS/nixpkgs/commit/1b845bc1e8b5f1a0852cec57e988a011c516d6ad) | `` python311Packages.nettigo-air-monitor: 2.2.1 -> 2.2.2 ``                 |
| [`c0eef128`](https://github.com/NixOS/nixpkgs/commit/c0eef128b335a8e0e6b60b2f9a5f96d387d43921) | `` zlib-ng: 2.1.4 -> 2.1.5 ``                                               |
| [`9fef199b`](https://github.com/NixOS/nixpkgs/commit/9fef199b2a79e66fd8fcb7f4b9730e641492a586) | `` hivex: 1.3.21 → 1.3.23 ``                                                |
| [`58810d2a`](https://github.com/NixOS/nixpkgs/commit/58810d2ac631f5c79cb7cdeeb972c88f29be668f) | `` python310Packages.camel-converter: 3.1.0 -> 3.1.1 ``                     |
| [`97e9d370`](https://github.com/NixOS/nixpkgs/commit/97e9d370d71f7ef267f527b06f4098d8e5b3eb86) | `` obuild: 0.1.10 → 0.1.11 ``                                               |
| [`0461296c`](https://github.com/NixOS/nixpkgs/commit/0461296c62baf3a029b09c2ac39b2977acb24ad6) | `` xmlstarlet: add autoreconfHook, fix cross compilation ``                 |
| [`61c231c0`](https://github.com/NixOS/nixpkgs/commit/61c231c07e7b610beaaed7f3c7116d6f3476363e) | `` python310Packages.branca: 0.6.0 -> 0.7.0 ``                              |
| [`e274d5a6`](https://github.com/NixOS/nixpkgs/commit/e274d5a6c23e8e9fab5f24a1cc71d6994e74f4b2) | `` ripgrep: 14.0.1 -> 14.0.2 ``                                             |
| [`c9f550e3`](https://github.com/NixOS/nixpkgs/commit/c9f550e3714902e9c17bd815e3d27d923aa02313) | `` sing-box: 1.6.6 -> 1.6.7 ``                                              |
| [`4469e227`](https://github.com/NixOS/nixpkgs/commit/4469e22700c47792f93daa882786d36f9bf8bc2a) | `` gh: 2.39.1 -> 2.39.2 ``                                                  |
| [`3303ff54`](https://github.com/NixOS/nixpkgs/commit/3303ff548b21ccdadeab3f9a670775a969c72444) | `` buildMozillaMach: prune patches ``                                       |
| [`7b72294a`](https://github.com/NixOS/nixpkgs/commit/7b72294a256f2503148d460125c913962c73e560) | `` python310Packages.botorch: 0.9.3 -> 0.9.4 ``                             |
| [`a72f24ef`](https://github.com/NixOS/nixpkgs/commit/a72f24ef3bf6538b1dbb5d024e7b0f9517dddb72) | `` buildMozillaMach: replace dbus workaround with upstream patch ``         |
| [`64b4586d`](https://github.com/NixOS/nixpkgs/commit/64b4586d20a6a1b74ec344b19cf76b8b75b44a83) | `` python310Packages.boto3-stubs: 1.28.78 -> 1.29.7 ``                      |
| [`f69da370`](https://github.com/NixOS/nixpkgs/commit/f69da3709818d1397bed93a340cfb42d550e25ad) | `` cpython: restore passthru.tests ``                                       |
| [`1f8c604e`](https://github.com/NixOS/nixpkgs/commit/1f8c604e4270651507cfdfe786741e812ae63267) | `` ArchiSteamFarm: 5.4.12.5 -> 5.4.13.4 ``                                  |
| [`49762946`](https://github.com/NixOS/nixpkgs/commit/4976294642aa001af26996bc125e4f594d1a1c62) | `` python310Packages.bentoml: 1.1.9 -> 1.1.10 ``                            |
| [`f4324ebf`](https://github.com/NixOS/nixpkgs/commit/f4324ebf2b47c71ef7353858d9870b6613691e12) | `` gallery-dl: 1.26.2 -> 1.26.3 ``                                          |
| [`348fb6cb`](https://github.com/NixOS/nixpkgs/commit/348fb6cba5744813850944e376e11d489a08ec41) | `` python311Packages.moto: 4.2.6 -> 4.2.10 ``                               |
| [`ae18f5de`](https://github.com/NixOS/nixpkgs/commit/ae18f5de96e1424846f5c3fb3f50da69d2c64030) | `` python311Packages.py-partialql-parser: 0.4.0 -> 0.4.2 ``                 |
| [`10e0ccbf`](https://github.com/NixOS/nixpkgs/commit/10e0ccbfa53d84af6e49b70580d16318cdde2fde) | `` sccache: 0.7.2 -> 0.7.4 ``                                               |
| [`dfae7c08`](https://github.com/NixOS/nixpkgs/commit/dfae7c0805861efba0afbd2f2d48324358e07ad4) | `` soju: 0.6.2 -> 0.7.0 ``                                                  |
| [`81b063be`](https://github.com/NixOS/nixpkgs/commit/81b063bee896d05495d2b461a1ffc4e90d901051) | `` jql: 7.0.6 -> 7.0.7 ``                                                   |
| [`f84656d4`](https://github.com/NixOS/nixpkgs/commit/f84656d4251a3456ee6c95130a0123e4928d273d) | `` gql: 0.8.0 -> 0.9.0 ``                                                   |
| [`51124177`](https://github.com/NixOS/nixpkgs/commit/5112417739f9b198047bedc352cebb41aa339e1d) | `` gum: 0.11.0 -> 0.12.0 ``                                                 |
| [`e061cb0d`](https://github.com/NixOS/nixpkgs/commit/e061cb0d71fe858f1c04d9c64ce4db53bed94084) | `` python310Packages.awswrangler: 3.4.0 -> 3.4.2 ``                         |
| [`01238b54`](https://github.com/NixOS/nixpkgs/commit/01238b54079c2ac451bb402be6d59072cfaa2d3c) | `` felix-fm: 2.10.1 -> 2.10.2 ``                                            |
| [`9ececdec`](https://github.com/NixOS/nixpkgs/commit/9ececdeceb0f42fb072b2b8eaef628b35652bd16) | `` difftastic: 0.53.0 -> 0.53.1 ``                                          |
| [`03554146`](https://github.com/NixOS/nixpkgs/commit/03554146c75f770ebdaf882d7a0c2556e6d86bd0) | `` tui-journal: 0.4.0 -> 0.5.0 ``                                           |
| [`64c132c4`](https://github.com/NixOS/nixpkgs/commit/64c132c42759d4bf3722e8e24905f86f02180567) | `` qt6.qtbase: fix build on older macOS ``                                  |
| [`20c316dd`](https://github.com/NixOS/nixpkgs/commit/20c316dd239a05f7e76ee702842b91d7bbe54b3b) | `` cargo-mutants: 23.11.1 -> 23.11.2 ``                                     |
| [`a7f14dd9`](https://github.com/NixOS/nixpkgs/commit/a7f14dd928b21b3d5cb84b9893fc8ba1a456e5f0) | `` fw: 2.18.0 -> 2.19.0 ``                                                  |
| [`0eeabb2d`](https://github.com/NixOS/nixpkgs/commit/0eeabb2d284ec26d1139fb935615a2a704f6cf94) | `` symbolicator: 23.11.0 -> 23.11.2 ``                                      |
| [`da55691a`](https://github.com/NixOS/nixpkgs/commit/da55691ab7e0189da1eeb3184beb679aaac1e40a) | `` moonlander: drop ``                                                      |