### PR TITLE
chore(flake/hyprland-contrib): `11bbb96e` -> `65e567a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700499713,
-        "narHash": "sha256-1+0EXzRXcHn3Zqy8+kdcHClDJR181sqGBRp0xVoedEA=",
+        "lastModified": 1700963402,
+        "narHash": "sha256-JhkanLmYRLekGOysO6JpCWKPlgRoemHPzUrARCGBqYA=",
         "owner": "hyprwm",
         "repo": "contrib",
-        "rev": "11bbb96e44818f67e5259c1788231f30fe5fe2e7",
+        "rev": "65e567a81176d39be7ce6513d1af23954f00cbec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                    |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`65e567a8`](https://github.com/hyprwm/contrib/commit/65e567a81176d39be7ce6513d1af23954f00cbec) | `` Nix: add aarch64-linux support (#75) `` |