### PR TITLE
chore(flake/nh): `23d21975` -> `4298c924`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -480,11 +480,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698826948,
-        "narHash": "sha256-Th05oofIIhsN2bmJNsb0Xev3+RJgtk8stjHZX9EdWA0=",
+        "lastModified": 1700997049,
+        "narHash": "sha256-2dZsKz6CeKTx76krMp9WV4t+lRs2xDWw0aYNUFgnJKI=",
         "owner": "viperML",
         "repo": "nh",
-        "rev": "23d21975231d569afbe3973eb19d955c650f8f08",
+        "rev": "4298c924bb6b52607207691af30ebeccdbfa359d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                      | Message                                      |
| ------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`d78dd6f5`](https://github.com/viperML/nh/commit/d78dd6f5ebe3f763e31affead8eb58317cc8b6f2) | `` fix version diffing for fresh installs `` |