### PR TITLE
chore(flake/unstable): `173b74db` -> `9e6f9c6d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -930,11 +930,11 @@
     },
     "unstable": {
       "locked": {
-        "lastModified": 1700995207,
-        "narHash": "sha256-uTyMkEVTlgPjQPyB0cAW0mLvXJs5Zq0ZYHnz1pheTgs=",
+        "lastModified": 1701084168,
+        "narHash": "sha256-gNYhVjJyKIg5xTfA/ROmVr4mxwPbNWl0RUjZ7ey+3XE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "173b74db07f26344f3517716edd4bff6987b512d",
+        "rev": "9e6f9c6d8325d92c5a4e680d8b1ed2495d6f3942",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                       |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
| [`9e6f9c6d`](https://github.com/NixOS/nixpkgs/commit/9e6f9c6d8325d92c5a4e680d8b1ed2495d6f3942) | `` nixos/sourcehut: remove usages of 'with lib;' ``                                           |
| [`ba6817ed`](https://github.com/NixOS/nixpkgs/commit/ba6817ed2260282021072ce79bdd820ea9190502) | `` nixos/sourcehut: add myself as maintainer ``                                               |
| [`087c83f4`](https://github.com/NixOS/nixpkgs/commit/087c83f45c3cc8d396971bb02ff27303e760d73d) | `` nixos/sourcehut: reformat expressions using nixpkgs-fmt ``                                 |
| [`f5da19d2`](https://github.com/NixOS/nixpkgs/commit/f5da19d226c9524dc15d8ca64dc6c2f9d59aea8c) | `` ocamlPackages.caqti*: improve meta.license ``                                              |
| [`f0f506c0`](https://github.com/NixOS/nixpkgs/commit/f0f506c0548c27eca94a0bff051123d97b92ed1a) | `` phosh: 0.32.0 -> 0.33.0 ``                                                                 |
| [`e92eba7c`](https://github.com/NixOS/nixpkgs/commit/e92eba7c8d1e80c2303973c2267838ac8c7eed2f) | `` wl-gammactl: don't need wlroots ``                                                         |
| [`271a11a2`](https://github.com/NixOS/nixpkgs/commit/271a11a2d6145f0a4c842779599251e8efcb3d48) | `` ripgrep: 13.0.0 -> 14.0.1 ``                                                               |
| [`2ec2d682`](https://github.com/NixOS/nixpkgs/commit/2ec2d68238e57cd69edcb93e5b104abde10cca03) | `` coqPackages.VST: 2.12 → 2.13 ``                                                            |
| [`1b732db2`](https://github.com/NixOS/nixpkgs/commit/1b732db24bf4ef1f0bb28c60834cccf2c00c5f08) | `` php81Extensions.datadog_trace: 0.93.1 -> 0.94.0 ``                                         |
| [`0a2a243a`](https://github.com/NixOS/nixpkgs/commit/0a2a243a44479584a1f516657a9e75b2e460d87c) | `` php81Extensions.ast: 1.1.0 -> 1.1.1 ``                                                     |
| [`ea4836f6`](https://github.com/NixOS/nixpkgs/commit/ea4836f69ae2b8ba1b1980aa7f9584e9f30a234b) | `` php81Extensions.apcu: 5.1.22 -> 5.1.23 ``                                                  |
| [`4c883d3f`](https://github.com/NixOS/nixpkgs/commit/4c883d3fcbbeef9108255d3062a8e496bf1c1108) | `` downonspot: unstable-2021-10-13 -> unstable-2023-11-26 ``                                  |
| [`a9557448`](https://github.com/NixOS/nixpkgs/commit/a95574483d88f635e879c6e266d559bca90b21d4) | `` sublime4: 4152 → 4169 ``                                                                   |
| [`8200cf15`](https://github.com/NixOS/nixpkgs/commit/8200cf15deda4d7348f8ab3fca9068bec83fb30f) | `` sublime4-dev: 4155 → 4168 ``                                                               |
| [`42761d63`](https://github.com/NixOS/nixpkgs/commit/42761d63ddd59f8871393448d5af6bfeeb0866b2) | `` python311Packages.imap-tools: 1.4.0 -> 1.5.0 ``                                            |
| [`544a1d37`](https://github.com/NixOS/nixpkgs/commit/544a1d375b47de09d6610c2059588032a9d8c192) | `` lib.attrsets.attrByPath: Don't allocate one extra list per lookup recursion ``             |
| [`7e07b3ec`](https://github.com/NixOS/nixpkgs/commit/7e07b3ecd55ac85675c26d9b09fab9996c410681) | `` lib.attrsets.hasAttrByPath: Don't allocate one extra list per lookup recursion ``          |
| [`cc390604`](https://github.com/NixOS/nixpkgs/commit/cc390604e6853561a6af0588e2fcbf68f03509a7) | `` cyme: add passthru.tests.version ``                                                        |
| [`f22c33db`](https://github.com/NixOS/nixpkgs/commit/f22c33dbfee86f96ded1329cc3ce11fa76f31545) | `` rclone: 1.64.2 -> 1.65.0 ``                                                                |
| [`d9b85241`](https://github.com/NixOS/nixpkgs/commit/d9b85241029e1d1f278b1181ce48d6add9dd0ead) | `` python3Packages.yamlpath: mark as broken (#270193) ``                                      |
| [`c1e9dde1`](https://github.com/NixOS/nixpkgs/commit/c1e9dde1f69da347ad369bdb4cebda5c4d5e14d7) | `` mirage-im: drop ``                                                                         |
| [`980243d9`](https://github.com/NixOS/nixpkgs/commit/980243d9e3b499d0e3eab54415ae9cc2396ef889) | `` openvi: 7.4.26 -> 7.4.27 ``                                                                |
| [`f31fc1b4`](https://github.com/NixOS/nixpkgs/commit/f31fc1b4a549ece4b7300d3b2cf458dc49e7c35e) | `` diebahn: 1.5.0 -> 2.1.0 ``                                                                 |
| [`3d2902dd`](https://github.com/NixOS/nixpkgs/commit/3d2902dd2e41dfa518c3e05fdbbb34b8d8be5d9d) | `` python311Packages.img2pdf: 0.5.0 -> 0.5.1 ``                                               |
| [`96052770`](https://github.com/NixOS/nixpkgs/commit/960527707b57520640d2fc694750be674e69c070) | `` nixos/mediawiki: don't clear default installed extensions ``                               |
| [`501680a6`](https://github.com/NixOS/nixpkgs/commit/501680a656e23465a379ad0732a0aec0d434db5c) | `` nixos/telegraf: include procps if procstat input is configured ``                          |
| [`30a8d37e`](https://github.com/NixOS/nixpkgs/commit/30a8d37e7a407d231b7760cae9b86cc06b731cea) | `` oh-my-zsh: add back to all-packages ``                                                     |
| [`8ae9c864`](https://github.com/NixOS/nixpkgs/commit/8ae9c8640cec51fcfa76b07f8cce2280716b72ce) | `` nixos/mediawiki: don't assume language of main page ``                                     |
| [`f68be841`](https://github.com/NixOS/nixpkgs/commit/f68be841c978199d710aa0e10d68efa5818027e4) | `` nixos/mediawiki: use fastcgi.conf file which contains extra parameter ``                   |
| [`54f913f8`](https://github.com/NixOS/nixpkgs/commit/54f913f862861c099f56678cec3fdc0e080b4ead) | `` igv: Fix missing wrapGAppsHook causing causing GLib-GIO-ERROR ``                           |
| [`f9bc6431`](https://github.com/NixOS/nixpkgs/commit/f9bc64313735c458a33f6c4b975adccb119ab3fe) | `` yabai: fix x86_64 build ``                                                                 |
| [`0c153f56`](https://github.com/NixOS/nixpkgs/commit/0c153f5611391f2f2858cc1c25cc89cbd70ef788) | `` mods: 0.2.0 -> 1.1.0 ``                                                                    |
| [`d2779b11`](https://github.com/NixOS/nixpkgs/commit/d2779b1194c012e249deac858ee79033266b820a) | `` checkSSLCert: 2.76.0 -> 2.77.0 ``                                                          |
| [`2459917e`](https://github.com/NixOS/nixpkgs/commit/2459917e66c70c80e16c315d62b3533c9239a2fa) | `` xearth: improve meta.license ``                                                            |
| [`17ee3bcc`](https://github.com/NixOS/nixpkgs/commit/17ee3bcc82adbe5666c42591f73eef41c4bd00f5) | `` t1utils: improve meta.license ``                                                           |
| [`55b73783`](https://github.com/NixOS/nixpkgs/commit/55b737831baa6080203ec490a8bfe5f9df420ae0) | `` zfsUnstable: 2.2.1-unstable-2023-10-21 -> 2.2.1 ``                                         |
| [`365cc965`](https://github.com/NixOS/nixpkgs/commit/365cc96597f674e9c1c70eb08fc84f0d2f9b25b3) | `` zfs: 2.2.0 -> 2.2.1 ``                                                                     |
| [`8f7dd88e`](https://github.com/NixOS/nixpkgs/commit/8f7dd88eebb230680d2af0d90c3ba837bc111159) | `` inkscape: 1.3 → 1.3.1 ``                                                                   |
| [`6e50bea2`](https://github.com/NixOS/nixpkgs/commit/6e50bea2089ce78d5de876ec5383eb99bda28aa0) | `` lib2geom: pick patch from Inkscape 1.3.1 ``                                                |
| [`e54e9ca4`](https://github.com/NixOS/nixpkgs/commit/e54e9ca4640669c4a637ed5cbad547a42f654160) | `` forgejo: 1.20.5-1 -> 1.21.1-0 ``                                                           |
| [`f468e0d1`](https://github.com/NixOS/nixpkgs/commit/f468e0d11180bdde888a7a16f9c043ec33dd284e) | `` nixos/mediawiki: quote shell flags passed to installer ``                                  |
| [`0bd8759d`](https://github.com/NixOS/nixpkgs/commit/0bd8759d1c962881f8e484d45cc71cda02b08b80) | `` nixos/mediawiki: drop sqlite variant ``                                                    |
| [`e580ab8c`](https://github.com/NixOS/nixpkgs/commit/e580ab8c3e35b304e78e160e998555378dc71b80) | `` nixos/mediawiki: update url option defaultText ``                                          |
| [`0ac7d194`](https://github.com/NixOS/nixpkgs/commit/0ac7d19428fb716d99c6511c58c18cfa1b975a34) | `` v2ray-domain-list-community: 20231121082246 -> 20231122065640 ``                           |
| [`f8f71bb9`](https://github.com/NixOS/nixpkgs/commit/f8f71bb978e75c49782fc19d0cb4009f670203dd) | `` Revert "swayfx: wrap like sway" ``                                                         |
| [`a1a4f9bb`](https://github.com/NixOS/nixpkgs/commit/a1a4f9bbaa8ea0f362095b50f1002a196f0f0e69) | `` python311Packages.edk2-pytool-library: 0.19.5 -> 0.19.6 ``                                 |
| [`fe5f6ab6`](https://github.com/NixOS/nixpkgs/commit/fe5f6ab623ef8ae59fa0d5d6c504048f5427d151) | `` stargazer: Add nixosTests.stargazer to passthru.tests ``                                   |
| [`fcbd3357`](https://github.com/NixOS/nixpkgs/commit/fcbd335763a98bfff039a691c20992827217ed18) | `` python311Packages.aiolifx-themes: remoive stale postPatch section ``                       |
| [`10b84133`](https://github.com/NixOS/nixpkgs/commit/10b84133e7950fec654285d165cffab4db50edd9) | `` python311Packages.aiolifx-themes: 0.4.9 -> 0.4.10 ``                                       |
| [`76da92d0`](https://github.com/NixOS/nixpkgs/commit/76da92d0666ff2468585bc99225a0b70e00b91df) | `` python311Packages.nextdns: 2.0.1 -> 2.1.0 ``                                               |
| [`bc5c75e9`](https://github.com/NixOS/nixpkgs/commit/bc5c75e9ee5a2ec0437159a4e11861fe31436931) | `` linuxPackages.systemtap: fix cross-build by depending on host Python ``                    |
| [`31fa2e5f`](https://github.com/NixOS/nixpkgs/commit/31fa2e5f9de265b32ce5ae48ccebdb4f9ccdb39f) | `` python311Packages.tcxreader: modernize ``                                                  |
| [`67e372dd`](https://github.com/NixOS/nixpkgs/commit/67e372ddd4fd522799d31711356fe65bbb2ae48d) | `` streamlink: 6.3.1 -> 6.4.1 ``                                                              |
| [`effbef4d`](https://github.com/NixOS/nixpkgs/commit/effbef4d5c0901be88f2d049ffeb7a438f02b1e5) | ``  python311Packages.python-hosts: refactor ``                                               |
| [`3e08ea28`](https://github.com/NixOS/nixpkgs/commit/3e08ea2896699d7b5db9e67bc9b5f17b582b2783) | `` fq: 0.8.0 -> 0.9.0 ``                                                                      |
| [`eab212e4`](https://github.com/NixOS/nixpkgs/commit/eab212e43a5ee57ce264fb38094bd53a8d333956) | `` gphotos-sync: move setuptools-scm to correct input (#244202) ``                            |
| [`fcaba88b`](https://github.com/NixOS/nixpkgs/commit/fcaba88b2b1cfaf42ce59633898c014d6ede710b) | `` python311Packages.python-hosts: add changelog to meta ``                                   |
| [`1afdfc52`](https://github.com/NixOS/nixpkgs/commit/1afdfc52597d5f1f7e167dab27d02912fab27e1e) | `` waydroid: remove `with lib;` ``                                                            |
| [`ac6c69dc`](https://github.com/NixOS/nixpkgs/commit/ac6c69dc733fef57030e4067f139fa4f0531685f) | `` python3Packages.pyclip: remove `with lib;` ``                                              |
| [`0d8ce512`](https://github.com/NixOS/nixpkgs/commit/0d8ce512f00eed8895556435d8318b2ca9b14618) | `` python3Packages.gbinder-python: remove `with lib;` ``                                      |
| [`d698a8be`](https://github.com/NixOS/nixpkgs/commit/d698a8be6828700ba7e8f198bc33f01331c754f1) | `` libglibutil: remove `with lib;` ``                                                         |
| [`d2fc0cba`](https://github.com/NixOS/nixpkgs/commit/d2fc0cbaa40804366e69cd8da5527f66f67c373e) | `` libgbinder: remove `with lib;` ``                                                          |
| [`be6ac65b`](https://github.com/NixOS/nixpkgs/commit/be6ac65b52d85056a69c548d52e70b2b60a038cd) | `` nixos/waydroid: remove `with lib;` and friends ``                                          |
| [`693b4d90`](https://github.com/NixOS/nixpkgs/commit/693b4d904a1e98daaa9df3a5734f0a9e891b0345) | `` python311Packages.warcio: disable failing test ``                                          |
| [`841819b8`](https://github.com/NixOS/nixpkgs/commit/841819b8db2a7ffb45cd81484cb312b17ee67534) | `` python311Packages.warcio: refactor ``                                                      |
| [`7e8ae922`](https://github.com/NixOS/nixpkgs/commit/7e8ae9222a96a248d75f19e95c84c1e7b2d0669d) | `` python311Packages.warcio: add format ``                                                    |
| [`14c62b15`](https://github.com/NixOS/nixpkgs/commit/14c62b156ad73cd4c5fefe36287e06a587b1ffa3) | `` lib2geom: skip failing test on musl (#266553) ``                                           |
| [`1224c9fe`](https://github.com/NixOS/nixpkgs/commit/1224c9fe3170e179a9f7391d488e0ce1ffb3a98d) | `` python311Packages.warcio: add changelog to meta ``                                         |
| [`ec84f77e`](https://github.com/NixOS/nixpkgs/commit/ec84f77e062c1daa1f8eb109d5fff753e3e1e3a5) | `` certinfo: init at 1.0.21 ``                                                                |
| [`b48c37f3`](https://github.com/NixOS/nixpkgs/commit/b48c37f3e1ba72ce20b69f569b514494ea7cc7c2) | `` certinfo: use vendorHash to fix evaluation ``                                              |
| [`1b38685b`](https://github.com/NixOS/nixpkgs/commit/1b38685b49448b7636662039f15b3dc06a185209) | `` acc: init at 1.60 ``                                                                       |
| [`089df4ec`](https://github.com/NixOS/nixpkgs/commit/089df4ec038a411893b68fafae358d8577f6e2cc) | `` Fix issues raised at review ``                                                             |
| [`95b24a5d`](https://github.com/NixOS/nixpkgs/commit/95b24a5d243e4b1bd78dac75cb8e358b6ac777af) | `` Add myself to the maintainer list ``                                                       |
| [`e4dcbbd2`](https://github.com/NixOS/nixpkgs/commit/e4dcbbd247699caeb616b75ea708e24248d64911) | `` git-cache: init at 2018-06-18 ``                                                           |
| [`1875a29c`](https://github.com/NixOS/nixpkgs/commit/1875a29c74f3ece7b955a266a02401701371eca5) | `` krusader: 2.7.2 -> 2.8.0 ``                                                                |
| [`a8f393e6`](https://github.com/NixOS/nixpkgs/commit/a8f393e6c1c80dc979e9209eea9eb4b75833df70) | `` cataclysmDDA: update mods: mirror github user ``                                           |
| [`474aae60`](https://github.com/NixOS/nixpkgs/commit/474aae6071deb7843afca6c745aff4f19a1e747c) | `` ockam: 0.90.0 -> 0.105.0 ``                                                                |
| [`d5a2e6b0`](https://github.com/NixOS/nixpkgs/commit/d5a2e6b04bfa8d9fc25e1fc381bee83d62821983) | `` labwc: 0.6.5 -> 0.6.6 ``                                                                   |
| [`aec8fdf3`](https://github.com/NixOS/nixpkgs/commit/aec8fdf31dbb53b43d20e202391435cc78cbb792) | `` mapscii: init at 0.3.1 ``                                                                  |
| [`ad700a86`](https://github.com/NixOS/nixpkgs/commit/ad700a86901402d3968652a1554e8afd40875e3f) | `` maintainers: add kinzoku-dev ``                                                            |
| [`7c53065f`](https://github.com/NixOS/nixpkgs/commit/7c53065f08dcab2230cd26f47fe686309bc2bd72) | `` khard: 0.18.0 -> 0.19.0 ``                                                                 |
| [`64002ec9`](https://github.com/NixOS/nixpkgs/commit/64002ec9b094c6e20a0db193ee12e97c16f8802e) | `` nixos/torrentstream: init ``                                                               |
| [`a18dfbf5`](https://github.com/NixOS/nixpkgs/commit/a18dfbf5e30b3a579d5cbe21d27438f5f728bed6) | `` torrentstream: init at 1.0.1.6 ``                                                          |
| [`82d499ac`](https://github.com/NixOS/nixpkgs/commit/82d499ac9e5d592d4af11168d4d94eab298cc5ab) | `` clipcat: 0.6.2 -> 0.7.0 ``                                                                 |
| [`a57efa18`](https://github.com/NixOS/nixpkgs/commit/a57efa182f0dcc99f03c2891dd3748429f3a0e36) | `` snappymail: 2.29.2 -> 2.29.4 ``                                                            |
| [`3fa09984`](https://github.com/NixOS/nixpkgs/commit/3fa09984847e32d5adbd1e3331ffe1de56732f77) | `` onedriver: 0.13.0-2 -> 0.14.1 ``                                                           |
| [`4f78f5b2`](https://github.com/NixOS/nixpkgs/commit/4f78f5b27782b43ebe23ae1ea9ab17666f2d5a30) | `` mendeley: 2.80.1 -> 2.105.0, add version to drv name ``                                    |
| [`2b891a2c`](https://github.com/NixOS/nixpkgs/commit/2b891a2cb6b5689b0b36cd75cc7387497d933f1e) | `` emulationstation-de: init at 2.2.1 ``                                                      |
| [`2ff208e8`](https://github.com/NixOS/nixpkgs/commit/2ff208e85b46c76330fbb7cb5a56553132a1245e) | `` maintainers: add ivarmedi ``                                                               |
| [`d59c9393`](https://github.com/NixOS/nixpkgs/commit/d59c93938b792cfb62f1d93ad6523afaa11dafb1) | `` python311Packages.bitstring: 4.1.2 -> 4.1.3 ``                                             |
| [`b00ec384`](https://github.com/NixOS/nixpkgs/commit/b00ec384d492d2ae9a09ec4c2c56f8f5d2ce4eee) | `` replace-secret: add mainProgram ``                                                         |
| [`a5ba4bf8`](https://github.com/NixOS/nixpkgs/commit/a5ba4bf8c7f46c463a5c98c8647f0cfd79718099) | `` ue4: remove ``                                                                             |
| [`688e3878`](https://github.com/NixOS/nixpkgs/commit/688e3878e580f4f30e32c1969ef3afc6ed279831) | `` iaito: fix desktop entry icon ``                                                           |
| [`51e20bb8`](https://github.com/NixOS/nixpkgs/commit/51e20bb809fbe921095d90fb29bce74ec17dc684) | `` bumblebee-status: init at 2.2.0 ``                                                         |
| [`297b2f61`](https://github.com/NixOS/nixpkgs/commit/297b2f617d7ea4d03cc1b9431c06e6d1e31371b6) | `` python311Packages.python-hosts: 1.0.4 -> 1.0.5 ``                                          |
| [`3b8d3c6c`](https://github.com/NixOS/nixpkgs/commit/3b8d3c6c6179453b53398d5ec4c1a3693fae38d0) | `` kamailio: add TLS support ``                                                               |
| [`231b889d`](https://github.com/NixOS/nixpkgs/commit/231b889d799e2350a52edef0ef23a10e1fc8bf16) | `` kamailio: make "modules" customiziable by overrideAttrs ``                                 |
| [`8110ae5f`](https://github.com/NixOS/nixpkgs/commit/8110ae5f411700bc186e768f01ec5103deebe181) | `` osquery: also apply `Use-locale.h-instead-of-removed-xlocale.h-header.patch` on aarch64 `` |
| [`9f3a21f0`](https://github.com/NixOS/nixpkgs/commit/9f3a21f0e9f2b23efce8af4a44ae968446ebcb91) | `` kamailio: make "modules" customiziable by overrideAttrs ``                                 |
| [`4ff48c9f`](https://github.com/NixOS/nixpkgs/commit/4ff48c9f84ce419a72629fda478077cdf9b73dc3) | `` super-slicer-beta: 2.5.59.2 -> 2.5.59.3 (#269969) ``                                       |
| [`fab9ae62`](https://github.com/NixOS/nixpkgs/commit/fab9ae621cc0ce07b2d79300dc78cae73767f319) | `` tbls: 1.71.0 -> 1.72.0 ``                                                                  |
| [`c9e65df9`](https://github.com/NixOS/nixpkgs/commit/c9e65df9df9de665981916fdbf101937dd0af1db) | `` osquery: add unreleased upstream patch for current Clang version ``                        |
| [`e921fd7f`](https://github.com/NixOS/nixpkgs/commit/e921fd7f997cafeba16a7315e20e59c4cad7b89c) | `` muffet: 2.9.2 -> 2.9.3 ``                                                                  |
| [`c973975a`](https://github.com/NixOS/nixpkgs/commit/c973975aa04bca80efb893937213d3145d20311f) | `` babashka: Remove superfluous removal of references ``                                      |
| [`56aedbd4`](https://github.com/NixOS/nixpkgs/commit/56aedbd477e78c9064d7c0558eeb820ab11c4ef8) | `` Move reference removal logic into build support ``                                         |
| [`7a834eeb`](https://github.com/NixOS/nixpkgs/commit/7a834eeb82a5e46247b25103651d68e385535998) | `` qgis-ltr: 3.28.12 -> 3.28.13 ``                                                            |
| [`a16cdc2e`](https://github.com/NixOS/nixpkgs/commit/a16cdc2e39eae17c1f8f9f772d59f6b9f19091b8) | `` qgis: 3.34.0 -> 3.34.1 ``                                                                  |
| [`50b6184a`](https://github.com/NixOS/nixpkgs/commit/50b6184a33783472bfefd28cfb5fe92062b52e5a) | `` python311Packages.ninebot-ble: init at 0.0.6 ``                                            |
| [`b9d0453d`](https://github.com/NixOS/nixpkgs/commit/b9d0453d1beb2b82871f603a95865fd9dd89bc3a) | `` python311Packages.miauth: init at 0.9.1 ``                                                 |
| [`854c8870`](https://github.com/NixOS/nixpkgs/commit/854c887047659cb696bb9e43f76b00b633cb3f8a) | `` python311Packages.aws-lambda-builders: 1.41.0 -> 1.42.0 ``                                 |
| [`d152e08a`](https://github.com/NixOS/nixpkgs/commit/d152e08a3ea42bea11234e6f6d29efd343da61e6) | `` python311Packages.awscrt: 0.19.12 -> 0.19.17 ``                                            |