### PR TITLE
chore(flake/unstable): `1b99d72c` -> `173b74db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -930,11 +930,11 @@
     },
     "unstable": {
       "locked": {
-        "lastModified": 1700867874,
-        "narHash": "sha256-0Dk63BLiG9rmfBf8LxFpz8KgpUkepehVzhhVDgfxWSo=",
+        "lastModified": 1700995207,
+        "narHash": "sha256-uTyMkEVTlgPjQPyB0cAW0mLvXJs5Zq0ZYHnz1pheTgs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1b99d72c8b7468def0c633635c469bf828db33a0",
+        "rev": "173b74db07f26344f3517716edd4bff6987b512d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`173b74db`](https://github.com/NixOS/nixpkgs/commit/173b74db07f26344f3517716edd4bff6987b512d) | `` jellyfin: 10.8.11 -> 10.8.12 ``                                                               |
| [`6ccd57c4`](https://github.com/NixOS/nixpkgs/commit/6ccd57c4c6f2b63362935165829fc38d04703155) | `` python311Packages.minikerberos: 0.4.2 -> 0.4.3 ``                                             |
| [`466e3aa8`](https://github.com/NixOS/nixpkgs/commit/466e3aa86eebe1f5e92ce755d33051f883b92e41) | `` python311Packages.pyvoro: mark as broken and unmaintained, preparing for removal (#269886) `` |
| [`967bdf92`](https://github.com/NixOS/nixpkgs/commit/967bdf9223667bf5e6aef54eda6adac901daca1e) | `` swayfx-unwrapped: add eclairevoyant to maintainers ``                                         |
| [`c3ba30d1`](https://github.com/NixOS/nixpkgs/commit/c3ba30d1518b1722877d5616b8ea1c154b4c4181) | `` swayfx-unwrapped: fix meta.mainProgram ``                                                     |
| [`ec60dd76`](https://github.com/NixOS/nixpkgs/commit/ec60dd76008c2a91413e4e516cdaa2c2db0dbe88) | `` magic-vlsi: 8.3.447 -> 8.3.449 ``                                                             |
| [`40eff710`](https://github.com/NixOS/nixpkgs/commit/40eff710afc4eefc05417e08422c249201408807) | `` Revert "Systemd package rewrite" ``                                                           |
| [`f7aec1f5`](https://github.com/NixOS/nixpkgs/commit/f7aec1f5d509cc15ab73f47de64ce2b298f97f29) | `` trash-cli: 0.23.9.23 -> 0.23.11.10 ``                                                         |
| [`a1674c57`](https://github.com/NixOS/nixpkgs/commit/a1674c57abc9c369467195ccbd5b6fd1d1dd6209) | `` swayfx: wrap like sway ``                                                                     |
| [`a25d8761`](https://github.com/NixOS/nixpkgs/commit/a25d87618a05e1f3c63debcbff95a846dcf87683) | `` oh-my-fish: patch to fixup permissions during installation ``                                 |
| [`dbed3c60`](https://github.com/NixOS/nixpkgs/commit/dbed3c605f8dd7c0272693df1a57532392c4ca36) | `` oh-my-fish: migrate to by-name ``                                                             |
| [`a95272e6`](https://github.com/NixOS/nixpkgs/commit/a95272e67f75b85e19b3796d99e56e9a435a2179) | `` oh-my-fish: refactor ``                                                                       |
| [`33d2a40d`](https://github.com/NixOS/nixpkgs/commit/33d2a40d6751477472a2eeb0531ef7ddbf1cc695) | `` systemd: migrate to by-name ``                                                                |
| [`7c588d14`](https://github.com/NixOS/nixpkgs/commit/7c588d141dafe72381bb1bef5c67353349bb1fde) | `` systemd: add meta.longDescription ``                                                          |
| [`d91b8d9f`](https://github.com/NixOS/nixpkgs/commit/d91b8d9fcbaa4514f1a3bdcf1df1b19b38c5df06) | `` systemd: cosmetic rewording of code ``                                                        |
| [`bc563998`](https://github.com/NixOS/nixpkgs/commit/bc563998c0fc0455781f9a90b5a0541de4c15014) | `` systemd: cosmetic rewording of comments ``                                                    |
| [`eab0837b`](https://github.com/NixOS/nixpkgs/commit/eab0837b6803f776a5eb055ffcc9c8041807036a) | `` systemd: remove some redundancy on mesonFlags ``                                              |
| [`1129756b`](https://github.com/NixOS/nixpkgs/commit/1129756b1a44deeeb08d09e4745f2aa8ed428282) | `` systemd: use  lib.meson* functions ``                                                         |
| [`396b66da`](https://github.com/NixOS/nixpkgs/commit/396b66da33e27f2f4ee9a43a4b02fb6e3c99dc2b) | `` llvm-mode: update src location ``                                                             |
| [`bf68ef90`](https://github.com/NixOS/nixpkgs/commit/bf68ef906b422ed198fdb077c10c88d4128fef9d) | `` budgie.budgie-desktop: Add dependency on Mutter ``                                            |
| [`47523cce`](https://github.com/NixOS/nixpkgs/commit/47523ccec2742bb9dbbd05d0eae714107f882967) | `` budgie.budgie-control-center: Replace Magpie with Mutter ``                                   |
| [`198e57d2`](https://github.com/NixOS/nixpkgs/commit/198e57d2dfc4a56afc419f465c5a56c729f71e8b) | `` budgie.budgie-gsettings-overrides: Replace Magpie with Mutter ``                              |
| [`c4f2f453`](https://github.com/NixOS/nixpkgs/commit/c4f2f4530cb99feaf977923ef68bd0dbe9797968) | `` newsflash: 2.3.1 -> 3.0.2 ``                                                                  |
| [`652728a7`](https://github.com/NixOS/nixpkgs/commit/652728a7e44c5be4d1ac1ad9500e460a3342c212) | `` python311Packages.canals: 0.10.0 -> 0.11.0 ``                                                 |
| [`7474a2f4`](https://github.com/NixOS/nixpkgs/commit/7474a2f4f7a193bad96f7e394bf8aa8a42fd82ae) | `` rPackages.XLConnect: fix build ``                                                             |
| [`eb602b02`](https://github.com/NixOS/nixpkgs/commit/eb602b02dedd22b29c08808b405c7f158d0cb8dc) | `` ngrep: improve meta.license ``                                                                |
| [`a89d38d4`](https://github.com/NixOS/nixpkgs/commit/a89d38d49814e94e5ad7fd8276b117f69c0cf93b) | `` udiskie: 2.5.0 -> 2.5.1 ``                                                                    |
| [`1558dea7`](https://github.com/NixOS/nixpkgs/commit/1558dea73b15a4ea7694c127a9502781b4efd4b3) | `` foliate: 2.6.4 -> 3.0.1 ``                                                                    |
| [`986d96a3`](https://github.com/NixOS/nixpkgs/commit/986d96a355c41d39245368e43c5f1707047d4908) | `` mcrypt: fix build on darwin ``                                                                |
| [`5a600478`](https://github.com/NixOS/nixpkgs/commit/5a6004785085ee4ec8ef20ac3f0c27d43dfa8fec) | `` quvi: drop ``                                                                                 |
| [`8ce8a58d`](https://github.com/NixOS/nixpkgs/commit/8ce8a58d8fbe6b7d37a693051a2bd5f42685b1d4) | `` python311Packages.pycontrol4: use pyproject ``                                                |
| [`a9cb4dc2`](https://github.com/NixOS/nixpkgs/commit/a9cb4dc2ef1f95598ab77eb5bb84c8a4371c6b40) | `` libmcrypt: fix build on darwin ``                                                             |
| [`a0f5d5e5`](https://github.com/NixOS/nixpkgs/commit/a0f5d5e500b4c7ddf619333a0341a049e1e345ee) | `` nixos/preload: init ``                                                                        |
| [`a08e49d5`](https://github.com/NixOS/nixpkgs/commit/a08e49d5d252284c1feb9dfe27865e33cbb946cf) | `` preload: init at 0.6.4 ``                                                                     |
| [`2c820c18`](https://github.com/NixOS/nixpkgs/commit/2c820c18931612b91e1a2d218bcdc5d0112ad917) | `` maintainers: add ldprg ``                                                                     |
| [`53014d27`](https://github.com/NixOS/nixpkgs/commit/53014d2701b9534a1120cfc07b57c167cd003235) | `` rPackages.redux: fix build ``                                                                 |
| [`aa9baf42`](https://github.com/NixOS/nixpkgs/commit/aa9baf42061019f285f964a58e93087f465f3908) | `` fractal: 4.4.2 -> 5 ``                                                                        |
| [`a3f83758`](https://github.com/NixOS/nixpkgs/commit/a3f8375852f44bd1714c53c1107a27d6c852e992) | `` asusctl: 4.7.1 -> 4.7.2 ``                                                                    |
| [`c4cd7258`](https://github.com/NixOS/nixpkgs/commit/c4cd72586f1ac64fc9aafdd06178e4e6218d2eda) | `` python3Packages.wasmer-compiler-llvm: fix build failure ``                                    |
| [`7e9c9763`](https://github.com/NixOS/nixpkgs/commit/7e9c976322b8e8045c739b8d1c34b978cee843bb) | `` photofield: add meta.mainProgram ``                                                           |
| [`469d56ae`](https://github.com/NixOS/nixpkgs/commit/469d56aedd90ae57d46b289e7250be122b51f46c) | `` photofield: add passthru.tests.version ``                                                     |
| [`f8adf710`](https://github.com/NixOS/nixpkgs/commit/f8adf710cb2e298b37649132791c93bebc69954b) | `` photofield: 0.11.0 -> 0.13.0 ``                                                               |
| [`68a2749b`](https://github.com/NixOS/nixpkgs/commit/68a2749b5bbdb351b5a07a6a0e9270424898b495) | `` instawow: init at 3.1.0 ``                                                                    |
| [`d517f146`](https://github.com/NixOS/nixpkgs/commit/d517f1465dfe3549ba7f32302eea5432923f308f) | `` irpf: 1.3 -> 1.5 ``                                                                           |
| [`679cb8ff`](https://github.com/NixOS/nixpkgs/commit/679cb8ff4db11edf3ac27b188f75a3cc55909cd5) | `` nushellPlugins: update for nu 0.87.1 and build on hydra ``                                    |
| [`f02bf1ba`](https://github.com/NixOS/nixpkgs/commit/f02bf1ba305666ce4d27c628ec5bff9bc3312505) | `` python311Packages.nibe: 2.5.0 -> 2.5.1 ``                                                     |
| [`96321ebf`](https://github.com/NixOS/nixpkgs/commit/96321ebf93b5d3b80522b5a761fa2513b8e1c9d8) | `` python311Packages.confection: 0.1.3 -> 0.1.4 ``                                               |
| [`3b295cf5`](https://github.com/NixOS/nixpkgs/commit/3b295cf5ae4ec42b3d99b6273890c2dac945b99e) | `` python311Packages.asysocks: 0.2.9 -> 0.2.11 ``                                                |
| [`748a0aaa`](https://github.com/NixOS/nixpkgs/commit/748a0aaa627dcc58114f88d9cda9aa3341d16803) | `` fblog: 4.5.0 -> 4.6.0 ``                                                                      |
| [`f7263685`](https://github.com/NixOS/nixpkgs/commit/f7263685dfbab3b1f0ea1c7933bf9f225474ad4b) | `` wol: add mainProgram ``                                                                       |
| [`b7a8d59e`](https://github.com/NixOS/nixpkgs/commit/b7a8d59e3ab68bc6e01ff660e5b8165eb399f443) | `` pyqt6: fix build on darwin ``                                                                 |
| [`617b9534`](https://github.com/NixOS/nixpkgs/commit/617b95347a4b45c0849933ca917fdee57171c11e) | `` colima: 0.6.0 -> 0.6.5 ``                                                                     |
| [`14d44910`](https://github.com/NixOS/nixpkgs/commit/14d4491000e386796beb9f5ad3378550bf4e6997) | `` nixos-render-docs: fix mypy test ``                                                           |
| [`fa07aaf5`](https://github.com/NixOS/nixpkgs/commit/fa07aaf5a91f1330a7a130015a5a9098a30812cf) | `` colima: 0.5.6 -> 0.6.0 ``                                                                     |
| [`c0bdb24c`](https://github.com/NixOS/nixpkgs/commit/c0bdb24caf9dc197116188dc89bc9966ff86be5f) | `` forgejo: 1.20.5-0 -> 1.20.5-1 ``                                                              |
| [`0de4a671`](https://github.com/NixOS/nixpkgs/commit/0de4a671c3a18451710c09c8f8408ec4d9c274c7) | `` python311Packages.rotary-embedding-torch: 0.3.5 -> 0.3.6 ``                                   |
| [`9c6515b1`](https://github.com/NixOS/nixpkgs/commit/9c6515b1138e59f02e06857d7154f43d2b059b59) | `` python311Packages.pyreadstat: 1.2.4 -> 1.2.5 ``                                               |
| [`694ddfae`](https://github.com/NixOS/nixpkgs/commit/694ddfae79e82174af41da825193dd9441624854) | `` python311Packages.dash: migrate to prefetch-yarn-deps ``                                      |
| [`b0a49f1b`](https://github.com/NixOS/nixpkgs/commit/b0a49f1bf173a211702edcbf60a6d27d64ede130) | `` bundix: update homepage ``                                                                    |
| [`0e0c9a66`](https://github.com/NixOS/nixpkgs/commit/0e0c9a6646a90abba3106fc62a0fdac80f14e821) | `` bundix: fix license attribute ``                                                              |
| [`07390fcb`](https://github.com/NixOS/nixpkgs/commit/07390fcb4aebd1dace7fcb238e9f285ca506efb5) | `` pythonPackages.pyheck: fix build on darwin ``                                                 |
| [`5304b1a4`](https://github.com/NixOS/nixpkgs/commit/5304b1a4eaee5234751103751c93d0d8533950b2) | `` vimPlugins.fidget-nvim: switch branch from legacy to main ``                                  |
| [`5e873ef2`](https://github.com/NixOS/nixpkgs/commit/5e873ef2ec2b556d18e78efd20cc0465e29b0b9b) | `` clipcat: 0.5.1 -> 0.6.2 ``                                                                    |
| [`da87e679`](https://github.com/NixOS/nixpkgs/commit/da87e679f59942b6b2b49ef3de7cb30f59af66bb) | `` gnomeExtensions.pop-shell: unstable-2023-04-27 -> unstable-2023-11-10 ``                      |
| [`833354eb`](https://github.com/NixOS/nixpkgs/commit/833354eb44a29e921f7c9e8f519fee9cb61785aa) | `` gerrit: 3.8.2 -> 3.8.3 ``                                                                     |
| [`f5b7885e`](https://github.com/NixOS/nixpkgs/commit/f5b7885e0cd047f986c6d573102450ac7e0f6a65) | `` rustic-rs: fix build on darwin ``                                                             |
| [`3ccf35fa`](https://github.com/NixOS/nixpkgs/commit/3ccf35fa5339d4d21f649db625305f1886d12cb9) | `` khronos: 3.7.0 -> 4.0.1 ``                                                                    |
| [`2fc0b97e`](https://github.com/NixOS/nixpkgs/commit/2fc0b97e57f3a0437a865663fc92452aa23568ca) | `` xmrig-proxy: 6.20.0 -> 6.21.0 ``                                                              |
| [`25f1b1f4`](https://github.com/NixOS/nixpkgs/commit/25f1b1f4ac055ddf99b0f8cfda9ba5f1ed449fa2) | `` tilt: migrate to prefetch-yarn-deps ``                                                        |
| [`fb1cc4af`](https://github.com/NixOS/nixpkgs/commit/fb1cc4af9c3ff397b0732ddfdeafd826ad54119b) | `` Skip `sqlite3_bind_bug68849.phpt` php unit test on i686 linux ``                              |
| [`3e96f75e`](https://github.com/NixOS/nixpkgs/commit/3e96f75e85822d7b643b894eb1d0c4665122f82e) | `` river: 0.2.5 -> 0.2.6 ``                                                                      |
| [`f6ef3d25`](https://github.com/NixOS/nixpkgs/commit/f6ef3d2527bf033808951d304ab759b3ea08ec9f) | `` exoscale-cli: 1.74.4 -> 1.75.0 ``                                                             |
| [`fc235bb0`](https://github.com/NixOS/nixpkgs/commit/fc235bb0fcb324cbce510f4cf1e1e51a6615a195) | `` python/hooks: use python.pythonVersion to support PyPy ``                                     |
| [`0bfeafe4`](https://github.com/NixOS/nixpkgs/commit/0bfeafe4a93326e404d4c06c7ca2fbe59497a726) | `` duperemove: 0.14 -> 0.14.1 ``                                                                 |
| [`d1941e77`](https://github.com/NixOS/nixpkgs/commit/d1941e77241c3ff1e2008c35130c6e903c75dcf2) | `` gotify-server: migrate to prefetch-yarn-deps ``                                               |
| [`b0eed3a0`](https://github.com/NixOS/nixpkgs/commit/b0eed3a0ac4c3313fef96c45239521bb73931005) | `` OVMF: mark broken on Darwin ``                                                                |
| [`5df1bb20`](https://github.com/NixOS/nixpkgs/commit/5df1bb20c8ef1d8c54aed0aa8e43f66ace1e8162) | `` python311Packages.vertica-python: 1.3.6 -> 1.3.7 ``                                           |
| [`db9b8f36`](https://github.com/NixOS/nixpkgs/commit/db9b8f36df1ae8fe6bc0337d8f25ea7b7031301e) | `` OVMF: support RISC-V ``                                                                       |
| [`dd6c677c`](https://github.com/NixOS/nixpkgs/commit/dd6c677c4d49ddb2f8c00e68b542acd48a917c7a) | `` grafana-agent: migrate to prefetch-yarn-deps ``                                               |
| [`232bf80b`](https://github.com/NixOS/nixpkgs/commit/232bf80bdc7ed6db0eb70a9b8f9ece3d80afe242) | `` civo: 1.0.68 -> 1.0.69 ``                                                                     |
| [`998308f5`](https://github.com/NixOS/nixpkgs/commit/998308f5fddb9c6b9a8098aa6a5eba3ca1b3d8e7) | `` python311Packages.augeas: 1.1.0 -> 1.2.0 ``                                                   |
| [`770194fa`](https://github.com/NixOS/nixpkgs/commit/770194fac17ea9bb018e612f426239f4f13c1785) | `` OVMF: disable `sourceDebug` by default ``                                                     |
| [`ffe74b61`](https://github.com/NixOS/nixpkgs/commit/ffe74b6158287a8730800ae81243f876b4bfef29) | `` pscale: 1.161.0 -> 1.162.0 ``                                                                 |
| [`6a2ed3ad`](https://github.com/NixOS/nixpkgs/commit/6a2ed3adf2d4e503676ca6dc16467ec88608eb7d) | `` edk2: support RISC-V ``                                                                       |
| [`e99c920f`](https://github.com/NixOS/nixpkgs/commit/e99c920fb1055850540ff8d31b7d347b7088fccc) | `` edk2: 202308 -> 202311 ``                                                                     |
| [`ff3adab3`](https://github.com/NixOS/nixpkgs/commit/ff3adab3708ec2f8ce2e4b7316e3c8f4456da638) | `` edk2: fix cross compilation ``                                                                |
| [`11440690`](https://github.com/NixOS/nixpkgs/commit/1144069008696abf9d817cbfb10a97e973b215b6) | `` aiohttp-client-cache: init at 0.10.0 ``                                                       |
| [`6f494c9a`](https://github.com/NixOS/nixpkgs/commit/6f494c9af4cdcb67dd9bbe93578a2238c79324f9) | `` bruno: add `kashw2` as maintainer ``                                                          |
| [`2c2c1b0d`](https://github.com/NixOS/nixpkgs/commit/2c2c1b0d728300f24a6337e82d5e7ca17c98615a) | `` bruno: 1.1.1 -> 1.2.0 ``                                                                      |
| [`ff7534f1`](https://github.com/NixOS/nixpkgs/commit/ff7534f13b87de1862334b7e9fac0b432471238f) | `` psutils: fix build on darwin by setting -std=c89 ``                                           |
| [`9d1029f2`](https://github.com/NixOS/nixpkgs/commit/9d1029f25386649794951d7354b3284ae06adf62) | `` anki: migrate to prefetch-yarn-deps ``                                                        |
| [`11e39b43`](https://github.com/NixOS/nixpkgs/commit/11e39b43a0772cc4ead0101646e8fd4fd78f32ea) | `` rocksdb: fix build of versions < 8 ``                                                         |
| [`0e4a87f4`](https://github.com/NixOS/nixpkgs/commit/0e4a87f4dd2089d99eb8d3f8a9c094e1d3e037d6) | `` qt6.qtwebengine: set correct platforms ``                                                     |
| [`fc1c549b`](https://github.com/NixOS/nixpkgs/commit/fc1c549b56d95855891e2ac3a64bf9468cd2f7e8) | `` python311Packages.phik: refactor, disable failing tests ``                                    |
| [`e4c1138c`](https://github.com/NixOS/nixpkgs/commit/e4c1138cb75fd8fee16675e05199b7413f853251) | `` karmor: 0.14.2 -> 0.14.3 ``                                                                   |
| [`1095d893`](https://github.com/NixOS/nixpkgs/commit/1095d8934b11e76de30ff3b2e8d442e470436490) | `` rocksdb: use finalAttrs ``                                                                    |
| [`7625075f`](https://github.com/NixOS/nixpkgs/commit/7625075fae710416ac4c2228e6e801ad639b97cb) | `` terragrunt: 0.53.5 -> 0.53.6 ``                                                               |
| [`8b44dca9`](https://github.com/NixOS/nixpkgs/commit/8b44dca9e66a6913d7e989484a71b2ff7f07009a) | `` python311Packages.pycontrol4: 1.1.0 -> 1.1.2 ``                                               |
| [`20b4687c`](https://github.com/NixOS/nixpkgs/commit/20b4687cf09c4ebee26bf8b9624a0654c52c3ad7) | `` maintainers: add das-g to geospatial team ``                                                  |
| [`efc80f37`](https://github.com/NixOS/nixpkgs/commit/efc80f379c114f9070a7f2a9433bff40c9e30dde) | `` ddosify: refactor ``                                                                          |
| [`4b31fbec`](https://github.com/NixOS/nixpkgs/commit/4b31fbecbb76fd3cc15b09c2d242feb1d2cb8dda) | `` patool: 1.12 -> 2.0.0 ``                                                                      |
| [`861fb5c0`](https://github.com/NixOS/nixpkgs/commit/861fb5c048f2118d591555b9bf90a2c0f410dabc) | `` python311Packages.pymc: 5.9.2 -> 5.10.0 ``                                                    |
| [`6568016f`](https://github.com/NixOS/nixpkgs/commit/6568016fa3397dfb07965855f56171a9c55ef7d7) | `` u-boot: ROCK64 RAM init improvements ``                                                       |
| [`144c241d`](https://github.com/NixOS/nixpkgs/commit/144c241d6a7103d045c295107c81b4cf36fad800) | `` python311Packages.aiolifx: refactor ``                                                        |
| [`055b31d6`](https://github.com/NixOS/nixpkgs/commit/055b31d670bcf561890705a8d69e2854561a389e) | `` python311Packages.aiolifx: 0.9.0 -> 1.0.0 ``                                                  |
| [`4faea1c2`](https://github.com/NixOS/nixpkgs/commit/4faea1c2836a70171d9156cc9dd29b45636d3457) | `` augeas: 1.12.0 -> 1.14.1; fix darwin build ``                                                 |
| [`c2478dd5`](https://github.com/NixOS/nixpkgs/commit/c2478dd50e3c62face958c06c7c25c25ecf6f53d) | `` python311Packages.authcaptureproxy: 1.2.0 -> 1.2.1 ``                                         |
| [`65217c32`](https://github.com/NixOS/nixpkgs/commit/65217c32df798138081d5fd724998dfbcdc2dfe7) | `` powerstat: 0.03.03 -> 0.04.01 ``                                                              |