### PR TITLE
chore(flake/unstable): `9e6f9c6d` -> `024e4447`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -930,11 +930,11 @@
     },
     "unstable": {
       "locked": {
-        "lastModified": 1701084168,
-        "narHash": "sha256-gNYhVjJyKIg5xTfA/ROmVr4mxwPbNWl0RUjZ7ey+3XE=",
+        "lastModified": 1701172651,
+        "narHash": "sha256-wP2F6NTa4Sh5tgfP2Ya0AOwt/6SvCAXylW0R6ASRS9w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9e6f9c6d8325d92c5a4e680d8b1ed2495d6f3942",
+        "rev": "024e4447a42868b4c8f3ac8b3e6a2da83c682de1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`024e4447`](https://github.com/NixOS/nixpkgs/commit/024e4447a42868b4c8f3ac8b3e6a2da83c682de1) | `` paraview: fix strlcat symbol provided by glibc 2.38 ``                       |
| [`8ae2bf1e`](https://github.com/NixOS/nixpkgs/commit/8ae2bf1e607cbdbb5cef93d9ebe8cbc55ff2bdd3) | `` dconf2nix: 0.0.12 -> 0.1.1 ``                                                |
| [`627dda7f`](https://github.com/NixOS/nixpkgs/commit/627dda7f87a1a6ec2a39be3ac11c009c3f759524) | `` tiledb: 2.8.3 -> 2.18.0 (#268876) ``                                         |
| [`c0eef128`](https://github.com/NixOS/nixpkgs/commit/c0eef128b335a8e0e6b60b2f9a5f96d387d43921) | `` zlib-ng: 2.1.4 -> 2.1.5 ``                                                   |
| [`9fef199b`](https://github.com/NixOS/nixpkgs/commit/9fef199b2a79e66fd8fcb7f4b9730e641492a586) | `` hivex: 1.3.21 → 1.3.23 ``                                                    |
| [`97e9d370`](https://github.com/NixOS/nixpkgs/commit/97e9d370d71f7ef267f527b06f4098d8e5b3eb86) | `` obuild: 0.1.10 → 0.1.11 ``                                                   |
| [`e274d5a6`](https://github.com/NixOS/nixpkgs/commit/e274d5a6c23e8e9fab5f24a1cc71d6994e74f4b2) | `` ripgrep: 14.0.1 -> 14.0.2 ``                                                 |
| [`4469e227`](https://github.com/NixOS/nixpkgs/commit/4469e22700c47792f93daa882786d36f9bf8bc2a) | `` gh: 2.39.1 -> 2.39.2 ``                                                      |
| [`3303ff54`](https://github.com/NixOS/nixpkgs/commit/3303ff548b21ccdadeab3f9a670775a969c72444) | `` buildMozillaMach: prune patches ``                                           |
| [`a72f24ef`](https://github.com/NixOS/nixpkgs/commit/a72f24ef3bf6538b1dbb5d024e7b0f9517dddb72) | `` buildMozillaMach: replace dbus workaround with upstream patch ``             |
| [`f69da370`](https://github.com/NixOS/nixpkgs/commit/f69da3709818d1397bed93a340cfb42d550e25ad) | `` cpython: restore passthru.tests ``                                           |
| [`1f8c604e`](https://github.com/NixOS/nixpkgs/commit/1f8c604e4270651507cfdfe786741e812ae63267) | `` ArchiSteamFarm: 5.4.12.5 -> 5.4.13.4 ``                                      |
| [`49762946`](https://github.com/NixOS/nixpkgs/commit/4976294642aa001af26996bc125e4f594d1a1c62) | `` python310Packages.bentoml: 1.1.9 -> 1.1.10 ``                                |
| [`f4324ebf`](https://github.com/NixOS/nixpkgs/commit/f4324ebf2b47c71ef7353858d9870b6613691e12) | `` gallery-dl: 1.26.2 -> 1.26.3 ``                                              |
| [`348fb6cb`](https://github.com/NixOS/nixpkgs/commit/348fb6cba5744813850944e376e11d489a08ec41) | `` python311Packages.moto: 4.2.6 -> 4.2.10 ``                                   |
| [`ae18f5de`](https://github.com/NixOS/nixpkgs/commit/ae18f5de96e1424846f5c3fb3f50da69d2c64030) | `` python311Packages.py-partialql-parser: 0.4.0 -> 0.4.2 ``                     |
| [`51124177`](https://github.com/NixOS/nixpkgs/commit/5112417739f9b198047bedc352cebb41aa339e1d) | `` gum: 0.11.0 -> 0.12.0 ``                                                     |
| [`e061cb0d`](https://github.com/NixOS/nixpkgs/commit/e061cb0d71fe858f1c04d9c64ce4db53bed94084) | `` python310Packages.awswrangler: 3.4.0 -> 3.4.2 ``                             |
| [`01238b54`](https://github.com/NixOS/nixpkgs/commit/01238b54079c2ac451bb402be6d59072cfaa2d3c) | `` felix-fm: 2.10.1 -> 2.10.2 ``                                                |
| [`9ececdec`](https://github.com/NixOS/nixpkgs/commit/9ececdeceb0f42fb072b2b8eaef628b35652bd16) | `` difftastic: 0.53.0 -> 0.53.1 ``                                              |
| [`da55691a`](https://github.com/NixOS/nixpkgs/commit/da55691ab7e0189da1eeb3184beb679aaac1e40a) | `` moonlander: drop ``                                                          |
| [`ec383f53`](https://github.com/NixOS/nixpkgs/commit/ec383f5377c76a1f3cac0edceb3ee0a7bda775df) | `` cargo-dist: 0.4.3 -> 0.5.0 ``                                                |
| [`d3b6b9e0`](https://github.com/NixOS/nixpkgs/commit/d3b6b9e08b649bc2de6d3caf15c672da89870927) | `` typst-preview: 0.9.1 -> 0.9.2 ``                                             |
| [`34d92e99`](https://github.com/NixOS/nixpkgs/commit/34d92e99fb4a0aba218cee666246ce646f915f3b) | `` nix-ld: mark as broken on 32 bit targets (#269919) ``                        |
| [`315df778`](https://github.com/NixOS/nixpkgs/commit/315df7787883c276f102ee5101f101c1454b1444) | `` python310Packages.appthreat-vulnerability-db: 5.5.3 -> 5.5.4 ``              |
| [`9f6844e1`](https://github.com/NixOS/nixpkgs/commit/9f6844e16e62f136af050a1acd5e05ddcc62bcf2) | `` python310Packages.anytree: 2.10.0 -> 2.12.0 ``                               |
| [`5257a52c`](https://github.com/NixOS/nixpkgs/commit/5257a52c8bd67827a6b3eec6574a50159068f7e6) | `` nixos/tests/systemd-timesyncd: tmpfiles.rules -> tmpfiles.settings ``        |
| [`c1508779`](https://github.com/NixOS/nixpkgs/commit/c150877925aacf41aa51d28bc82693ad2da1b541) | `` home-assistant: prune test configuration ``                                  |
| [`742ea5dc`](https://github.com/NixOS/nixpkgs/commit/742ea5dcc81eed1c24ef1c50cbebab75376562a2) | `` home-assistant: propagate pyotp and pyqrcode ``                              |
| [`cbbbee5c`](https://github.com/NixOS/nixpkgs/commit/cbbbee5ce3f3deb416c7a495f627233eb8235a1c) | `` home-assistant: migrate to pythonRelaxDepsHook ``                            |
| [`3e81aac9`](https://github.com/NixOS/nixpkgs/commit/3e81aac9bbe9553b49c97c400d5c12920f5e8463) | `` python311Packages.construct: 2.10.68 -> 2.10.69 ``                           |
| [`6e1beb3b`](https://github.com/NixOS/nixpkgs/commit/6e1beb3b157f0a8c5de62bec8085164db3030fee) | `` python311Packages.construct: remove unused input ``                          |
| [`9263b507`](https://github.com/NixOS/nixpkgs/commit/9263b5077ccff2bbd141d9e9feeb277f974599d0) | `` python311Packages.construct: add optional-dependencies ``                    |
| [`5620bda6`](https://github.com/NixOS/nixpkgs/commit/5620bda6954f41e268253224a9495783210decaf) | `` python311Packages.construct: refactor ``                                     |
| [`b7cedafe`](https://github.com/NixOS/nixpkgs/commit/b7cedafeb610c499e06550d7da9037d669d20d57) | `` python311Packages.construct: add pythonImportsCheck ``                       |
| [`508645f1`](https://github.com/NixOS/nixpkgs/commit/508645f160f8ce271a132ec42f5764f2a07253b7) | `` python311Packages.construct: add changelog to meta ``                        |
| [`83263612`](https://github.com/NixOS/nixpkgs/commit/83263612a9f10213d50fb248f75d14af7a3a1589) | `` python311Packages.pyregion: 2.1.1 -> 2.2.0; fix darwin build ``              |
| [`a1e020ca`](https://github.com/NixOS/nixpkgs/commit/a1e020cac85ab1c8957da84d065949bf474413c5) | `` diebahn: add meta.mainProgram ``                                             |
| [`b068064f`](https://github.com/NixOS/nixpkgs/commit/b068064ff1a80d25305315c6b09e9a150e16af40) | `` python310Packages.aiortm: 0.8.5 -> 0.8.6 ``                                  |
| [`5075c3f6`](https://github.com/NixOS/nixpkgs/commit/5075c3f6ec5c40d10ca3c4b5e2ca0353d1ee7fd4) | `` slack: 4.34.121 -> 4.35.126 ``                                               |
| [`4b1b63da`](https://github.com/NixOS/nixpkgs/commit/4b1b63da3208f1a1805e6e7c4497444b5a5db9e0) | `` python310Packages.aioopenexchangerates: 0.4.4 -> 0.4.5 ``                    |
| [`4fc20754`](https://github.com/NixOS/nixpkgs/commit/4fc20754d8798adfb6570a0b33af022b7d2360da) | `` fastnetmon-advanced: 2.0.353 -> 2.0.356 (#268122) ``                         |
| [`c0acebea`](https://github.com/NixOS/nixpkgs/commit/c0acebea252acca2f5d1b7c0db36154f1422c3c9) | `` tox-prpl: drop ``                                                            |
| [`fa07281c`](https://github.com/NixOS/nixpkgs/commit/fa07281c0b78c42ffc396a505a8dcfbc7fefcc5e) | `` newsraft: 0.21 -> 0.22 ``                                                    |
| [`43326297`](https://github.com/NixOS/nixpkgs/commit/43326297e35e601c591928174c233a0a1c99bb4e) | `` python311Packages.python-lsp-ruff: 1.6.0 -> 2.0.0 ``                         |
| [`47536e71`](https://github.com/NixOS/nixpkgs/commit/47536e7115505114ea7e47eb1e4e1e922ce37cfe) | `` python310Packages.agate-excel: 0.3.0 -> 0.4.1 ``                             |
| [`a2502f79`](https://github.com/NixOS/nixpkgs/commit/a2502f79d1fefc3019c98961d47baca4a94aa49d) | `` buildMozillaMach: update no-buildconfig patch for 121+ ``                    |
| [`876ab429`](https://github.com/NixOS/nixpkgs/commit/876ab4292ff792e21e7634ae8ac9cd69d56bd5b4) | `` firefox-devedition-unwrapped: 120.0b9 -> 121.0b3 ``                          |
| [`d66796d4`](https://github.com/NixOS/nixpkgs/commit/d66796d44e93efe51cfd4cb987927a238f435155) | `` firefox-beta-unwrapped: 120.0b9 -> 121.0b3 ``                                |
| [`827579aa`](https://github.com/NixOS/nixpkgs/commit/827579aa46eecd5eca03dfaf98d7f965634ef070) | `` nss_latest: 3.94 -> 3.95 ``                                                  |
| [`301cb47e`](https://github.com/NixOS/nixpkgs/commit/301cb47e718ca8099407def782f1d805d3da42fb) | `` tuxmux: fix meta.license ``                                                  |
| [`0a957d97`](https://github.com/NixOS/nixpkgs/commit/0a957d97ccbb758f9cb8eb6afd46b9b337d12bc5) | `` ktfmt: fix meta.license ``                                                   |
| [`c14250de`](https://github.com/NixOS/nixpkgs/commit/c14250deba1e1e58182bb599fb5e198586b9084f) | `` aws-sam-cli: 1.90.0 -> 1.103.0 ``                                            |
| [`be467387`](https://github.com/NixOS/nixpkgs/commit/be46738736289a0572768f20fb76d7d6677bada7) | `` awscli2: fix meta.homepage ``                                                |
| [`0f983f2b`](https://github.com/NixOS/nixpkgs/commit/0f983f2bdfe9286de21feb4de76b6f6960accdc9) | `` awscli2: 2.13.33 -> 2.13.38 ``                                               |
| [`98245cb2`](https://github.com/NixOS/nixpkgs/commit/98245cb2f16ad7df0d252200900fff66d12b3063) | `` sonic-server: fix build with clang 16 ``                                     |
| [`da3f1ab2`](https://github.com/NixOS/nixpkgs/commit/da3f1ab2d5f04055897deb2840655e2d418fbc89) | `` python310Packages.accuweather: 2.1.0 -> 2.1.1 ``                             |
| [`a403a118`](https://github.com/NixOS/nixpkgs/commit/a403a118d1d509abfb916f1283738d4ab1f5da48) | `` fahclient: 7.6.21 -> 8.1.18 (#246832) ``                                     |
| [`b662f3b6`](https://github.com/NixOS/nixpkgs/commit/b662f3b6a711aecd3ef0fd99c1e879123aa7ebf1) | `` kontact: add all the plugins to the wrapper ``                               |
| [`9e9485e1`](https://github.com/NixOS/nixpkgs/commit/9e9485e1aba82058c7ad7e8924739a4efb0d8383) | `` libretro: fix meta.license attribute ``                                      |
| [`8fd9119a`](https://github.com/NixOS/nixpkgs/commit/8fd9119a3dc0f33b57a18d28dafc8fae08e93bcb) | `` purescript: 0.15.12 -> 0.15.13 ``                                            |
| [`67c354b0`](https://github.com/NixOS/nixpkgs/commit/67c354b0814624b84665c50d5dbf8fb352e27343) | `` nixos-rebuild: remove manpage hint on feature that is not merged ``          |
| [`22c3c8ce`](https://github.com/NixOS/nixpkgs/commit/22c3c8ce2455af5de167579b03874aac55c7379a) | `` vscode-extensions.mgt19937.typst-preview: 0.9.1 -> 0.9.2 ``                  |
| [`90cd52a5`](https://github.com/NixOS/nixpkgs/commit/90cd52a5594d641048cd3c71bb1bbc8ea0affa6b) | `` mpv-unwrapped: fix shebangs for cross-compiled builds ``                     |
| [`c7acc727`](https://github.com/NixOS/nixpkgs/commit/c7acc727d49564ffb32fa3439b7ab02fef0cbd69) | `` checkov: 3.1.14 -> 3.1.15 ``                                                 |
| [`dffaca7e`](https://github.com/NixOS/nixpkgs/commit/dffaca7e7891df222281018a937388ad9085a6f2) | `` php81Packages.php-cs-fixer: 3.37.1 -> 3.40.0 ``                              |
| [`6e85eedc`](https://github.com/NixOS/nixpkgs/commit/6e85eedc651d3654ab587d6046acb89691ecadf8) | `` python311Packages.vncdo: adjust inputs ``                                    |
| [`aeb5204b`](https://github.com/NixOS/nixpkgs/commit/aeb5204b5c66ed60bdfda0fe01669bd1bebaa87a) | `` fractal: enable gstreamer-good support ``                                    |
| [`1cd67291`](https://github.com/NixOS/nixpkgs/commit/1cd6729155160e547e48e45b3302f9223b28c4e1) | `` python311Packages.wordcloud: disable failing tests ``                        |
| [`eeb6a017`](https://github.com/NixOS/nixpkgs/commit/eeb6a017a9e61a153fa2c6ba4b928bc0dea4f894) | `` python311Packages.watermark: add optional-dependencies ``                    |
| [`98a0153c`](https://github.com/NixOS/nixpkgs/commit/98a0153ced0f944cf0fd2d6b3819383935af4878) | `` nix-output-monitor: 2.0.0.7 -> 2.1.1 ``                                      |
| [`545c49e7`](https://github.com/NixOS/nixpkgs/commit/545c49e7d0a00ae95215cd3144c52bb0ba8a8e68) | `` python311Packages.allure-pytest: remove tests parts ``                       |
| [`79d09979`](https://github.com/NixOS/nixpkgs/commit/79d09979cf2bfad6cf3d49094e07e30cfb2d6b36) | `` nixVersions.unstable: fix patch name related to rapidcheck shared library `` |
| [`ee3810a1`](https://github.com/NixOS/nixpkgs/commit/ee3810a1c98a5118998287f0dea4be410a079f05) | `` frankenphp: init at 1.0.0-rc3 ``                                             |
| [`3a5125ec`](https://github.com/NixOS/nixpkgs/commit/3a5125ec88c5be270a424d4d9b8d5e47535cd363) | `` trunk-ng: 0.17.10 -> 0.17.11 ``                                              |
| [`8d162ec7`](https://github.com/NixOS/nixpkgs/commit/8d162ec7b8c87525af611f163e424ea9b09f7fa0) | `` lib.customisation: Don't allocate intermediate list for missing args ``      |
| [`7903613b`](https://github.com/NixOS/nixpkgs/commit/7903613b0bcdd3e7182f672b98aed9d1964fa9c2) | `` lib.customisation: Inherit lib/builtins into scope ``                        |
| [`b14f9cef`](https://github.com/NixOS/nixpkgs/commit/b14f9cef0c0822115eca5e3c086b1b05b2b6804b) | `` glamoroustoolkit: 1.0.2 -> 1.0.6 ``                                          |