### PR TITLE
chore(flake/spicetify-nix): `c9b1d9bd` -> `f6c7b0f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -837,11 +837,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701317663,
-        "narHash": "sha256-kkMW1h2LVc8+E0YEupVs4syAdBt+K2WoDIivaKJcX3U=",
+        "lastModified": 1701389028,
+        "narHash": "sha256-rIxZeMQTbxIJzsPNRxdvJxsbAYjpAMnJtQcZ5KQro3c=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "c9b1d9bd7e62609e0ad9f672a2bff8a419bcb02c",
+        "rev": "f6c7b0f6e122bfba280967dfa2af156f55633574",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`f6c7b0f6`](https://github.com/Gerg-L/spicetify-nix/commit/f6c7b0f6e122bfba280967dfa2af156f55633574) | `` big rework in progress ``     |
| [`929a196e`](https://github.com/Gerg-L/spicetify-nix/commit/929a196e565affbda822b2bb9bd09e5099e42cfb) | `` remade repo ``                |
| [`caae7310`](https://github.com/Gerg-L/spicetify-nix/commit/caae7310c895dfd4e69171f99927c6dec015b6fe) | `` CI update 2023-11-30 (#95) `` |