### PR TITLE
chore(flake/chaotic): `1bca2465` -> `45d2aa68`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1701281948,
-        "narHash": "sha256-l18n5B1DG6o63Sugtcdwapp91q2lhUzMjjR4SfuFYBc=",
+        "lastModified": 1701362606,
+        "narHash": "sha256-rtVwebz6emWNGFwD4sQFjbww6HEs6702b/op4IugduU=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "1bca2465c2d9b5c3daa530e0f97761fb60803480",
+        "rev": "45d2aa68e9c0bbb42737c0b645e82b3119b81595",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                 |
| ----------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`45d2aa68`](https://github.com/chaotic-cx/nyx/commit/45d2aa68e9c0bbb42737c0b645e82b3119b81595) | `` docs: play with xl-rem ``            |
| [`ab680e82`](https://github.com/chaotic-cx/nyx/commit/ab680e822cc6d1e589c0daafbe5775e90db4bcce) | `` docs: force lang for highlighting `` |
| [`8c5bf013`](https://github.com/chaotic-cx/nyx/commit/8c5bf0137bcddf45fd028b7637b88d7fac2271cb) | `` docs: add highlights ``              |
| [`2261b3bc`](https://github.com/chaotic-cx/nyx/commit/2261b3bca3666816ce75ca0202801a2a55c22b84) | `` docs: dark theme ``                  |