### PR TITLE
chore(flake/unstable): `024e4447` -> `e2fa3d60`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -930,11 +930,11 @@
     },
     "unstable": {
       "locked": {
-        "lastModified": 1701172651,
-        "narHash": "sha256-wP2F6NTa4Sh5tgfP2Ya0AOwt/6SvCAXylW0R6ASRS9w=",
+        "lastModified": 1701239926,
+        "narHash": "sha256-k5R3QQJMGU11nhTPctbpqWenAkRnqngH5VnGMQCtHyg=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "024e4447a42868b4c8f3ac8b3e6a2da83c682de1",
+        "rev": "e2fa3d60550627938495aa368a1d4635c9cf64ff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`9ad22d35`](https://github.com/NixOS/nixpkgs/commit/9ad22d35b67cf3bb03ffd56e96f38bcdbb9163a0) | `` Revert "nixos/switch-to-configuration: remove explicit tmpfiles invocation" `` |
| [`76c5738e`](https://github.com/NixOS/nixpkgs/commit/76c5738ef231b19072cd7b1c0fa6d65cb61b1208) | `` coqPackages.mathcomp-word: 2.1 → {2.2, 3.0} ``                                 |
| [`c4ffc839`](https://github.com/NixOS/nixpkgs/commit/c4ffc83975e38459202145f18528aa602744775f) | `` ocamlPackages.bap: use LLVM 14 ``                                              |
| [`369650ef`](https://github.com/NixOS/nixpkgs/commit/369650ef388e4a6488b1783dc747cab7559a90d4) | `` poco: fix static build ``                                                      |
| [`d341b7d9`](https://github.com/NixOS/nixpkgs/commit/d341b7d95cc9d571e2547850689682373b68603d) | `` gifski: 1.13.0 -> 1.31.1 ``                                                    |
| [`67456fd6`](https://github.com/NixOS/nixpkgs/commit/67456fd6ca7b7511e2ce07e820df89d3a7d054c4) | `` oxlint: 0.0.17 -> 0.0.18 ``                                                    |
| [`9c933f9d`](https://github.com/NixOS/nixpkgs/commit/9c933f9d855e443a7f46fcc09bbf777ebcb11579) | `` cargo-zigbuild: 0.17.5 -> 0.18.0 ``                                            |
| [`fa3cd52b`](https://github.com/NixOS/nixpkgs/commit/fa3cd52b3e4ef8ae07e4a01f1c2f2acb5fa32756) | `` drogon: 1.9.0 -> 1.9.1 ``                                                      |
| [`53850d6d`](https://github.com/NixOS/nixpkgs/commit/53850d6d440df52d16f6bc13ba8e9c487f910ba8) | `` cargo-shuttle: 0.33.0 -> 0.34.1 ``                                             |
| [`10ee18ca`](https://github.com/NixOS/nixpkgs/commit/10ee18ca9265cada45acfc7a6d7644cd22b82465) | `` certbot: 2.6.0 -> 2.7.4 (#267710) ``                                           |
| [`b5514083`](https://github.com/NixOS/nixpkgs/commit/b5514083094a1f532fc654edb1190ad6cf81f587) | `` qovery-cli: 0.74.3 -> 0.74.4 ``                                                |
| [`21672ccd`](https://github.com/NixOS/nixpkgs/commit/21672ccd691ebd2f18fa6b41446389c069adfdbb) | `` firefox-devedition-unwrapped: 121.0b3 -> 121.0b4 ``                            |
| [`2438f55f`](https://github.com/NixOS/nixpkgs/commit/2438f55f0989f1be60b292ef82fa1568b1b8967b) | `` firefox-beta-unwrapped: 121.0b3 -> 121.0b4 ``                                  |
| [`395c3204`](https://github.com/NixOS/nixpkgs/commit/395c32048e786ea4ff756ea6fd46cdb28b85c19a) | `` firefox: Adds patch for systems without a default page size (#270722) ``       |
| [`b5869682`](https://github.com/NixOS/nixpkgs/commit/b5869682246c587aa19ab0c9f4141217f7940f98) | `` nix-direnv: 2.4.0 -> 2.5.1 ``                                                  |
| [`7071bf24`](https://github.com/NixOS/nixpkgs/commit/7071bf24d415cf025c42eb6b60ff04d880905001) | `` mus: change upstream src; migrate to by-name ``                                |
| [`2a3d97bc`](https://github.com/NixOS/nixpkgs/commit/2a3d97bcb08324c14a06c0861e05673a16690015) | `` maintainers: sfr -> nbsp ``                                                    |
| [`ce95d592`](https://github.com/NixOS/nixpkgs/commit/ce95d5928143ac7b957ea1dd8b43fb31aae109fe) | `` cloudlog: 2.5.1 -> 2.5.2 ``                                                    |
| [`e0311009`](https://github.com/NixOS/nixpkgs/commit/e03110096545ccd2504654d6d93242bb50893b25) | `` python311Packages.pubnub: 7.3.1 -> 7.3.2 ``                                    |
| [`7ff19330`](https://github.com/NixOS/nixpkgs/commit/7ff193305b852074d1ce1278e3bc008419c491be) | `` treewide: remove henrytill as maintainer from various pkgs ``                  |
| [`60bd6ad8`](https://github.com/NixOS/nixpkgs/commit/60bd6ad87f351fe9305f9c5420f71caee34148c5) | `` ipinfo: 3.1.2 -> 3.2.0 ``                                                      |
| [`29175e61`](https://github.com/NixOS/nixpkgs/commit/29175e613e20bea94ffba87a310fd5ecfa492980) | `` cargo-tarpaulin: 0.27.1 -> 0.27.2 ``                                           |
| [`0864e05d`](https://github.com/NixOS/nixpkgs/commit/0864e05d727dc04acd6b3ba2aed89a4a607df3c8) | `` .github/CODEOWNERS: Add roberth to module system ``                            |
| [`9e445876`](https://github.com/NixOS/nixpkgs/commit/9e4458763fb51df6040a02c515a43a4e3cc3bf77) | `` python311Packages.altair: 5.1.2 -> 5.2.0 ``                                    |
| [`f9abf151`](https://github.com/NixOS/nixpkgs/commit/f9abf151855f04e2f35bf9c22f307f7e788d2ac7) | `` dnf5: tag was moved, fix hash ``                                               |
| [`1e1bd362`](https://github.com/NixOS/nixpkgs/commit/1e1bd362e50cd3d8729a170b084340701bcdd550) | `` timg: 1.5.2 -> 1.5.3 ``                                                        |
| [`acab2ad0`](https://github.com/NixOS/nixpkgs/commit/acab2ad0e77f1b9e27cd3217e69a004959487353) | `` release-notes: mention Nim changes ``                                          |
| [`1753744b`](https://github.com/NixOS/nixpkgs/commit/1753744b35ade75f329bd487d4397c7cb69e8f71) | `` nim_lk: wrap with nix-prefetch, nix-prefetch-git ``                            |
| [`8effb983`](https://github.com/NixOS/nixpkgs/commit/8effb98377496b3d17d34136cc494428d32b8a2e) | `` nim: 1.6.14 -> 2.0.0 ``                                                        |
| [`8672b5ca`](https://github.com/NixOS/nixpkgs/commit/8672b5cabdc10359cc6e9bc2c04fd281618ae2c5) | `` Remove nimPackages and nim2Packages ``                                         |
| [`7bd3fa9f`](https://github.com/NixOS/nixpkgs/commit/7bd3fa9faf6581a6167c63f721db0112245a0872) | `` emocli: use top-level buildNimPackage ``                                       |
| [`5dd13314`](https://github.com/NixOS/nixpkgs/commit/5dd133142ff17e74594eb6369b983e1c47bd540e) | `` snekim: build with lockfile ``                                                 |
| [`6240432c`](https://github.com/NixOS/nixpkgs/commit/6240432c4490fe941f65947930056dd4e011300b) | `` nimlsp: build with lockfile ``                                                 |
| [`862b9061`](https://github.com/NixOS/nixpkgs/commit/862b90618926848cc04b4d0061f0a45f1a237592) | `` nimmm: build with lockfile ``                                                  |
| [`607c5fdb`](https://github.com/NixOS/nixpkgs/commit/607c5fdb0433d316f24b756cbad7afca94d05b8f) | `` nim-atlas: migrate from nimPackages.atlas ``                                   |
| [`6f8f9a92`](https://github.com/NixOS/nixpkgs/commit/6f8f9a9254d9942d2e6b606ba6e2b506cefdda27) | `` nimble: migrate from nimPackages ``                                            |
| [`53c5ce37`](https://github.com/NixOS/nixpkgs/commit/53c5ce37bd39270f98bed6a9a8b87f869f521484) | `` base45: migrate from nimPackages ``                                            |
| [`3d5455ac`](https://github.com/NixOS/nixpkgs/commit/3d5455ac3b609bbdca913a523a94a327a00936f3) | `` eriscmd: migrate from nimPackages.eris ``                                      |
| [`6df86cc6`](https://github.com/NixOS/nixpkgs/commit/6df86cc655a99e9db0569b53054b20404b4eacba) | `` c2nim: move out of nimPackages ``                                              |
| [`0f2dc695`](https://github.com/NixOS/nixpkgs/commit/0f2dc695198d4bdaaecf1b29d878a390b7eb3646) | `` nrpl: use new buildNimPackage ``                                               |
| [`146947ca`](https://github.com/NixOS/nixpkgs/commit/146947ca3b1d703eac5f93803d442f25a8567820) | `` promexplorer: build with lockfile ``                                           |
| [`29b30270`](https://github.com/NixOS/nixpkgs/commit/29b302705b282bedde66f1fe7f199e4a46be842f) | `` swaycwd: use new buildNimPackage ``                                            |
| [`48840e17`](https://github.com/NixOS/nixpkgs/commit/48840e17625420eb9ab9a165a368379e600b3714) | `` nitch: use new buildNimPackage ``                                              |
| [`a7758d7d`](https://github.com/NixOS/nixpkgs/commit/a7758d7dd8222ae1e0187b41aa38b412d446d6dc) | `` tridactyl-native: build with lockfile ``                                       |
| [`dce1f58e`](https://github.com/NixOS/nixpkgs/commit/dce1f58e63342945dfedaf1fb1752ef422caad13) | `` nimdow: build with lockfile ``                                                 |
| [`0f089515`](https://github.com/NixOS/nixpkgs/commit/0f089515b15af25212c404ced278fa3e8e178270) | `` mosdepth: build with a lockfile ``                                             |
| [`cab3fd4d`](https://github.com/NixOS/nixpkgs/commit/cab3fd4d50a05becce0e4df3779c8d1b3e23586f) | `` nitter: build with buildNimPackage ``                                          |
| [`ee21b616`](https://github.com/NixOS/nixpkgs/commit/ee21b61658dd195be61e93b0937ad65d6e41fb6a) | `` ttop: build with lockfile ``                                                   |
| [`35f108c7`](https://github.com/NixOS/nixpkgs/commit/35f108c7d7742fc9119a03783f40dd44cf7f6251) | `` buildNimPackage: load lockfiles and overrides ``                               |
| [`39d4eace`](https://github.com/NixOS/nixpkgs/commit/39d4eace911f9e838df023ad80f52132380e01c2) | `` nimPackages.buildNimPackage: move to top-level ``                              |
| [`89153ceb`](https://github.com/NixOS/nixpkgs/commit/89153ceb44198bba7b6fc74451a7dbf38d0193dd) | `` nimPackages.nim_builder: move out to pkgs/by-name ``                           |
| [`9e00db7b`](https://github.com/NixOS/nixpkgs/commit/9e00db7b79b2deadab0dd056f117b339b9e19b63) | `` nim: invert nim1 to be a definition of nim2 ``                                 |
| [`9c24e11f`](https://github.com/NixOS/nixpkgs/commit/9c24e11f3a9c2eed56792e6288b7feabce265fe1) | `` nvidiaPackages.(settings|persistened): add fallback cdn ``                     |
| [`c953c85b`](https://github.com/NixOS/nixpkgs/commit/c953c85b9ebdd2773f95180254ec9429cb1426f8) | `` nix-unit: init at 2.18.0 ``                                                    |
| [`d97d2fb2`](https://github.com/NixOS/nixpkgs/commit/d97d2fb271e4d9d0f86cf704c6d9fb3aa851d80d) | `` nixos/clamav: ensure freshclam starts before clamav (if enabled) ``            |
| [`7afbfd38`](https://github.com/NixOS/nixpkgs/commit/7afbfd384d51cbb01230bc3ae3b2b88ee4713d44) | `` fbvnc: cleanup, fix cross compilation ``                                       |
| [`3281455a`](https://github.com/NixOS/nixpkgs/commit/3281455a2613ceb321e97e6560312b72214214ed) | `` nvidiaPackages: format generic.nix ``                                          |
| [`3b1db407`](https://github.com/NixOS/nixpkgs/commit/3b1db4070e930ae4e8110a39dfb5961a7e5c9616) | `` python311Packages.aiolifx-themes: 0.4.10 -> 0.4.11 ``                          |
| [`e9d43e61`](https://github.com/NixOS/nixpkgs/commit/e9d43e61bf3d1de31fdcccb8fd3cf74819282399) | `` exploitdb: 2023-11-25 -> 2023-11-28 ``                                         |
| [`e3c83148`](https://github.com/NixOS/nixpkgs/commit/e3c831487b871207aeeddb74618f6907eb5394af) | `` checkov: 3.1.15 -> 3.1.18 ``                                                   |
| [`352d3a3a`](https://github.com/NixOS/nixpkgs/commit/352d3a3ad9345a0d9864c3923904b81a0e1f4ef7) | `` maubot: switch to ensureNewerSourcesForZipFilesHook ``                         |
| [`00070cf8`](https://github.com/NixOS/nixpkgs/commit/00070cf866af5945cefdb59803005de8a47abaf2) | `` nixos/maubot: init ``                                                          |
| [`e96b8fd9`](https://github.com/NixOS/nixpkgs/commit/e96b8fd970b947c71e559a5ddc89d64a829ab615) | `` maubot: add plugins & plugins update script ``                                 |
| [`ec54fee3`](https://github.com/NixOS/nixpkgs/commit/ec54fee3b5c9d4ec0f635f6b63689742fc8b4bcc) | `` rl-2311: Link to blog post on the file set library ``                          |
| [`8b713aa6`](https://github.com/NixOS/nixpkgs/commit/8b713aa68935f0d582de79921f35e672a65c2756) | `` gcal: fix build in darwin ``                                                   |
| [`9d53f93b`](https://github.com/NixOS/nixpkgs/commit/9d53f93b88a9fe0ccad3123a5c46996cae16b722) | `` postgresqlPackages.pgrouting: add geospatial team to maintainers ``            |
| [`1b87c9dc`](https://github.com/NixOS/nixpkgs/commit/1b87c9dcd640d19dd0bdc2c16e6e4c7b199c2db6) | `` httptunnel: update to latest rev; fix darwin ``                                |
| [`9fa73548`](https://github.com/NixOS/nixpkgs/commit/9fa735486088c53760608c2d8cea514f47150e7f) | `` tile38: add geospatial team to maintainers ``                                  |
| [`e1f3eed3`](https://github.com/NixOS/nixpkgs/commit/e1f3eed3fdb2c13bf100fff42d680c1f4d4c8054) | `` t-rex: add geospatial team to maintainers ``                                   |
| [`1536d9f3`](https://github.com/NixOS/nixpkgs/commit/1536d9f3aeac7d7ee7eac630aef4d6154a534501) | `` mbtileserver: add geospatial team to maintainers ``                            |
| [`c11bc06f`](https://github.com/NixOS/nixpkgs/commit/c11bc06f5326a2d5ab8058677d978957d4d03868) | `` mapcache: add geospatial team to maintainers ``                                |
| [`64205f60`](https://github.com/NixOS/nixpkgs/commit/64205f60aff5a90ab8a0ac4afcddfbc9fa52486c) | `` pg_featureserv: add geospatial team to maintainers ``                          |
| [`5d3a53c0`](https://github.com/NixOS/nixpkgs/commit/5d3a53c02e7edd269ee1d87764685829e10da6c8) | `` pg_tileserv: add geospatial team to maintainers ``                             |
| [`214fb088`](https://github.com/NixOS/nixpkgs/commit/214fb08814596bdf2ed70f93a1fa25731f10f6fd) | `` mapserver: add geospatial team to maintainers ``                               |
| [`04e31b72`](https://github.com/NixOS/nixpkgs/commit/04e31b72c4eae5cd277982fd9a03c2a8cb675af0) | `` audiobookshelf: 2.5.0 -> 2.6.0 ``                                              |
| [`6224235f`](https://github.com/NixOS/nixpkgs/commit/6224235f2b13ff9d8dbb834f4d78c633e7f230b9) | `` khal: no longer broken on Darwin ``                                            |
| [`a9a14d5f`](https://github.com/NixOS/nixpkgs/commit/a9a14d5fe48bd9260fc6cc6dd91ad7724865ba06) | `` python310Packages.clickhouse-connect: 0.6.18 -> 0.6.21 ``                      |
| [`3a3cd401`](https://github.com/NixOS/nixpkgs/commit/3a3cd401810fadbd2d2a99a0ba8676060082f92f) | `` soft-serve: 0.7.2 -> 0.7.3 ``                                                  |
| [`eb198e32`](https://github.com/NixOS/nixpkgs/commit/eb198e32f042ad37c7204e745d93c18cfbc5b032) | `` kotlin-native: update darwin hashes; fix build ``                              |
| [`f3c44905`](https://github.com/NixOS/nixpkgs/commit/f3c44905d8f10582ca81dfff509705e3c961c796) | `` python311Packages.gentools: adjust inputs ``                                   |
| [`2a5388a5`](https://github.com/NixOS/nixpkgs/commit/2a5388a54e6dad4828647c53c180d69df7683605) | `` python311Packages.gentools: add changelog to meta ``                           |
| [`6d2cb963`](https://github.com/NixOS/nixpkgs/commit/6d2cb963287f8bca8c1f5b6feaa2669372fb9d7d) | `` python311Packages.gentools: switch to pyproject; fix build ``                  |
| [`2a8d6aee`](https://github.com/NixOS/nixpkgs/commit/2a8d6aeea56478423e3a20f865d9540255756c56) | `` python311Packages.rpcq: disable failing tests ``                               |
| [`e5391840`](https://github.com/NixOS/nixpkgs/commit/e539184044cefe093e4cc196c9eab883b866de0b) | `` python311Packages.aiohttp-fast-url-dispatcher: init at 0.3.0 ``                |
| [`26a7b7b1`](https://github.com/NixOS/nixpkgs/commit/26a7b7b1723efe6598ce2a39cb4633260a358470) | `` python311Packages.gios: 3.2.1 -> 3.2.2 ``                                      |
| [`b5f8a5b8`](https://github.com/NixOS/nixpkgs/commit/b5f8a5b808584e68772783681f8ec304a46e0b32) | `` python311Packages.sfrbox-api: 0.0.6 -> 0.0.8 ``                                |
| [`50d4ec0e`](https://github.com/NixOS/nixpkgs/commit/50d4ec0e5d1f4064f5d175c8301fc9dac05339f6) | `` python311Packages.ring-doorbell: 0.8.1 -> 0.8.3 ``                             |
| [`1b845bc1`](https://github.com/NixOS/nixpkgs/commit/1b845bc1e8b5f1a0852cec57e988a011c516d6ad) | `` python311Packages.nettigo-air-monitor: 2.2.1 -> 2.2.2 ``                       |
| [`58810d2a`](https://github.com/NixOS/nixpkgs/commit/58810d2ac631f5c79cb7cdeeb972c88f29be668f) | `` python310Packages.camel-converter: 3.1.0 -> 3.1.1 ``                           |
| [`0461296c`](https://github.com/NixOS/nixpkgs/commit/0461296c62baf3a029b09c2ac39b2977acb24ad6) | `` xmlstarlet: add autoreconfHook, fix cross compilation ``                       |
| [`61c231c0`](https://github.com/NixOS/nixpkgs/commit/61c231c07e7b610beaaed7f3c7116d6f3476363e) | `` python310Packages.branca: 0.6.0 -> 0.7.0 ``                                    |
| [`c9f550e3`](https://github.com/NixOS/nixpkgs/commit/c9f550e3714902e9c17bd815e3d27d923aa02313) | `` sing-box: 1.6.6 -> 1.6.7 ``                                                    |
| [`7b72294a`](https://github.com/NixOS/nixpkgs/commit/7b72294a256f2503148d460125c913962c73e560) | `` python310Packages.botorch: 0.9.3 -> 0.9.4 ``                                   |
| [`64b4586d`](https://github.com/NixOS/nixpkgs/commit/64b4586d20a6a1b74ec344b19cf76b8b75b44a83) | `` python310Packages.boto3-stubs: 1.28.78 -> 1.29.7 ``                            |
| [`bcba0334`](https://github.com/NixOS/nixpkgs/commit/bcba03343583d6d080a0383674117c3bdf4bfb7b) | `` serious-sans: init at unstable-2023-09-04 ``                                   |
| [`10e0ccbf`](https://github.com/NixOS/nixpkgs/commit/10e0ccbfa53d84af6e49b70580d16318cdde2fde) | `` sccache: 0.7.2 -> 0.7.4 ``                                                     |
| [`dfae7c08`](https://github.com/NixOS/nixpkgs/commit/dfae7c0805861efba0afbd2f2d48324358e07ad4) | `` soju: 0.6.2 -> 0.7.0 ``                                                        |
| [`81b063be`](https://github.com/NixOS/nixpkgs/commit/81b063bee896d05495d2b461a1ffc4e90d901051) | `` jql: 7.0.6 -> 7.0.7 ``                                                         |
| [`f84656d4`](https://github.com/NixOS/nixpkgs/commit/f84656d4251a3456ee6c95130a0123e4928d273d) | `` gql: 0.8.0 -> 0.9.0 ``                                                         |
| [`03554146`](https://github.com/NixOS/nixpkgs/commit/03554146c75f770ebdaf882d7a0c2556e6d86bd0) | `` tui-journal: 0.4.0 -> 0.5.0 ``                                                 |
| [`64c132c4`](https://github.com/NixOS/nixpkgs/commit/64c132c42759d4bf3722e8e24905f86f02180567) | `` qt6.qtbase: fix build on older macOS ``                                        |
| [`20c316dd`](https://github.com/NixOS/nixpkgs/commit/20c316dd239a05f7e76ee702842b91d7bbe54b3b) | `` cargo-mutants: 23.11.1 -> 23.11.2 ``                                           |
| [`a7f14dd9`](https://github.com/NixOS/nixpkgs/commit/a7f14dd928b21b3d5cb84b9893fc8ba1a456e5f0) | `` fw: 2.18.0 -> 2.19.0 ``                                                        |
| [`8cf9ec9b`](https://github.com/NixOS/nixpkgs/commit/8cf9ec9b02dfd0949d3a7fd30fd0a84f40944e4c) | `` runelite: fix desktop entry ``                                                 |
| [`0eeabb2d`](https://github.com/NixOS/nixpkgs/commit/0eeabb2d284ec26d1139fb935615a2a704f6cf94) | `` symbolicator: 23.11.0 -> 23.11.2 ``                                            |
| [`353ec7d1`](https://github.com/NixOS/nixpkgs/commit/353ec7d15489e325d442d25b9d811f5b3b886349) | `` microsoft-edge: 119.0.2151.44 -> 119.0.2151.72 ``                              |
| [`ef47a483`](https://github.com/NixOS/nixpkgs/commit/ef47a483c2245a9b1a865105018839c712baac18) | `` homepage-dashboard: 0.7.4 -> 0.8.2 ``                                          |
| [`899e6383`](https://github.com/NixOS/nixpkgs/commit/899e638397cf2e62613c6df3c6a28f3d1a73fa2d) | `` python311Packages.python-rapidjson: 1.11 -> 1.13 ``                            |
| [`1debdc97`](https://github.com/NixOS/nixpkgs/commit/1debdc9730ff3b9bc5942c2bf206600005d03036) | `` remnote: 1.12.64 -> 1.13.0 ``                                                  |
| [`d91e9ecd`](https://github.com/NixOS/nixpkgs/commit/d91e9ecd5bd36982553cb38d3889c7890b65653a) | `` maintainers: rename jgarcia to chewblacka ``                                   |
| [`b30aa72d`](https://github.com/NixOS/nixpkgs/commit/b30aa72d57572f44e960856af3bafe854fddb13a) | `` qt6.qtwayland: drop outdated patches ``                                        |
| [`4b8fb7d6`](https://github.com/NixOS/nixpkgs/commit/4b8fb7d6da71196f0e5d450fbf38ae9f5685d4e8) | `` qt6.qtsvg: drop outdated patches ``                                            |
| [`8d7da804`](https://github.com/NixOS/nixpkgs/commit/8d7da804f0825d0fcadb48bfd213a0314dad4777) | `` python311Packages.types-tqdm: init at 4.66.0.5 ``                              |
| [`b29fef33`](https://github.com/NixOS/nixpkgs/commit/b29fef333197f8d22997d901cd61ebb074d1bc7d) | `` xfce.xfce4-whiskermenu-plugin: 2.8.1 -> 2.8.2 ``                               |
| [`da086000`](https://github.com/NixOS/nixpkgs/commit/da086000735e4987c922f949c48b11a494ceb251) | `` qt6.qtbase: derive plugin load path from PATH ``                               |
| [`53ad6fd1`](https://github.com/NixOS/nixpkgs/commit/53ad6fd1b4377b8cc591fd74a5a4b90ead42d6e3) | `` qt6.qtbase: refresh patches ``                                                 |
| [`3e46f20a`](https://github.com/NixOS/nixpkgs/commit/3e46f20afe1665a1abbb68a0461fa57293f3dda2) | `` qt6: 6.6.0 -> 6.6.1 ``                                                         |
| [`b83da258`](https://github.com/NixOS/nixpkgs/commit/b83da2587c72e2c0344426707c09d0130c053730) | `` cinnamon.mint-l-theme: 1.9.5 -> 1.9.6 ``                                       |
| [`f598dcdc`](https://github.com/NixOS/nixpkgs/commit/f598dcdc955c51f4af5ba0759dc4ae5449924705) | `` cinnamon.mint-l-icons: 1.6.5 -> 1.6.6 ``                                       |
| [`18d00072`](https://github.com/NixOS/nixpkgs/commit/18d00072f76f8732cea9fdfd94b56ade2a256896) | `` cinnamon.mint-y-icons: 1.6.7 -> 1.6.9 ``                                       |
| [`2b98c646`](https://github.com/NixOS/nixpkgs/commit/2b98c6462fada76d13c99301e7ca4752dbf7d3d2) | `` cinnamon.mint-themes: 2.1.5 -> 2.1.6 ``                                        |
| [`31519d98`](https://github.com/NixOS/nixpkgs/commit/31519d989e09945dbb29db2d64e4b48f52096ec3) | `` cinnamon.xreader: 3.8.2 -> 3.8.3 ``                                            |
| [`9e6fbe3b`](https://github.com/NixOS/nixpkgs/commit/9e6fbe3bfd7fb46f5a3a0f86f65ebc40895d5190) | `` cinnamon.mint-artwork: 1.7.6 -> 1.7.7 ``                                       |
| [`0d0cc171`](https://github.com/NixOS/nixpkgs/commit/0d0cc171b1721422dfa0379cf7dee96e6f851304) | `` lxd-to-incus: 0.2 -> 0.3 ``                                                    |
| [`2fb50aab`](https://github.com/NixOS/nixpkgs/commit/2fb50aab69a8729d827b5f5870ab0affdd78bc04) | `` incus-unwrapped: 0.2 -> 0.3 ``                                                 |
| [`2eecd0cf`](https://github.com/NixOS/nixpkgs/commit/2eecd0cf688e723f0c3e96b5a9f9ccdaec73006f) | `` xcwd: cleanup ``                                                               |
| [`f937c5e7`](https://github.com/NixOS/nixpkgs/commit/f937c5e7572f70a798cc96f20dc8496e44c426e9) | `` pdfsam-basic: 5.0.3 -> 5.2.0 ``                                                |
| [`1ed22e19`](https://github.com/NixOS/nixpkgs/commit/1ed22e19742f3ff12361f12f4722f62b526436c1) | `` transgui: set updateScript to unstableGitUpdater ``                            |
| [`a4ce630f`](https://github.com/NixOS/nixpkgs/commit/a4ce630f3e7e9c096ca97d12f9af60434fcaa512) | `` redis-plus-plus: 1.3.7 -> 1.3.10 ``                                            |
| [`485684d5`](https://github.com/NixOS/nixpkgs/commit/485684d5d81b571b227551f54faa419995346a7f) | `` kgeotag: init at 1.4.0 ``                                                      |
| [`27386a6f`](https://github.com/NixOS/nixpkgs/commit/27386a6fb4663dc35d855c283dab254718624a41) | `` python311Packages.dateparser: add meta.mainProgram ``                          |
| [`62ca5836`](https://github.com/NixOS/nixpkgs/commit/62ca5836361ae73f07bae70d2d5591f9d485c864) | `` python311Packages.dateparser: 1.1.8 -> 1.2.0 ``                                |
| [`fef59b3b`](https://github.com/NixOS/nixpkgs/commit/fef59b3b8519bc261fa1bc00996bd6ea1624b6dd) | `` python311Packages.calmjs-parse: 1.3.0 -> 1.3.1 ``                              |
| [`0d220827`](https://github.com/NixOS/nixpkgs/commit/0d220827ac37547654418b9e1880e225521ee562) | `` liberasurecode: ignore strict prototypes on clang; fix darwin ``               |
| [`6df99202`](https://github.com/NixOS/nixpkgs/commit/6df9920261314153f159c965780a497f925e622e) | `` gdlauncher: 3.1.44 -> 3.1.45 ``                                                |
| [`b4ebded2`](https://github.com/NixOS/nixpkgs/commit/b4ebded26a536cc6a9bee54f31c989646d9d826f) | `` python311Packages.rapidgzip: add changelog to meta ``                          |
| [`522a4348`](https://github.com/NixOS/nixpkgs/commit/522a4348d89f08c20696f2137521a5b049604026) | `` python311Packages.rapidgzip: 0.10.3 -> 0.10.4 ``                               |
| [`c4e5aac4`](https://github.com/NixOS/nixpkgs/commit/c4e5aac4e5aa6b89931f0f957a165ae0a314d641) | `` shavee: 0.5.1 -> 0.7.3 ``                                                      |
| [`79e3ab84`](https://github.com/NixOS/nixpkgs/commit/79e3ab84dd10e448b06f2af7a5b322c03932a9d9) | `` nixos/tests/nextcloud: fix with-declarative-redis-and-secrets test ``          |