### PR TITLE
chore(flake/nur): `54e5c118` -> `c408d778`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -692,11 +692,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701274502,
-        "narHash": "sha256-0q3S6WSHQp40JLQhs6gWx7B0B1iUHqA2JUfD/s9f40k=",
+        "lastModified": 1701593035,
+        "narHash": "sha256-Z18Qog6jDAdk0LFj+Lgl1biM8FQAsIQPaDXchS+U3BQ=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "54e5c1183d178322e0dd79ebba7551ccb543b6b6",
+        "rev": "c408d77824d798e87249207c747a2c742745e6bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c408d778`](https://github.com/nix-community/NUR/commit/c408d77824d798e87249207c747a2c742745e6bf) | `` automatic update `` |
| [`e2c94e7b`](https://github.com/nix-community/NUR/commit/e2c94e7b39f3b9f4f82310a8c4168c886d7bd204) | `` automatic update `` |
| [`ee2c2ffb`](https://github.com/nix-community/NUR/commit/ee2c2ffb63f53cefe25e20e5386589967e426c67) | `` automatic update `` |
| [`3c73e262`](https://github.com/nix-community/NUR/commit/3c73e262aafcf393976124557a26731dd1038a27) | `` automatic update `` |
| [`910ea1ac`](https://github.com/nix-community/NUR/commit/910ea1ac6db158f066cb2f666fb9c86e3bea2051) | `` automatic update `` |
| [`ce93686d`](https://github.com/nix-community/NUR/commit/ce93686dc874ac9e17c94d3332ddd8d95bd19b6e) | `` automatic update `` |
| [`2cd6706b`](https://github.com/nix-community/NUR/commit/2cd6706becb7fc6a52f755836bbbd2ef181deea8) | `` automatic update `` |
| [`364e6d42`](https://github.com/nix-community/NUR/commit/364e6d42c4fc455136d90aebd28f0d36b2ed06fc) | `` automatic update `` |
| [`bde57d7e`](https://github.com/nix-community/NUR/commit/bde57d7e3083eb949de430e99c9e63e88aac4a2f) | `` automatic update `` |
| [`e14b7740`](https://github.com/nix-community/NUR/commit/e14b77401d63ba75aa9523f7ad9d327ee5085479) | `` automatic update `` |
| [`2852283c`](https://github.com/nix-community/NUR/commit/2852283c5f07fdb12fa595d0d2d5fa27d8557586) | `` automatic update `` |
| [`9a9be0de`](https://github.com/nix-community/NUR/commit/9a9be0de4ef24fdc32f59b1806bcf33b02199de6) | `` automatic update `` |
| [`88a64969`](https://github.com/nix-community/NUR/commit/88a6496906d4911b1376f11d8bd2a56cea8e181e) | `` automatic update `` |
| [`7f1aa252`](https://github.com/nix-community/NUR/commit/7f1aa252fe8326024a2c53dcbc044a26e128cd2d) | `` automatic update `` |
| [`11a6b708`](https://github.com/nix-community/NUR/commit/11a6b708e5b63ebcf5971789a770b95794b37679) | `` automatic update `` |
| [`5761cc49`](https://github.com/nix-community/NUR/commit/5761cc492e2462b8bb848a7784e4b0c40dde081d) | `` automatic update `` |
| [`42ab0f7e`](https://github.com/nix-community/NUR/commit/42ab0f7e3ccf462cd674e7349772ec4c4c480238) | `` automatic update `` |
| [`3dcc22ab`](https://github.com/nix-community/NUR/commit/3dcc22ab64bd10e99305e7e28c0e44e51a19455c) | `` automatic update `` |
| [`36249d39`](https://github.com/nix-community/NUR/commit/36249d390635b1363a700a29d912dbc2ba1ba45f) | `` automatic update `` |
| [`12c2a661`](https://github.com/nix-community/NUR/commit/12c2a661c3f4663c17cd0d948c2d7c085a0f1d31) | `` automatic update `` |
| [`e2571627`](https://github.com/nix-community/NUR/commit/e25716275afdacc223ec13a487331cd7f131b0dd) | `` automatic update `` |
| [`2acc78d3`](https://github.com/nix-community/NUR/commit/2acc78d309ac9d348c1665206016daeff72ea07f) | `` automatic update `` |
| [`3c9e1dcc`](https://github.com/nix-community/NUR/commit/3c9e1dcc6c5963e19380e26f6b1a3a96f42da70c) | `` automatic update `` |
| [`afeea0c0`](https://github.com/nix-community/NUR/commit/afeea0c0f88ecd473baf3f10579ea7835dec724c) | `` automatic update `` |
| [`265278db`](https://github.com/nix-community/NUR/commit/265278dbbf3c45d56796be81c1305b78c9978b8a) | `` automatic update `` |
| [`8eaf6595`](https://github.com/nix-community/NUR/commit/8eaf6595fc3c0681509a33ed08f74cbf1438e8ae) | `` automatic update `` |
| [`9593bb9b`](https://github.com/nix-community/NUR/commit/9593bb9bb0b60b8e9023587386bd32743072ac68) | `` automatic update `` |
| [`03f67bd9`](https://github.com/nix-community/NUR/commit/03f67bd929bf306ffeb389cabe00acc7d437cdd2) | `` automatic update `` |
| [`6566d9cb`](https://github.com/nix-community/NUR/commit/6566d9cb63d2abad2bf136e60e0425ba6caa37b6) | `` automatic update `` |
| [`519e3185`](https://github.com/nix-community/NUR/commit/519e3185add56438a31c983a6c5e5c1814c599c3) | `` automatic update `` |
| [`6cd4311e`](https://github.com/nix-community/NUR/commit/6cd4311eb516ed36f2021df17deaf9ac28adc493) | `` automatic update `` |
| [`6116bcba`](https://github.com/nix-community/NUR/commit/6116bcba07c8275f1985d6e3ad4e26a9809ef81c) | `` automatic update `` |
| [`191cf30a`](https://github.com/nix-community/NUR/commit/191cf30aac068779bea481f248b3e835d8e44a3b) | `` automatic update `` |
| [`6336b6b0`](https://github.com/nix-community/NUR/commit/6336b6b0dde64f7df5cb891127f327afaadc1302) | `` automatic update `` |
| [`123132fe`](https://github.com/nix-community/NUR/commit/123132fea68f7da6d4e9d48bdc95d0432a9c5bf9) | `` automatic update `` |
| [`fc1f2f48`](https://github.com/nix-community/NUR/commit/fc1f2f48b3246452bad5257fcad6e4eab81d260d) | `` automatic update `` |
| [`02c30cd3`](https://github.com/nix-community/NUR/commit/02c30cd30b571324160db7fe943acfb88668a722) | `` automatic update `` |
| [`053c99a2`](https://github.com/nix-community/NUR/commit/053c99a2832f8488236047ec5157477c43fb88c0) | `` automatic update `` |
| [`036ab649`](https://github.com/nix-community/NUR/commit/036ab649dd418880f71e1e9c97bf7888f56435b5) | `` automatic update `` |
| [`074bfd61`](https://github.com/nix-community/NUR/commit/074bfd61448a00b13f6c62b81d1c2ab3d659c7a6) | `` automatic update `` |
| [`866b527f`](https://github.com/nix-community/NUR/commit/866b527f4c31601ed379d1c39e9572270e09c758) | `` automatic update `` |
| [`f6744687`](https://github.com/nix-community/NUR/commit/f6744687a0393402ec5faada9e53a02901fe069f) | `` automatic update `` |
| [`6d20531d`](https://github.com/nix-community/NUR/commit/6d20531df418598064b91e5e2153487597a04bac) | `` automatic update `` |
| [`b4d3b345`](https://github.com/nix-community/NUR/commit/b4d3b34569a8f2b38bb68272637f2eb9bbe2e31d) | `` automatic update `` |
| [`08ec80e2`](https://github.com/nix-community/NUR/commit/08ec80e24e36fec0c65db08dbeea4439c7672fcd) | `` automatic update `` |
| [`da2d1078`](https://github.com/nix-community/NUR/commit/da2d107831df50c8935dfb08999adf06834bea19) | `` automatic update `` |
| [`f662327f`](https://github.com/nix-community/NUR/commit/f662327f8e3ca15c7e38dec01a1468b2e2fbcffa) | `` automatic update `` |
| [`5818b009`](https://github.com/nix-community/NUR/commit/5818b009f45ed707da85db017fc464aa087138e9) | `` automatic update `` |
| [`f4318c26`](https://github.com/nix-community/NUR/commit/f4318c2621d55b05ce2787a2645053082dfe340c) | `` automatic update `` |
| [`ac49e0ea`](https://github.com/nix-community/NUR/commit/ac49e0ea429f347980474f438416a4a049d5ef48) | `` automatic update `` |
| [`8ed7fe6c`](https://github.com/nix-community/NUR/commit/8ed7fe6c934eb518ac7078bba1e8f1a2866f4d64) | `` automatic update `` |
| [`d3a19e6a`](https://github.com/nix-community/NUR/commit/d3a19e6ae124536bca96f054cff20d21a0fba8c9) | `` automatic update `` |
| [`31286f03`](https://github.com/nix-community/NUR/commit/31286f039fde1c3f9af56c50195f5bfbc87ee1c0) | `` automatic update `` |
| [`9425d593`](https://github.com/nix-community/NUR/commit/9425d59324d5d549b179c3b94e2e3dec55c20c3a) | `` automatic update `` |
| [`dea7b6a5`](https://github.com/nix-community/NUR/commit/dea7b6a587fd591178d64dc98659edca701394c8) | `` automatic update `` |
| [`38a400bd`](https://github.com/nix-community/NUR/commit/38a400bdf1c847cb7b7ff0fc9c13492e6dfd2708) | `` automatic update `` |
| [`a19283a3`](https://github.com/nix-community/NUR/commit/a19283a32023989190eb078cf498a8656bde0101) | `` automatic update `` |
| [`5c2a7fb3`](https://github.com/nix-community/NUR/commit/5c2a7fb3c0608e1b89b5fd523000dcc6b55510aa) | `` automatic update `` |
| [`056bdad4`](https://github.com/nix-community/NUR/commit/056bdad4c92b9051f86b27d6853eb3db16eec273) | `` automatic update `` |
| [`06557d48`](https://github.com/nix-community/NUR/commit/06557d484099afc6dc70413d5faf63a792220d4c) | `` automatic update `` |
| [`01c737a9`](https://github.com/nix-community/NUR/commit/01c737a9f24aa94949bad48379de20e601c4fe15) | `` automatic update `` |
| [`d16468a8`](https://github.com/nix-community/NUR/commit/d16468a8fc6ea13c030349f293e5958adc0e4a54) | `` automatic update `` |
| [`6b077c8e`](https://github.com/nix-community/NUR/commit/6b077c8e58ecd06f156a1add6ac0bd88165c9aab) | `` automatic update `` |
| [`95a0e6e9`](https://github.com/nix-community/NUR/commit/95a0e6e9948e39883c216adeacc4815236833fed) | `` automatic update `` |
| [`23f68684`](https://github.com/nix-community/NUR/commit/23f6868483f836ab82718286fe481109fda91b62) | `` automatic update `` |
| [`79b18f37`](https://github.com/nix-community/NUR/commit/79b18f376d0b4e0ad866afce09e197b62be93004) | `` automatic update `` |
| [`1700ffa5`](https://github.com/nix-community/NUR/commit/1700ffa56e4be50857d26834f361a6230af32add) | `` automatic update `` |
| [`324ad0be`](https://github.com/nix-community/NUR/commit/324ad0be4c9e41942b41136c6acff0e9535253e3) | `` automatic update `` |
| [`2cc4abc1`](https://github.com/nix-community/NUR/commit/2cc4abc1e50f98dcddb30a42ab9faebff599eb47) | `` automatic update `` |
| [`a5d60038`](https://github.com/nix-community/NUR/commit/a5d600380e7e97b5bc833b1841c4c35add894dcb) | `` automatic update `` |
| [`d1620b57`](https://github.com/nix-community/NUR/commit/d1620b57ed0b1752a5f91479a477b54f65c35c78) | `` automatic update `` |
| [`f0d92d27`](https://github.com/nix-community/NUR/commit/f0d92d2737c97b37804ca485d10148ee9abccf69) | `` automatic update `` |
| [`f42bcbab`](https://github.com/nix-community/NUR/commit/f42bcbabc670b834e8036df2d9542c9b277d9458) | `` automatic update `` |
| [`428ed787`](https://github.com/nix-community/NUR/commit/428ed7870c61b0ed6764af9970f6cdefbca9bb1c) | `` automatic update `` |
| [`c77ef1d5`](https://github.com/nix-community/NUR/commit/c77ef1d5c95da65fc1e263c31af29ca62d5309ab) | `` automatic update `` |
| [`75eaaade`](https://github.com/nix-community/NUR/commit/75eaaade3d6923aba0ce92fd06b3fc070742b759) | `` automatic update `` |
| [`acf4c84f`](https://github.com/nix-community/NUR/commit/acf4c84f63f71524dab80877be205190859e749a) | `` automatic update `` |
| [`de338e0f`](https://github.com/nix-community/NUR/commit/de338e0fd64c901e3d343cd79abc2298e8e5b6f3) | `` automatic update `` |
| [`b959a994`](https://github.com/nix-community/NUR/commit/b959a9942aa3aa1ac4f175f72a293f7148611353) | `` automatic update `` |
| [`23bc5141`](https://github.com/nix-community/NUR/commit/23bc51410f94b33af7f032bae4ce24c38ebeeba1) | `` automatic update `` |
| [`89bb6f3f`](https://github.com/nix-community/NUR/commit/89bb6f3f8cbcfddfa61df052549451ea607951bc) | `` automatic update `` |
| [`940a70ca`](https://github.com/nix-community/NUR/commit/940a70ca002a96ddeb74335afbcc3a5389fda6af) | `` automatic update `` |
| [`b62060be`](https://github.com/nix-community/NUR/commit/b62060be2f8e4d62c9ea1306d731f452f861bfe2) | `` automatic update `` |
| [`64dba129`](https://github.com/nix-community/NUR/commit/64dba129a417f506338de690a3e8b8829e7d8df6) | `` automatic update `` |
| [`0e51ca08`](https://github.com/nix-community/NUR/commit/0e51ca08c93d3082a1affc08588a2c89cf701320) | `` automatic update `` |
| [`21d83255`](https://github.com/nix-community/NUR/commit/21d83255a5dac9dd773a5aff647557bdf483a47d) | `` automatic update `` |
| [`2713d3b9`](https://github.com/nix-community/NUR/commit/2713d3b997fc72bcdadacef4972dd10fb6b69aa9) | `` automatic update `` |
| [`09b4b78e`](https://github.com/nix-community/NUR/commit/09b4b78e9a062569dbe905704071a9e4511318af) | `` automatic update `` |