### PR TITLE
chore(flake/hyprland): `99ca26d4` -> `80b9b21f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -322,11 +322,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1701023633,
-        "narHash": "sha256-lX/PsZrKEtdk/cUIET/UYhQKPJRkNq2hlbLH6VQSpWc=",
+        "lastModified": 1701528705,
+        "narHash": "sha256-SJENLaYS4hIuvQMgupKlclGZ5Mz40OvUc2Vu8vFBSow=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "99ca26d4eb84e0071264713902e5b287fcab392e",
+        "rev": "80b9b21f9f24b6e8db2fc6f7705cd124f436ffba",
         "type": "github"
       },
       "original": {
@@ -929,18 +929,18 @@
       "flake": false,
       "locked": {
         "host": "gitlab.freedesktop.org",
-        "lastModified": 1700734054,
-        "narHash": "sha256-SBu1y01WjCSrcCKvgfCDDckrZjU/OmCJT8Xc+hPow7E=",
+        "lastModified": 1701368958,
+        "narHash": "sha256-7kvyoA91etzVEl9mkA/EJfB6z/PltxX7Xc4gcr7/xlo=",
         "owner": "wlroots",
         "repo": "wlroots",
-        "rev": "2eb225236eb72f27beec921e9f37ddf58e874fba",
+        "rev": "5d639394f3e83b01596dcd166a44a9a1a2583350",
         "type": "gitlab"
       },
       "original": {
         "host": "gitlab.freedesktop.org",
         "owner": "wlroots",
         "repo": "wlroots",
-        "rev": "2eb225236eb72f27beec921e9f37ddf58e874fba",
+        "rev": "5d639394f3e83b01596dcd166a44a9a1a2583350",
         "type": "gitlab"
       }
     },


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                        |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
| [`80b9b21f`](https://github.com/hyprwm/Hyprland/commit/80b9b21f9f24b6e8db2fc6f7705cd124f436ffba) | `` opengl: fix nvidia read formats ``                                          |
| [`758cf90e`](https://github.com/hyprwm/Hyprland/commit/758cf90ea1066eea361a9d8c347e7fcf40f6636f) | `` workspacerules: Add workspace rule for master layout orientation (#3964) `` |
| [`6e8b9ef7`](https://github.com/hyprwm/Hyprland/commit/6e8b9ef7d8aa53247d5122b6641b9afa0df798df) | `` opengl: fix swapped rgb drm formats ``                                      |
| [`9c09f2a8`](https://github.com/hyprwm/Hyprland/commit/9c09f2a847a1372c73cf67dc9e7e9ebe309b142e) | `` screencopy: fix shm exports with 10-bit ``                                  |
| [`8440a302`](https://github.com/hyprwm/Hyprland/commit/8440a30231ea41a6b1dacc60a28837b265a6efec) | `` input: fix overzealous mouse capture on resize_on_border (#4010) ``         |
| [`ab40f240`](https://github.com/hyprwm/Hyprland/commit/ab40f240c3211412641fdf05b52bf0f1b033fa7d) | `` screencopy: use drmFormat instead of wlr funcs ``                           |
| [`b394c169`](https://github.com/hyprwm/Hyprland/commit/b394c1695c05cf3b2133a473aa459d4cd750911b) | `` [gha] Nix: update wlroots ``                                                |
| [`0a4c4da5`](https://github.com/hyprwm/Hyprland/commit/0a4c4da5f0dde3a24ef8c64aa65a9d21fe074370) | `` deps: update wlroots ``                                                     |
| [`b2f36231`](https://github.com/hyprwm/Hyprland/commit/b2f36231312427d65362521836484fddb6ff91f8) | `` events: add keyPress and mouseAxis ``                                       |
| [`5513eed6`](https://github.com/hyprwm/Hyprland/commit/5513eed64d46ef542a2dfaeb4a3229e1d195b02b) | `` managers: fix debug log using printf format (#4007) ``                      |
| [`29970228`](https://github.com/hyprwm/Hyprland/commit/29970228c5f71f417b0a3e1b4851d9430ed095dd) | `` nix: override libdrm to use newer version (#4003) ``                        |
| [`12ec549a`](https://github.com/hyprwm/Hyprland/commit/12ec549a183abd59779a294c2f5bca0e95e528c0) | `` screencopy: fix shm sharing if introspection required ``                    |
| [`9f2027be`](https://github.com/hyprwm/Hyprland/commit/9f2027be4bd888c5828412848bd73ba694ee2dbc) | `` opengl: don't make a mirror buffer on fakeFrame ``                          |
| [`b9937484`](https://github.com/hyprwm/Hyprland/commit/b9937484f4deefbc07c5fc3483d15885068e975d) | `` screencopy: fix broken shm copying ``                                       |
| [`776f9446`](https://github.com/hyprwm/Hyprland/commit/776f944619168e1812e7f8bee0258757fed987a4) | `` opengl: fix missed makeEGLCurrent ``                                        |
| [`1fc1e4e9`](https://github.com/hyprwm/Hyprland/commit/1fc1e4e9cbc2569eb4d3841f22020f35e9642f12) | `` monitor: remove comma from monitor description (#3996) ``                   |
| [`e1258707`](https://github.com/hyprwm/Hyprland/commit/e1258707adeb3061600c43a5445063c5e3c59037) | `` [gha] Nix: update wlroots ``                                                |
| [`d2c3b23a`](https://github.com/hyprwm/Hyprland/commit/d2c3b23ace745d3f79926c71d4cb3c481a394841) | `` deps: update wlroots ``                                                     |
| [`b80c72c7`](https://github.com/hyprwm/Hyprland/commit/b80c72c7ddbf79147d64759c8659eb5939d0327e) | `` groupbar: fix crash in renderGradientTo ``                                  |
| [`3caaa483`](https://github.com/hyprwm/Hyprland/commit/3caaa483d4bf8f18f62f8a8f03a0922ea8a4cb7e) | `` configmgr: fix parsing of touchdevice groups ``                             |
| [`e2f18f8c`](https://github.com/hyprwm/Hyprland/commit/e2f18f8c7f95e4094acb94c5a06dc6d75d7fc9c1) | `` groupbar: more safety around gradient textures ``                           |