### PR TITLE
chore(flake/spicetify-nix): `50e08054` -> `c9b1d9bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700972047,
-        "narHash": "sha256-vDRP5WuezoWRrrVziQZZuUplt5RPApzSfrC+Y7hsbIM=",
+        "lastModified": 1701317663,
+        "narHash": "sha256-kkMW1h2LVc8+E0YEupVs4syAdBt+K2WoDIivaKJcX3U=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "50e08054cb8734babaa4589e15c7677a42a20bc7",
+        "rev": "c9b1d9bd7e62609e0ad9f672a2bff8a419bcb02c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`c9b1d9bd`](https://github.com/Gerg-L/spicetify-nix/commit/c9b1d9bd7e62609e0ad9f672a2bff8a419bcb02c) | `` CI update 2023-11-30 (#95) `` |
| [`24d7702e`](https://github.com/Gerg-L/spicetify-nix/commit/24d7702ee33e76f1251afcaaca497cf18d93e229) | `` big rework in progress ``     |
| [`609b30df`](https://github.com/Gerg-L/spicetify-nix/commit/609b30dfeff884856e9c0306cf6454d98015fd7f) | `` CI update 2023-11-29 (#94) `` |
| [`18ffbec4`](https://github.com/Gerg-L/spicetify-nix/commit/18ffbec4127889e0de6661de8ec39dc9f7903d24) | `` CI update 2023-11-28 (#93) `` |
| [`7056f0c7`](https://github.com/Gerg-L/spicetify-nix/commit/7056f0c77e228088864d918ab364957b6b0a2e20) | `` CI update 2023-11-27 (#92) `` |
| [`3e8a03b5`](https://github.com/Gerg-L/spicetify-nix/commit/3e8a03b554cb33e10eaad3b4b43b3ac4c6260a85) | `` CI update 2023-11-26 (#91) `` |
| [`8fea4b17`](https://github.com/Gerg-L/spicetify-nix/commit/8fea4b17a2783cdcbc2342dbc370ad4fe17650f0) | `` CI update 2023-11-25 (#90) `` |