### PR TITLE
chore(flake/chaotic): `45d2aa68` -> `72d65d0d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1701362606,
-        "narHash": "sha256-rtVwebz6emWNGFwD4sQFjbww6HEs6702b/op4IugduU=",
+        "lastModified": 1701548580,
+        "narHash": "sha256-MWxOBp8lOMHD0omtRB62uTpVL3gemPfq6+Avnx5/9Vc=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "45d2aa68e9c0bbb42737c0b645e82b3119b81595",
+        "rev": "72d65d0d42004971334c3f4c4297d2504e6438a2",
         "type": "github"
       },
       "original": {
@@ -549,12 +549,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701068326,
-        "narHash": "sha256-vmMceA+q6hG1yrjb+MP8T0YFDQIrW3bl45e7z24IEts=",
-        "rev": "8cfef6986adfb599ba379ae53c9f5631ecd2fd9c",
-        "revCount": 553283,
+        "lastModified": 1701253981,
+        "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
+        "rev": "e92039b55bcd58469325ded85d4f58dd5a4eaf58",
+        "revCount": 554114,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.553283%2Brev-8cfef6986adfb599ba379ae53c9f5631ecd2fd9c/018c18d1-b364-7bfd-aced-a123b87538af/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.554114%2Brev-e92039b55bcd58469325ded85d4f58dd5a4eaf58/018c246f-3485-7920-b58c-92909d475b54/source.tar.gz"
       },
       "original": {
         "type": "tarball",


### PR DESCRIPTION
| Commit                                                                                          | Message                                    |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`72d65d0d`](https://github.com/chaotic-cx/nyx/commit/72d65d0d42004971334c3f4c4297d2504e6438a2) | `` linux_cachyos: 6.6.2 -> 6.6.3 (#461) `` |
| [`289e85bc`](https://github.com/chaotic-cx/nyx/commit/289e85bc21519120065d7cf1cb524b5323211838) | `` nixpkgs: bump to 20231202 ``            |