### PR TITLE
chore(flake/master): `54c8a156` -> `d491c9db`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -455,11 +455,11 @@
     },
     "master": {
       "locked": {
-        "lastModified": 1701392950,
-        "narHash": "sha256-jhmBuNeLq5p3VqZj+JC/c1+zHRnKTeMDIUwjlpctlso=",
+        "lastModified": 1701564279,
+        "narHash": "sha256-gVMqvE65WtowNJUkjIJ46zNKeRrbZGlLZYy8p85arko=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "54c8a156500d5c9b44294e1dab9bd930073721fb",
+        "rev": "d491c9dbc4edd30c5f43426cb2d23a3eeca25ec6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| [`97312082`](https://github.com/NixOS/nixpkgs/commit/973120823b5824d426b97a7e9e027191b22f33ac) | `` lib.systems.elaborate: fix passing `rust` (more) (#271707) ``                                        |
| [`0616776a`](https://github.com/NixOS/nixpkgs/commit/0616776a5e4072e9455e3966d1fce58feefa7a58) | `` fastgron: 0.6.4 -> 0.6.5 ``                                                                          |
| [`60057270`](https://github.com/NixOS/nixpkgs/commit/600572706589601e291abd818009c0c4a623a523) | `` mlt: 7.20.0 -> 7.22.0 (#270928) ``                                                                   |
| [`1b45f71c`](https://github.com/NixOS/nixpkgs/commit/1b45f71c2efb34ab9db46e4da6bfaf24a3cf6935) | `` elixir: enable Erlang compiler option - deterministic ``                                             |
| [`37445f3c`](https://github.com/NixOS/nixpkgs/commit/37445f3c5c1015a4f8019900e9a23528f7c6bd2a) | `` lib/customisation: fix callPackage error messages ``                                                 |
| [`fba1d733`](https://github.com/NixOS/nixpkgs/commit/fba1d73326c8c355ae6a4ab4ea8559a342d17dcc) | `` exploitdb: 2023-12-01 -> 2023-12-02 ``                                                               |
| [`57bfbc78`](https://github.com/NixOS/nixpkgs/commit/57bfbc781c39b51aa440f0d1aebead78eab9bdf4) | `` nixos/home-assistant: fix error when switching between writable and none writable lovelace config `` |
| [`13a5743c`](https://github.com/NixOS/nixpkgs/commit/13a5743c442d840284e58cb56958e462671881a4) | `` workflows/periodic-merge: allow manual dispatch ``                                                   |
| [`c0b23268`](https://github.com/NixOS/nixpkgs/commit/c0b2326892f6f2468522b2062745e8d1cd1fae09) | `` libnss-mysql: add test ``                                                                            |
| [`ac3352a6`](https://github.com/NixOS/nixpkgs/commit/ac3352a65c67adcd2d75d461b31ba02234394180) | `` pam_mysql: add test ``                                                                               |
| [`dffba140`](https://github.com/NixOS/nixpkgs/commit/dffba14043168d767a12ff86c39464b8503d3d29) | `` nixos/matrix-appservice-irc: fix syscall filter ``                                                   |
| [`37ad50cd`](https://github.com/NixOS/nixpkgs/commit/37ad50cdcf38b837929e914b9c2989606ef65917) | `` awscli2: sphinx disable test that is flaky on hydra ``                                               |
| [`df0c3c57`](https://github.com/NixOS/nixpkgs/commit/df0c3c570c20eb9aa0075dbf973a731c2fa31bcc) | `` fsautocomplete: fix build ``                                                                         |
| [`22b5fecd`](https://github.com/NixOS/nixpkgs/commit/22b5fecd98c2af980c787e03ea98ead70f7d5a01) | `` nixos/tests/auth-mysql: fix test ``                                                                  |
| [`5776e40f`](https://github.com/NixOS/nixpkgs/commit/5776e40f8b455972b9f92233180fd25fd7f69aa8) | `` python311Packages.zope-configuration: fix eval without aliases ``                                    |
| [`c36d884e`](https://github.com/NixOS/nixpkgs/commit/c36d884e6aafc55f1ce06cfef41f702cb16ece6f) | `` osinfo-db-tools: 1.10.0 -> 1.11.0 ``                                                                 |
| [`6f33e6e4`](https://github.com/NixOS/nixpkgs/commit/6f33e6e4ab2e47124e8c1160c574f9c60c40a523) | `` nixos/preload: fix log permission ``                                                                 |
| [`298f98bc`](https://github.com/NixOS/nixpkgs/commit/298f98bcd8247e143fe136f280848c48df6d830a) | `` maintainers: add alex-fu27 ``                                                                        |
| [`6a5fcd06`](https://github.com/NixOS/nixpkgs/commit/6a5fcd063ecc08198e8a634a390474ea19516573) | `` python310Packages.fschat: 0.2.32 -> 0.2.33 ``                                                        |
| [`28517a7a`](https://github.com/NixOS/nixpkgs/commit/28517a7a6b8e0c7803a2fe18ccd3be574d65a43e) | `` python310Packages.faster-whisper: 0.9.0 -> 0.10.0 ``                                                 |
| [`3aa4ed09`](https://github.com/NixOS/nixpkgs/commit/3aa4ed098504c16c7a6fc801dc9612253b4f72c6) | `` nixos/tests/installer: init clevis tests ``                                                          |
| [`27493b4d`](https://github.com/NixOS/nixpkgs/commit/27493b4d49b6d92f4baa049424cbb2fa48b4c948) | `` nixos/clevis: init ``                                                                                |
| [`fefcf28f`](https://github.com/NixOS/nixpkgs/commit/fefcf28f8260da8be4f344e2a26f14881798a3c5) | `` libadwaita: 1.4.0 -> 1.4.1 ``                                                                        |
| [`c1567ae4`](https://github.com/NixOS/nixpkgs/commit/c1567ae44fbfa593a0bd4c0b7b639eada51db562) | `` argyllcms: 3.0.2 -> 3.1.0 ``                                                                         |
| [`81b362f8`](https://github.com/NixOS/nixpkgs/commit/81b362f89ae04c4696f0ddabc268efe0243794cb) | `` vimPlugins.nvim-treesitter: update grammars ``                                                       |
| [`8293f1a4`](https://github.com/NixOS/nixpkgs/commit/8293f1a4bc7c47cb4cafa88afbb30b3e05310055) | `` vimPlugins: update on 2023-12-02 ``                                                                  |
| [`d00d51e4`](https://github.com/NixOS/nixpkgs/commit/d00d51e45129abc69a22ffdb733cb630f3ee3765) | `` luaPackages.luasnip: init at 2.1.1-1 ``                                                              |
| [`4428fe8f`](https://github.com/NixOS/nixpkgs/commit/4428fe8f0cd8af22fd97efac66127472648e9002) | `` xfce.xfce4-settings: 4.18.3 -> 4.18.4 ``                                                             |
| [`02c2d83d`](https://github.com/NixOS/nixpkgs/commit/02c2d83dc81dee9a99c90db8d6847b57d2400932) | `` xfce.xfce4-power-manager: 4.18.2 -> 4.18.3 ``                                                        |
| [`23075760`](https://github.com/NixOS/nixpkgs/commit/230757608b2eb004b1a8a207c219337bdecd5c51) | `` xfce.tumbler: 4.18.1 -> 4.18.2 ``                                                                    |
| [`c31bc86d`](https://github.com/NixOS/nixpkgs/commit/c31bc86da8753de6575603385dd2e260af056f8e) | `` xfce.parole: 4.18.0 -> 4.18.1 ``                                                                     |
| [`3c9e42e3`](https://github.com/NixOS/nixpkgs/commit/3c9e42e35172ea77d19e95e7a2e14215cc71c001) | `` recoll: fix changelog ``                                                                             |
| [`7084473d`](https://github.com/NixOS/nixpkgs/commit/7084473d63a718467f4e09a491551c399f3874b5) | `` recoll: 1.36.0 -> 1.36.2 ``                                                                          |
| [`18f48f28`](https://github.com/NixOS/nixpkgs/commit/18f48f2852c49e6f9842aca4f8d4f783c37c6228) | `` binocle: 0.3.1 -> 0.3.2 ``                                                                           |
| [`5b7ae356`](https://github.com/NixOS/nixpkgs/commit/5b7ae3565de3cf15882c1304d0dd0771004382c8) | `` sudo: fix meta license information (#269788) ``                                                      |
| [`4ff7f410`](https://github.com/NixOS/nixpkgs/commit/4ff7f410735f9d89f6b35be17a1b994f4eba3422) | `` tiledb: 2.18.0 -> 2.18.2 ``                                                                          |
| [`f6972351`](https://github.com/NixOS/nixpkgs/commit/f697235162fd6a63de10fa440d5a53b75b2bdb07) | `` etcd_3_4: 3.4.27 -> 3.4.28 ``                                                                        |
| [`5b9f691f`](https://github.com/NixOS/nixpkgs/commit/5b9f691ffe6cc373f581dbdaac4b0a1a074c09b9) | `` python310Packages.fontawesomefree: 6.4.2 -> 6.5.1 ``                                                 |
| [`190d2619`](https://github.com/NixOS/nixpkgs/commit/190d261984d508c694ac2fcca00c58009ecb6069) | `` etcd_3_5: 3.5.9 -> 3.5.10 ``                                                                         |
| [`853e3d5a`](https://github.com/NixOS/nixpkgs/commit/853e3d5a36a010490289664cc9c68a9dc6582b67) | `` amoeba: fix build ``                                                                                 |
| [`ee0dfa51`](https://github.com/NixOS/nixpkgs/commit/ee0dfa51926c06dfc1df33e650318264b97f1aa0) | `` librewolf: 120.0-1 -> 120.0.1-1 ``                                                                   |
| [`90b6a020`](https://github.com/NixOS/nixpkgs/commit/90b6a0206e93e9773c55963f1614b792ba564008) | `` pgpool: 4.4.4 -> 4.4.5 ``                                                                            |
| [`5fe77546`](https://github.com/NixOS/nixpkgs/commit/5fe775466225dd7fd9d99223be806fc03cdfc4c8) | `` twilio-cli: 5.16.2 -> 5.16.3 ``                                                                      |
| [`8339ce0e`](https://github.com/NixOS/nixpkgs/commit/8339ce0e0f64fffac08b35c0d74c0eab5112d468) | `` flow: 0.222.0 -> 0.223.2 ``                                                                          |
| [`4c17c83b`](https://github.com/NixOS/nixpkgs/commit/4c17c83b2722524bc868239f085b5c69053ae18c) | `` buildkit: 0.12.3 -> 0.12.4 ``                                                                        |
| [`9450e16a`](https://github.com/NixOS/nixpkgs/commit/9450e16ad12586885b2ac3836c83d384aebac426) | `` Revert "patchutils: add man pages" ``                                                                |
| [`ac827004`](https://github.com/NixOS/nixpkgs/commit/ac82700414f1c2877cc33d11bbc39d309295e367) | `` update-python-libraries: quiet nix stderr output ``                                                  |
| [`50311a8d`](https://github.com/NixOS/nixpkgs/commit/50311a8d071c7f741f9a4d12736a8025b962ec64) | `` update-python-libraries: format with black/isort ``                                                  |
| [`180ccef7`](https://github.com/NixOS/nixpkgs/commit/180ccef717a349e70479325dc56c7ee628b4ccf6) | `` update-python-libraries: add package changelog to commit message ``                                  |
| [`929da502`](https://github.com/NixOS/nixpkgs/commit/929da5021636f123c836c8091f009ba64b81ed98) | `` update-python-libraries: don't update packages with cargoDeps ``                                     |
| [`db19573e`](https://github.com/NixOS/nixpkgs/commit/db19573eeb621101e5cc52c90dd91f1967f894a2) | `` kodiPackages.pvr-hts: 20.6.4 -> 20.6.5 ``                                                            |
| [`4fa591f8`](https://github.com/NixOS/nixpkgs/commit/4fa591f807070a87734e83d6136491243f342df8) | `` tests.fetchtorrent: add watched-cd license ``                                                        |
| [`9a16042c`](https://github.com/NixOS/nixpkgs/commit/9a16042cc362ee729922651c444b94110c16760d) | `` fetchtorrent: add `meta` support ``                                                                  |
| [`ea2ee49a`](https://github.com/NixOS/nixpkgs/commit/ea2ee49a5af251ae6e3a15f545e3879cc7ac41f1) | `` python310Packages.click-help-colors: 0.9.2 -> 0.9.4 ``                                               |
| [`d21afee8`](https://github.com/NixOS/nixpkgs/commit/d21afee8d0de0944074647c33f6d886eca2a602a) | `` openttd-jgrpp: 0.55.3 -> 0.56.0 ``                                                                   |
| [`7723c4da`](https://github.com/NixOS/nixpkgs/commit/7723c4da3ba6ab1ce3e3e36c41c4bd5b749a0058) | `` python310Packages.backports-entry-points-selectable: 1.2.0 -> 1.3.0 ``                               |
| [`3aa6d61a`](https://github.com/NixOS/nixpkgs/commit/3aa6d61a2b025a2f76e354f52529280999813618) | `` python310Packages.blockfrost-python: 0.5.3 -> 0.6.0 ``                                               |
| [`c2a97510`](https://github.com/NixOS/nixpkgs/commit/c2a97510541e6f5ab26bb70f0895e44b0755e2b9) | `` openapi-generator-cli: 7.0.1 -> 7.1.0 ``                                                             |
| [`c70d0c8c`](https://github.com/NixOS/nixpkgs/commit/c70d0c8ce362a0671a2bbbcd97c719589b6dcb14) | `` gitea: 1.20.5 -> 1.21.1 ``                                                                           |
| [`3bf6d6d2`](https://github.com/NixOS/nixpkgs/commit/3bf6d6d251f4df59690b6ec7174a90789ec3717b) | `` documentation-highlighter: 9.12.0 -> 11.9.0, add new langs ``                                        |
| [`3e3b6b14`](https://github.com/NixOS/nixpkgs/commit/3e3b6b14950a50949803378869dde692eef118f2) | `` python311Packages.flask-themes2: 1.0.0 -> 1.0.1 ``                                                   |
| [`7e0464aa`](https://github.com/NixOS/nixpkgs/commit/7e0464aa5062265b6e46c676dcd6afe95390a2ad) | `` spandsp: fix function argument name ``                                                               |
| [`62dbf14a`](https://github.com/NixOS/nixpkgs/commit/62dbf14a306c9feb008ca6cd561cc1669fb870f2) | `` gcc: put environment variables in drvAttrs.env ``                                                    |
| [`246a164a`](https://github.com/NixOS/nixpkgs/commit/246a164a436043e8ad572ef26283c5604828d48f) | `` bruno: 1.2.0 -> 1.3.0 ``                                                                             |
| [`56de34a2`](https://github.com/NixOS/nixpkgs/commit/56de34a2b8229de9395228a70993618a06466b3e) | `` bosh-cli: 7.4.1 -> 7.5.0 ``                                                                          |
| [`d4693215`](https://github.com/NixOS/nixpkgs/commit/d4693215900301172d513b6d556155b20c1eae23) | `` itd: update upstream URL ``                                                                          |
| [`b5ded105`](https://github.com/NixOS/nixpkgs/commit/b5ded105970c1ff3adccd45c19443202f62d4720) | `` palemoon-bin: Fix WebGL support ``                                                                   |
| [`bd6bc361`](https://github.com/NixOS/nixpkgs/commit/bd6bc36101404329ba7f500e94e56b9cd65b82bb) | `` gg-scm: 1.3.0 -> 1.3.1 ``                                                                            |
| [`a5eac6f9`](https://github.com/NixOS/nixpkgs/commit/a5eac6f91ac778a47d078e9707f75333d82f9865) | `` python311Packages.amazon-ion: 0.10.0 -> 0.11.2 ``                                                    |
| [`e3bbde81`](https://github.com/NixOS/nixpkgs/commit/e3bbde81e79652f77b63a5d64bb845b732349993) | `` eks-node-viewer: 0.5.0 -> 0.6.0 ``                                                                   |
| [`2274d331`](https://github.com/NixOS/nixpkgs/commit/2274d331583bedccdbe56c4f11090cb8973d72ff) | `` flix: 0.41.0 -> 0.42.0 ``                                                                            |
| [`ad4d7391`](https://github.com/NixOS/nixpkgs/commit/ad4d73919b67ec8a66ea5b21e2fe714f828c9638) | `` polybar: 3.7.0 -> 3.7.1 ``                                                                           |
| [`c1044955`](https://github.com/NixOS/nixpkgs/commit/c104495534807f6c47d4f1323ef510f6a80e44c8) | `` gojq: 0.12.13 -> 0.12.14 ``                                                                          |
| [`4ce29f6c`](https://github.com/NixOS/nixpkgs/commit/4ce29f6c8baa12a1c941249ad48d022c8aabe6f3) | `` inkscape: 1.3.1 → 1.3.2 ``                                                                           |
| [`339a90f3`](https://github.com/NixOS/nixpkgs/commit/339a90f30bf2777229f53ec08777df812a537187) | `` wasmtime: 15.0.0 -> 15.0.1 ``                                                                        |
| [`0940898c`](https://github.com/NixOS/nixpkgs/commit/0940898ca1d29416c903c1253e86c0e7ede6ea3d) | `` dnscontrol: 4.6.1 -> 4.6.2 ``                                                                        |
| [`6b60e11e`](https://github.com/NixOS/nixpkgs/commit/6b60e11e69cf3085de541f423c0430fc30df5b79) | `` lscolors: 0.15.0 -> 0.16.0 ``                                                                        |
| [`c049b6a5`](https://github.com/NixOS/nixpkgs/commit/c049b6a56e8c4cfd3af933fc05d46c9e47b0d9f6) | `` opensearch: 2.11.0 -> 2.11.1 ``                                                                      |
| [`c1f0be03`](https://github.com/NixOS/nixpkgs/commit/c1f0be03736e6d5ab4d19e867e6684686203eee8) | `` nixos/postgresqlBackup: add Scrumplex as maintainer ``                                               |
| [`0aaf428f`](https://github.com/NixOS/nixpkgs/commit/0aaf428fde038183adfb433dbbc8688b5ef0eb6c) | `` nixos/postgresqlBackup: add --rsyncable to compression programs ``                                   |
| [`7c7ba687`](https://github.com/NixOS/nixpkgs/commit/7c7ba6877315b114adb8408cefb75799d88399ae) | `` nheko: Add meta.mainProgram ``                                                                       |
| [`44457922`](https://github.com/NixOS/nixpkgs/commit/44457922aa31516457289559a37204911345a4c5) | `` tart: 2.4.0 -> 2.4.1 ``                                                                              |
| [`ae7f90f1`](https://github.com/NixOS/nixpkgs/commit/ae7f90f1b6263a8263387f1a090812162b2eac3c) | `` frankenphp: 1.0.0-rc.3 -> 1.0.0-rc.4 ``                                                              |
| [`548f98f4`](https://github.com/NixOS/nixpkgs/commit/548f98f4fbf4ff72294cc21ab261f810ca5e5c6e) | `` nixos-render-docs: wrap code in <pre><code>, not <pre> ``                                            |
| [`39946883`](https://github.com/NixOS/nixpkgs/commit/3994688356e7ea9f6eec912a8e550b67d26f8300) | `` phpunit: 10.5.0 -> 10.5.1 ``                                                                         |
| [`b7c363b2`](https://github.com/NixOS/nixpkgs/commit/b7c363b20dbc962b1c762a23b69d098cfd143428) | `` vinegar: init at 1.5.8 ``                                                                            |
| [`229e6eb8`](https://github.com/NixOS/nixpkgs/commit/229e6eb8edb304a8b0e8dec70eaf8a6e9f990020) | `` nixos-render-docs: don't drop code languages anymore ``                                              |
| [`6a0ca85d`](https://github.com/NixOS/nixpkgs/commit/6a0ca85da09be7b58660ed90c2b6d02c5155b9b6) | `` python311Packages.torchmetrics: 1.2.0 -> 1.2.1 ``                                                    |
| [`49a204d4`](https://github.com/NixOS/nixpkgs/commit/49a204d40e716c4dfff411613dad75ebf205b111) | `` spdk: fix python installation prefix ``                                                              |
| [`e763745e`](https://github.com/NixOS/nixpkgs/commit/e763745e5af241b34b0c9bf958dab4f18bdd03a4) | `` ycmd: unstable-2022-08-15 -> unstable-2023-11-06 ``                                                  |
| [`98c619e4`](https://github.com/NixOS/nixpkgs/commit/98c619e4174eef873a0eabbd4d59ea38de53d3da) | `` material-cursors: init at 2023-11-30 ``                                                              |