### PR TITLE
chore(flake/sops-nix): `49a87c6c` -> `b1edbf5c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -647,11 +647,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1700342017,
-        "narHash": "sha256-HaibwlWH5LuqsaibW3sIVjZQtEM/jWtOHX4Nk93abGE=",
+        "lastModified": 1700905716,
+        "narHash": "sha256-w1vHn2MbGfdC+CrP3xLZ3scsI06N0iQLU7eTHIVEFGw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "decdf666c833a325cb4417041a90681499e06a41",
+        "rev": "dfb95385d21475da10b63da74ae96d89ab352431",
         "type": "github"
       },
       "original": {
@@ -816,11 +816,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1700362823,
-        "narHash": "sha256-/H7XgvrYM0IbkpWkcdfkOH0XyBM5ewSWT1UtaLvOgKY=",
+        "lastModified": 1701127353,
+        "narHash": "sha256-qVNX0wOl0b7+I35aRu78xUphOyELh+mtUp1KBx89K1Q=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "49a87c6c827ccd21c225531e30745a9a6464775c",
+        "rev": "b1edbf5c0464b4cced90a3ba6f999e671f0af631",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`b1edbf5c`](https://github.com/Mic92/sops-nix/commit/b1edbf5c0464b4cced90a3ba6f999e671f0af631) | `` update vendorHash ``                                           |
| [`f9442c47`](https://github.com/Mic92/sops-nix/commit/f9442c477d6d606176417b45d35f1b6e675b60f6) | `` build(deps): bump golang.org/x/crypto from 0.15.0 to 0.16.0 `` |
| [`4be58d80`](https://github.com/Mic92/sops-nix/commit/4be58d802693d7def8622ff34d36714f8db40371) | `` flake.lock: Update ``                                          |