### PR TITLE
chore(flake/nur): `f69fe2f3` -> `54e5c118`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -711,11 +711,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701047095,
-        "narHash": "sha256-Au/U65SGDH4jtrD9Btv63t8X7MbaSLKcEVPtpKGhvAA=",
+        "lastModified": 1701274502,
+        "narHash": "sha256-0q3S6WSHQp40JLQhs6gWx7B0B1iUHqA2JUfD/s9f40k=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "f69fe2f32f963f16b2abeeb941866a0273142af7",
+        "rev": "54e5c1183d178322e0dd79ebba7551ccb543b6b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`54e5c118`](https://github.com/nix-community/NUR/commit/54e5c1183d178322e0dd79ebba7551ccb543b6b6) | `` automatic update `` |
| [`4771f0ad`](https://github.com/nix-community/NUR/commit/4771f0ad93cde5b847e840ce5ac27cee4e85a8c1) | `` automatic update `` |
| [`d5926575`](https://github.com/nix-community/NUR/commit/d5926575eed2a8f8851fbe2c46f2c6c705f437cb) | `` automatic update `` |
| [`d6f93721`](https://github.com/nix-community/NUR/commit/d6f93721ade604ab02a42276ecf94e79edfbd07d) | `` automatic update `` |
| [`034e7a93`](https://github.com/nix-community/NUR/commit/034e7a9342ce059511d2d28cc8ac1177cb6ee620) | `` automatic update `` |
| [`88391f2c`](https://github.com/nix-community/NUR/commit/88391f2c4638fba9070c9f2eb3e47d23ad2e1b74) | `` automatic update `` |
| [`3dd8c0f0`](https://github.com/nix-community/NUR/commit/3dd8c0f0fb9d25bf2855854ef5a9709611d2a6f9) | `` automatic update `` |
| [`244dfb85`](https://github.com/nix-community/NUR/commit/244dfb85d0cf98918728d93107cc189198e2ebcf) | `` automatic update `` |
| [`cf59569a`](https://github.com/nix-community/NUR/commit/cf59569a75167a405577c3452261200c5c72064c) | `` automatic update `` |
| [`35198afc`](https://github.com/nix-community/NUR/commit/35198afc8b9fa7bdffd2ce9d3bb4412e1e45bb45) | `` automatic update `` |
| [`06928454`](https://github.com/nix-community/NUR/commit/06928454918d1f13ec9c8156d47910c4318928e8) | `` automatic update `` |
| [`cc705ad8`](https://github.com/nix-community/NUR/commit/cc705ad8bd1dce959447690070619e55c05f7f31) | `` automatic update `` |
| [`34f00768`](https://github.com/nix-community/NUR/commit/34f007685d5e12be7b209375fb802d4e267f4bd9) | `` automatic update `` |
| [`9e312c26`](https://github.com/nix-community/NUR/commit/9e312c26cb0e971602145ce26039e891a2a4addf) | `` automatic update `` |
| [`b8a559b3`](https://github.com/nix-community/NUR/commit/b8a559b3f42489523815ba229b0e53bf469f5063) | `` automatic update `` |
| [`49e373c9`](https://github.com/nix-community/NUR/commit/49e373c95c84b8297a0d78d243b3bd1eaa51d82f) | `` automatic update `` |
| [`41f9bd9c`](https://github.com/nix-community/NUR/commit/41f9bd9c7d60888a396ff5674bbf8725623d7f83) | `` automatic update `` |
| [`a4670bc5`](https://github.com/nix-community/NUR/commit/a4670bc574aa6c29c3866104a48de9971f782951) | `` automatic update `` |
| [`90609c10`](https://github.com/nix-community/NUR/commit/90609c101813a199d745f7efed4ab42f6d86d7b6) | `` automatic update `` |
| [`26c0607a`](https://github.com/nix-community/NUR/commit/26c0607a348303c1a73572f565bcdf60bcad0ef8) | `` automatic update `` |
| [`6e644b54`](https://github.com/nix-community/NUR/commit/6e644b546287d102c671bde55cf90fc00b46cd21) | `` automatic update `` |
| [`37fa533d`](https://github.com/nix-community/NUR/commit/37fa533da97941f90ce4a3366252fe0efcbb7854) | `` automatic update `` |
| [`f842b913`](https://github.com/nix-community/NUR/commit/f842b9130e824053881c6aa79b91981b64608cdb) | `` automatic update `` |
| [`05d01bba`](https://github.com/nix-community/NUR/commit/05d01bbace13bffaaba6e7f0792640db283eaf99) | `` automatic update `` |
| [`affe0f69`](https://github.com/nix-community/NUR/commit/affe0f69f2dda1ffb7f00a5db5cfdf1173299b3d) | `` automatic update `` |
| [`021b78d0`](https://github.com/nix-community/NUR/commit/021b78d0ffd70f59d1211c5c5f6742bc06ab4129) | `` automatic update `` |
| [`c713d19b`](https://github.com/nix-community/NUR/commit/c713d19b37b4ee88925a6fcf653a9f2af73e82e0) | `` automatic update `` |
| [`333a8e34`](https://github.com/nix-community/NUR/commit/333a8e348f51cfcfcc20794441712a5b6c3f6184) | `` automatic update `` |
| [`54d72329`](https://github.com/nix-community/NUR/commit/54d72329affbb714ef7fcda8574e0b38af74be35) | `` automatic update `` |
| [`9b9e0863`](https://github.com/nix-community/NUR/commit/9b9e0863e8473fbad9df7ecac66fa4eeba3ee229) | `` automatic update `` |
| [`30497442`](https://github.com/nix-community/NUR/commit/30497442f7f899f6e24bb4bad34414eb8475ac32) | `` automatic update `` |
| [`5dca4f0c`](https://github.com/nix-community/NUR/commit/5dca4f0c44b4030a70b24a3f16e4519d49544f7f) | `` automatic update `` |
| [`1cd0a267`](https://github.com/nix-community/NUR/commit/1cd0a267b09c8c035e5c32bf9e1017b5ae90bec4) | `` automatic update `` |
| [`fe1721e7`](https://github.com/nix-community/NUR/commit/fe1721e7d39a76582cfb2fcc57076a523ff10d28) | `` automatic update `` |
| [`fe19b4c0`](https://github.com/nix-community/NUR/commit/fe19b4c06d0996e666887230a01f9018c174529d) | `` automatic update `` |
| [`5c53b8b1`](https://github.com/nix-community/NUR/commit/5c53b8b1e0021f673f42dfabe68fa082779cb487) | `` automatic update `` |
| [`a2f8ce2e`](https://github.com/nix-community/NUR/commit/a2f8ce2e744f7d1197118be992caf36f7c39c63f) | `` automatic update `` |
| [`6ba20d2f`](https://github.com/nix-community/NUR/commit/6ba20d2f567cc2feedb902af75a0f38367ebebb6) | `` automatic update `` |
| [`c3f81aec`](https://github.com/nix-community/NUR/commit/c3f81aecb4124b9bf13956c5bb4acfeecbfb8c5a) | `` automatic update `` |
| [`e0368708`](https://github.com/nix-community/NUR/commit/e03687087cad1bf3134c3cbcef61f3831ae00b21) | `` automatic update `` |
| [`ff367bc1`](https://github.com/nix-community/NUR/commit/ff367bc15b15bd6860f0902adc4f6373dd9903d4) | `` automatic update `` |
| [`8080784f`](https://github.com/nix-community/NUR/commit/8080784fb794a587bfc86540349203af6aa211f8) | `` automatic update `` |
| [`d24d4d5c`](https://github.com/nix-community/NUR/commit/d24d4d5c15ce3b142f0e92fa80092e8d7299bb71) | `` automatic update `` |
| [`5ae1d816`](https://github.com/nix-community/NUR/commit/5ae1d81684da36facb97c7f45eb6e003b62c45c5) | `` automatic update `` |
| [`95271c0c`](https://github.com/nix-community/NUR/commit/95271c0caebedc42e9f3273a524d7a565a77dcb3) | `` automatic update `` |
| [`dcd4670d`](https://github.com/nix-community/NUR/commit/dcd4670dc545a3996a87d4533c5ca82427b90a55) | `` automatic update `` |
| [`d2bb9222`](https://github.com/nix-community/NUR/commit/d2bb9222bfb0c4d7a190c50f840ff6acc21884d4) | `` automatic update `` |
| [`2aac3f35`](https://github.com/nix-community/NUR/commit/2aac3f35b161d93b786369d97f1eb956a0f6be11) | `` automatic update `` |
| [`193f168e`](https://github.com/nix-community/NUR/commit/193f168ecaabcfbe35e909587a9301667c2df07f) | `` automatic update `` |
| [`82fc3d55`](https://github.com/nix-community/NUR/commit/82fc3d559e4e1cf99618ffd7f5f5f1ea26509763) | `` automatic update `` |
| [`eab21a55`](https://github.com/nix-community/NUR/commit/eab21a5514fd3dae3093b5c671b16ed7caabb402) | `` automatic update `` |
| [`576b5f3d`](https://github.com/nix-community/NUR/commit/576b5f3d0a7fd0677f11498eb9a2d07f88c852ca) | `` automatic update `` |
| [`9326ec75`](https://github.com/nix-community/NUR/commit/9326ec75ce265a65d1b305fed5059fa77f43d7dc) | `` automatic update `` |
| [`d87b3b55`](https://github.com/nix-community/NUR/commit/d87b3b5503d53f16cc20957aa69ff7ad8ba52d57) | `` automatic update `` |
| [`218c0b56`](https://github.com/nix-community/NUR/commit/218c0b566f8519bad3ada0e25fc5e328e4720a66) | `` automatic update `` |
| [`42b61488`](https://github.com/nix-community/NUR/commit/42b61488351ba57a489eb46fd8ceb97ee4e19b06) | `` automatic update `` |
| [`86d3b5ab`](https://github.com/nix-community/NUR/commit/86d3b5ab992cece6c79bf2a3b30c8d6cde47bbf3) | `` automatic update `` |
| [`5b543aa2`](https://github.com/nix-community/NUR/commit/5b543aa25fdc06ae3f60c45acc050bd0876541bc) | `` automatic update `` |
| [`4b42a063`](https://github.com/nix-community/NUR/commit/4b42a0638687473d21d369b9c692b39b944713c5) | `` automatic update `` |
| [`ddbe5c9d`](https://github.com/nix-community/NUR/commit/ddbe5c9d41db49fed8db184b8de2034ec55d4bb2) | `` automatic update `` |
| [`a6a6faa2`](https://github.com/nix-community/NUR/commit/a6a6faa261c9324ec2c7154ebec87bd17820baff) | `` automatic update `` |
| [`1af599d2`](https://github.com/nix-community/NUR/commit/1af599d275dd49cf62eca391f43f4ae70d1f5017) | `` automatic update `` |
| [`13001183`](https://github.com/nix-community/NUR/commit/1300118335519d491e7a0bd2d45d07162c567380) | `` automatic update `` |
| [`7a780b49`](https://github.com/nix-community/NUR/commit/7a780b49e43f5318aa23956cbe5ab7478a9793d1) | `` automatic update `` |
| [`0bf7ca01`](https://github.com/nix-community/NUR/commit/0bf7ca01861cdf16538549f8f31d85796567ef21) | `` automatic update `` |
| [`dcc89448`](https://github.com/nix-community/NUR/commit/dcc894483567d2213507217d598f81bb2cd3264b) | `` automatic update `` |
| [`5dc6daff`](https://github.com/nix-community/NUR/commit/5dc6daff2a68f6e9cbda6b8a482c3c9dafa0a874) | `` automatic update `` |
| [`4182df9d`](https://github.com/nix-community/NUR/commit/4182df9d7f62c58a7be42a3a3a23014cd557c996) | `` automatic update `` |
| [`20954abd`](https://github.com/nix-community/NUR/commit/20954abdd52e1941e13c0ab3ea676097ccec0183) | `` automatic update `` |
| [`c2834572`](https://github.com/nix-community/NUR/commit/c2834572c536aeb582412ffb6358f169b1225b71) | `` automatic update `` |
| [`4ac04b17`](https://github.com/nix-community/NUR/commit/4ac04b17a0cc259c37cdbf8d916cfa7325d4e5ee) | `` automatic update `` |
| [`503b834c`](https://github.com/nix-community/NUR/commit/503b834c86a5fcebe8c824e9a2f9ccade2f1e9fa) | `` automatic update `` |
| [`ae6a9846`](https://github.com/nix-community/NUR/commit/ae6a9846dfafebb8cfbf3800cca219dd4d984698) | `` automatic update `` |
| [`a0e751e3`](https://github.com/nix-community/NUR/commit/a0e751e325d83b0350a32afe946bc3ca46ebe095) | `` automatic update `` |