### PR TITLE
chore(flake/nh): `4298c924` -> `c192a4a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -471,20 +471,16 @@
     },
     "nh": {
       "inputs": {
-        "flake-parts": [
-          "flake-parts"
-        ],
-        "nix-filter": "nix-filter",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1700997049,
-        "narHash": "sha256-2dZsKz6CeKTx76krMp9WV4t+lRs2xDWw0aYNUFgnJKI=",
+        "lastModified": 1701344951,
+        "narHash": "sha256-F0jd1tbSFreIpxNGtqVCxzUHKdSxjKLl2XFZPiz83zY=",
         "owner": "viperML",
         "repo": "nh",
-        "rev": "4298c924bb6b52607207691af30ebeccdbfa359d",
+        "rev": "c192a4a937ed3ab974e14c09b90092b226188281",
         "type": "github"
       },
       "original": {
@@ -511,21 +507,6 @@
       "original": {
         "owner": "misterio77",
         "repo": "nix-colors",
-        "type": "github"
-      }
-    },
-    "nix-filter": {
-      "locked": {
-        "lastModified": 1694857738,
-        "narHash": "sha256-bxxNyLHjhu0N8T3REINXQ2ZkJco0ABFPn6PIe2QUfqo=",
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "rev": "41fd48e00c22b4ced525af521ead8792402de0ea",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "nix-filter",
         "type": "github"
       }
     },


### PR DESCRIPTION
| Commit                                                                                      | Message                                                   |
| ------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`c192a4a9`](https://github.com/viperML/nh/commit/c192a4a937ed3ab974e14c09b90092b226188281) | `` fix ci ``                                              |
| [`fa217e61`](https://github.com/viperML/nh/commit/fa217e618f6a35a0c485b3759427d2cdaf798a98) | `` fix ci ``                                              |
| [`b55bc82a`](https://github.com/viperML/nh/commit/b55bc82aa0839fed2e91e69c1694f8d2a2ef7074) | `` fix ci ``                                              |
| [`a5e270cd`](https://github.com/viperML/nh/commit/a5e270cd03391da1cf61eeedcf1918fc50c95e5a) | `` fix ci ``                                              |
| [`f8270fd4`](https://github.com/viperML/nh/commit/f8270fd4ee7bb39523242fc4116218f77bb35c5a) | `` fix ci ``                                              |
| [`83c5d891`](https://github.com/viperML/nh/commit/83c5d8916de308d484cd7b26451bcb46db4ff903) | `` no checkout in CI ``                                   |
| [`fbbffc79`](https://github.com/viperML/nh/commit/fbbffc7902d179383322644e02d6d0007218c1b8) | `` Update to NixOS 23.11, and try to fix install issue `` |