### PR TITLE
chore(flake/master): `3f83e9f1` -> `54c8a156`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -455,11 +455,11 @@
     },
     "master": {
       "locked": {
-        "lastModified": 1701219481,
-        "narHash": "sha256-p+d+K4PMi/A5eCPmcPQBVJPVyRUY/AA55QhCHgRO7M0=",
+        "lastModified": 1701392950,
+        "narHash": "sha256-jhmBuNeLq5p3VqZj+JC/c1+zHRnKTeMDIUwjlpctlso=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3f83e9f16dcb04116e1564b1928e12252e0c1c8e",
+        "rev": "54c8a156500d5c9b44294e1dab9bd930073721fb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`2123ab85`](https://github.com/NixOS/nixpkgs/commit/2123ab85ed9a371bc9a088f3bfb45cd65ff0285f) | `` ledfx: add python-{mbedtls,osc} dependency ``                             |
| [`3c99c6c9`](https://github.com/NixOS/nixpkgs/commit/3c99c6c99343afc4b7c30a441fd1a94324e9d7ac) | `` python3Packages.python-mbedtls: init at 2.8.0 ``                          |
| [`73c42a12`](https://github.com/NixOS/nixpkgs/commit/73c42a12538c2cd57ad99bfdb832487f8b8750ba) | `` hybridreverb2: 2.1.2 -> 2.1.2-unstable-2021-12-19 ``                      |
| [`a93d0cfe`](https://github.com/NixOS/nixpkgs/commit/a93d0cfecbfc40b454d23ef7ff5865f7e473219a) | `` python310Packages.django-rq: 2.8.1 -> 2.9.0 ``                            |
| [`8d0f0ca3`](https://github.com/NixOS/nixpkgs/commit/8d0f0ca32319439fe9940b1de917dbbdcb8e6f3d) | `` tipidee: 0.0.1.0 -> 0.0.2.0 ``                                            |
| [`1cdbb538`](https://github.com/NixOS/nixpkgs/commit/1cdbb538811e928da27b6f0a5f70eb96c92653a9) | `` s6-networking: 2.6.0.0 -> 2.7.0.0 ``                                      |
| [`5784fa51`](https://github.com/NixOS/nixpkgs/commit/5784fa51f252230dfd2c94272f440545d5a52b3c) | `` s6-dns: 2.3.6.0 -> 2.3.7.0 ``                                             |
| [`44c1e78c`](https://github.com/NixOS/nixpkgs/commit/44c1e78ccbdf00e7a19fe21b2985e826e093eb79) | `` s6: 2.12.0.0 -> 2.12.0.2 ``                                               |
| [`f78ad50e`](https://github.com/NixOS/nixpkgs/commit/f78ad50e0b03d79a94504a3e0413360dcdb8bc06) | `` skalibs: 2.14.0.0 -> 2.14.0.1 ``                                          |
| [`60508802`](https://github.com/NixOS/nixpkgs/commit/60508802527176bd2489b25c4fd963bc36db71e3) | `` gdal: 3.7.3 -> 3.8.1 (#271240) ``                                         |
| [`a233133b`](https://github.com/NixOS/nixpkgs/commit/a233133b1a0813fe2021afdf5c9fbfa21d02f159) | `` conan: add xcrun to nativeCheckInputs on darwin ``                        |
| [`073a55f2`](https://github.com/NixOS/nixpkgs/commit/073a55f214ad69521307bb8dd29ca354b5b72c64) | `` nodePackages.postcss-cli: improve meta.license ``                         |
| [`5f4ee9b5`](https://github.com/NixOS/nixpkgs/commit/5f4ee9b5feafa94430a1e2d4520fc73caf187200) | `` pdf2odt: 20170207 -> 20220827 ``                                          |
| [`437ced83`](https://github.com/NixOS/nixpkgs/commit/437ced8331f8db91a30decf563d02b354f292e7b) | `` wp-cli: allow overriding entire config file ``                            |
| [`b7e03b1c`](https://github.com/NixOS/nixpkgs/commit/b7e03b1c50235179fc64fec1c82089d922b69737) | `` firefox-devedition-unwrapped: 121.0b4 -> 121.0b5 ``                       |
| [`0ec4c74c`](https://github.com/NixOS/nixpkgs/commit/0ec4c74c352268d05396430910475210a755dc94) | `` firefox-beta-unwrapped: 121.0b4 -> 121.0b5 ``                             |
| [`79d3d59f`](https://github.com/NixOS/nixpkgs/commit/79d3d59f58cccc6c1d167b8f6b8b6bd27b663aa7) | `` treewide: replace `mkPackageOptionMD` with `mkPackageOption` ``           |
| [`d3ccd1aa`](https://github.com/NixOS/nixpkgs/commit/d3ccd1aa2fc906dd71d44b29dc9b7817c05cfa03) | `` nixos/sysctl: Move changelog entry for yama ``                            |
| [`7115d8a7`](https://github.com/NixOS/nixpkgs/commit/7115d8a728d44b4121c6b56be0d71072d135a3a4) | `` paperless-ngx: 1.17.4 -> 2.0.1 ``                                         |
| [`9c4dd01d`](https://github.com/NixOS/nixpkgs/commit/9c4dd01dea631e494d46885a0a8f64bd7bbbbefc) | `` screenly-cli: init at 0.2.3 ``                                            |
| [`4b324167`](https://github.com/NixOS/nixpkgs/commit/4b324167cfaa7382e52758a1ca47013f772d1378) | `` fastly: 10.6.4 -> 10.7.0 ``                                               |
| [`bb9f1fc4`](https://github.com/NixOS/nixpkgs/commit/bb9f1fc46e188a24e4f1abe342f214c37c9c7eb1) | `` ocamlPackages.fiber: unstable-2023-02-28 -> 3.7.0 ``                      |
| [`f52f3f8b`](https://github.com/NixOS/nixpkgs/commit/f52f3f8be6eafa0c579255dea9b76f185d45e057) | `` libreoffice: backport fix for expired test certs ``                       |
| [`2f2672d7`](https://github.com/NixOS/nixpkgs/commit/2f2672d77297ec661b134297bbea7a2564df9995) | `` vscode-extensions.bmewburn.vscode-intelephense-client: 1.9.5 -> 1.10.1 `` |
| [`2e2c8f6f`](https://github.com/NixOS/nixpkgs/commit/2e2c8f6fb7e5ebfe579bc0df2df481edf191030c) | `` clightning: 23.08.1 -> 23.11 ``                                           |
| [`4a59f5a8`](https://github.com/NixOS/nixpkgs/commit/4a59f5a8752c48df6b8ac029b152c7c582652752) | `` pocketbase: add passthru.updateScript ``                                  |
| [`bfdc9aed`](https://github.com/NixOS/nixpkgs/commit/bfdc9aedd598c85ab25b5529968cc2faca167b0f) | `` python310Packages.cssbeautifier: 1.14.9 -> 1.14.11 ``                     |
| [`172a5a21`](https://github.com/NixOS/nixpkgs/commit/172a5a2104aef6a915956bd8d3b54c121189c5dd) | `` sparse: set llvm to llvm_14 ``                                            |
| [`0835f4bc`](https://github.com/NixOS/nixpkgs/commit/0835f4bc1f709e20c8890114483165e590f85906) | `` python3Packages.python-ipware: 0.9.0 -> 2.0.0 ``                          |
| [`e44b3f0c`](https://github.com/NixOS/nixpkgs/commit/e44b3f0c85d3e09d2a6a161fadf75351bf76c7e3) | `` python3Packages.gotenberg-client: init at 0.3.0 ``                        |
| [`496167b6`](https://github.com/NixOS/nixpkgs/commit/496167b6324e1b482290adff1157451a7afda1a3) | `` python3Packages.django-auditlog: init at 2.2.2 ``                         |
| [`d266f6f9`](https://github.com/NixOS/nixpkgs/commit/d266f6f91b3fa177b7cde84c9bae66d9cf502e5e) | `` firefox-unwrapped: 120.0 -> 120.0.1 ``                                    |
| [`410698c7`](https://github.com/NixOS/nixpkgs/commit/410698c71a787e38fc40092d73eba52d13864101) | `` materia-theme: fix build ``                                               |
| [`4739e28e`](https://github.com/NixOS/nixpkgs/commit/4739e28eb1ad7e474ebbe051850f7d2b9340d377) | `` fts: set to musl-fts on musl ``                                           |
| [`0d44b5b7`](https://github.com/NixOS/nixpkgs/commit/0d44b5b7733e35fe17b34921c611c21f805068a9) | `` pkgsStatic.stdenv: fix custom CMake LINKER_LANGUAGE ``                    |
| [`4552f3aa`](https://github.com/NixOS/nixpkgs/commit/4552f3aa254e5c50406ca59c2c04483ef8539161) | `` direnv: 2.32.3 -> 2.33.0 (#271059) ``                                     |
| [`ed48ad7b`](https://github.com/NixOS/nixpkgs/commit/ed48ad7b256ba45209d4d3e6ee641706faccb0e0) | `` teeworlds: fix meta.license ``                                            |
| [`9cf0738e`](https://github.com/NixOS/nixpkgs/commit/9cf0738eaf72b9f0c02e0e78d9443a1e2d7fa3e1) | `` todoist-electron: 8.9.3 -> 8.10.1 ``                                      |
| [`34da65ba`](https://github.com/NixOS/nixpkgs/commit/34da65ba2a6fc0e0c6c54397a4aaab4213ec2c72) | `` gcc6: don’t link libstdc++ to CoreFoundation ``                           |
| [`bcb34ba8`](https://github.com/NixOS/nixpkgs/commit/bcb34ba8b7a8876f3e665073a6f68d34acb514aa) | `` python311Packages.qcodes-loop: remove ``                                  |
| [`0de321de`](https://github.com/NixOS/nixpkgs/commit/0de321de7253279dd51842f69fde3dd231f7abce) | `` python311Packages.qcodes: disable flaky tests ``                          |
| [`0881edb6`](https://github.com/NixOS/nixpkgs/commit/0881edb66aa4b27e5894898bb2844aee79a5761a) | `` coqPackages.{hydra-battles,gaia-hydras}: 0.6 → 0.9 ``                     |
| [`36878436`](https://github.com/NixOS/nixpkgs/commit/36878436756a147c04f1ab11cdfc560e9523bf19) | `` coqPackages.gaia: 1.15 → 1.17 ``                                          |
| [`310cda5a`](https://github.com/NixOS/nixpkgs/commit/310cda5a0c679f62a86151d55ba964de72e80ba7) | `` mkAdoptopenjdk: allow missing {jre,jdk}-openj9 attribute ``               |
| [`72985fe2`](https://github.com/NixOS/nixpkgs/commit/72985fe2d139b92137824c4ca0fcf7831a19fd9d) | `` cudaPackages_10.cudaFlags: fix broken eval ``                             |
| [`e30975f8`](https://github.com/NixOS/nixpkgs/commit/e30975f8324fb8361198890c3227f18355f45465) | `` darwin.iosSdkPkgs: fix broken eval ``                                     |
| [`bffbf8bb`](https://github.com/NixOS/nixpkgs/commit/bffbf8bb537a06075e06d4f6cee306e3704055cc) | `` test.cuda: fix broken eval ``                                             |
| [`6755e476`](https://github.com/NixOS/nixpkgs/commit/6755e47637aef2302102457eaa6e0223cf9972a1) | `` mold: 2.3.3 -> 2.4.0 ``                                                   |
| [`dbe4453f`](https://github.com/NixOS/nixpkgs/commit/dbe4453f436f00977170ae7d1b5f633a49d6686d) | `` python310Packages.cloup: 3.0.2 -> 3.0.3 ``                                |
| [`936af716`](https://github.com/NixOS/nixpkgs/commit/936af716350f50a2b02380f49c4922bf4c43a105) | `` okteto: 2.22.0 -> 2.22.3 ``                                               |
| [`776c4279`](https://github.com/NixOS/nixpkgs/commit/776c4279109d1d1e5e7fecac6be3ffbddd0e2e6d) | `` python311Packages.qcodes: 0.41.1 -> 0.42.0 ``                             |
| [`aab46215`](https://github.com/NixOS/nixpkgs/commit/aab46215e8356872d0ada02d0fa41023a8692712) | `` python311Packages.canmatrix: add optional-dependencies ``                 |
| [`a90ce20c`](https://github.com/NixOS/nixpkgs/commit/a90ce20c9c8c3bec5967954e694abc300bb65aa1) | `` python311Packages.canmatrix: add changelog to meta ``                     |
| [`986af5c7`](https://github.com/NixOS/nixpkgs/commit/986af5c7748e0fe204f5b6ec31e26214194cddb5) | `` python310Packages.canmatrix: 0.9.5 -> 1.0 ``                              |
| [`54a8f13f`](https://github.com/NixOS/nixpkgs/commit/54a8f13f93858764fb89cf3f9ee02674557bf11f) | `` avr-sim: init at 2.8 ``                                                   |
| [`f8ea911f`](https://github.com/NixOS/nixpkgs/commit/f8ea911f7c4e44b167d4b1b51f6d00ebd93e1ed1) | `` lib.customisation.callPackageWith: use throw, not abort ``                |
| [`9b58faad`](https://github.com/NixOS/nixpkgs/commit/9b58faad99f8418baea31a6a1293c7f9c21b1d86) | `` nixosTests.jitsi-meet: test `cfg.caddy.enable` ``                         |
| [`9a821ebe`](https://github.com/NixOS/nixpkgs/commit/9a821ebe0fcd5a74e1aa4286d43ace78b30be909) | `` nixos/jitsi-meet: fix `cfg.caddy.enable` ``                               |
| [`6c455651`](https://github.com/NixOS/nixpkgs/commit/6c4556515f1669ea6e9589feb61c149f36d98628) | `` conserve: 23.9.0 -> 23.11.0 ``                                            |
| [`4585058f`](https://github.com/NixOS/nixpkgs/commit/4585058fc614fcf05f13016ef2a2c00434fad89b) | `` spectrwm: unstable-2023-05-07 -> 3.5.1 ``                                 |
| [`91666651`](https://github.com/NixOS/nixpkgs/commit/916666515a9418eafb503f0092c1bcf5fb855f56) | `` maintainers: christianharke -> rake5k ``                                  |
| [`e8fb6417`](https://github.com/NixOS/nixpkgs/commit/e8fb64175f40d95438edcd2bdac6c4463f9268a8) | `` publii: 0.43.1 -> 0.44.1 ``                                               |
| [`da49e141`](https://github.com/NixOS/nixpkgs/commit/da49e141e62ed3c1c44ab3426658f4ff999b254b) | `` eza: 0.16.1 -> 0.16.2 ``                                                  |
| [`6e1ae782`](https://github.com/NixOS/nixpkgs/commit/6e1ae782c2fcb6d03dcd52ac7d345e3177f6347a) | `` fortune-kind: 0.1.10 -> 0.1.11 ``                                         |
| [`556712bb`](https://github.com/NixOS/nixpkgs/commit/556712bb7c057797d5b83d6349ec443084421877) | `` acgtk: 1.5.4 → 2.0.0 ``                                                   |
| [`147eabb0`](https://github.com/NixOS/nixpkgs/commit/147eabb0f47b6cf6be50ae5a1ffb021f33088526) | `` ocamlPackages.readline: init at 0.1 ``                                    |
| [`cda93e08`](https://github.com/NixOS/nixpkgs/commit/cda93e08b20fb49366798041cfdb8eb0dd72d38e) | `` racket: use hash instead of sha256 in fetchurl ``                         |
| [`d291d63e`](https://github.com/NixOS/nixpkgs/commit/d291d63e62286af7da5a842be761db1f38305c89) | `` racket,racket-minimal: 8.11 -> 8.11.1 ``                                  |
| [`c3055100`](https://github.com/NixOS/nixpkgs/commit/c305510073b8a3b843dd7e35969c59aa18369a3c) | `` anki-sync-server: init at 2.1.66 ``                                       |
| [`46f83cdd`](https://github.com/NixOS/nixpkgs/commit/46f83cdd85f4624dc632b21c101beb9b5e8225d4) | `` mmctl: 7.10.5 -> 9.2.2 (#269709) ``                                       |
| [`c0fad37a`](https://github.com/NixOS/nixpkgs/commit/c0fad37a70cce3f219614fdf4e41fed42dfa19bc) | `` sing-box: 1.6.7 -> 1.7.0 ``                                               |
| [`0bfbf285`](https://github.com/NixOS/nixpkgs/commit/0bfbf2857781aa9ccd9f52e553789ad850e4536e) | `` python311Packages.aiorecollect: 2023.09.0 -> 2023.11.0 ``                 |
| [`8c734937`](https://github.com/NixOS/nixpkgs/commit/8c734937d6473d4e707c5c96c36e3d91009d2e3d) | `` nixos/sourcehut: fix eval ``                                              |
| [`85cba397`](https://github.com/NixOS/nixpkgs/commit/85cba39704aa90dfa6d33bd05e57996d112165f4) | `` rtx: change username of repo owner ``                                     |
| [`73df03d0`](https://github.com/NixOS/nixpkgs/commit/73df03d0c43559a4131ec95da0d92c6550b05237) | `` clear: set platforms ``                                                   |
| [`27e8db2b`](https://github.com/NixOS/nixpkgs/commit/27e8db2bcfd32a9bcc24a68347cd493a4b3f4e7d) | `` bilibili: update meta info ``                                             |
| [`e86c08bf`](https://github.com/NixOS/nixpkgs/commit/e86c08bf2065ab9eb8bc329e0fca3098c31e8ded) | `` syft: 0.97.1 -> 0.98.0 ``                                                 |
| [`89926323`](https://github.com/NixOS/nixpkgs/commit/89926323eca11b21dde00d480eabb3350b367472) | `` hydrus: 553 -> 554 ``                                                     |
| [`15185e53`](https://github.com/NixOS/nixpkgs/commit/15185e5362c194dc44db1ba5545ae98dfbdd8f30) | `` python311Packages.peft: 0.6.0 -> 0.6.2 ``                                 |
| [`51378601`](https://github.com/NixOS/nixpkgs/commit/51378601be3c9da32a51c5f3336bb90bf446f604) | `` spicetify-cli: 2.27.1 -> 2.27.2 ``                                        |
| [`abbd12a2`](https://github.com/NixOS/nixpkgs/commit/abbd12a26eac18d0a471adc1313b1742cde4ce86) | `` python310Packages.pinocchio: fix build on x86_64-darwin ``                |
| [`c7eca14f`](https://github.com/NixOS/nixpkgs/commit/c7eca14f84da53d15d25cb1019c0a5cb5a706efc) | `` python311Packages.optimum: 1.14.0 -> 1.14.1 ``                            |
| [`52f4aaf4`](https://github.com/NixOS/nixpkgs/commit/52f4aaf4170b592222901768667ae3e3dd66989b) | `` python311Packages.pyairvisual: 2023.08.0 -> 2023.11.0 ``                  |
| [`517d5ab0`](https://github.com/NixOS/nixpkgs/commit/517d5ab0b5646a36a971503b5c638aa7106d8ad5) | `` chia: drop ``                                                             |
| [`e79e4fa3`](https://github.com/NixOS/nixpkgs/commit/e79e4fa3f2d85925f18c3c8ed876d3db575f21a5) | `` python311Packages.zamg: modernize ``                                      |
| [`4d568d2f`](https://github.com/NixOS/nixpkgs/commit/4d568d2fa75612207b7207528789a149f8994841) | `` python311Packages.zamg: 0.3.1 -> 0.3.3 ``                                 |
| [`e1906b8e`](https://github.com/NixOS/nixpkgs/commit/e1906b8e81164d8debd99c0c2c8235004b9e5c56) | `` python311Packages.pyopenuv: 2023.08.0 -> 2023.11.0 ``                     |