### PR TITLE
chore(flake/nh): `c192a4a9` -> `375c6cf5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701344951,
-        "narHash": "sha256-F0jd1tbSFreIpxNGtqVCxzUHKdSxjKLl2XFZPiz83zY=",
+        "lastModified": 1701522423,
+        "narHash": "sha256-V5TQ/1loQnegDjfLh61DxBWEQZivYEBq2kQpT0fn2cQ=",
         "owner": "viperML",
         "repo": "nh",
-        "rev": "c192a4a937ed3ab974e14c09b90092b226188281",
+        "rev": "375c6cf57de3a839b7937358659bea526da27eae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                      | Message              |
| ------------------------------------------------------------------------------------------- | -------------------- |
| [`375c6cf5`](https://github.com/viperML/nh/commit/375c6cf57de3a839b7937358659bea526da27eae) | `` add dep status `` |
| [`4c35bd8a`](https://github.com/viperML/nh/commit/4c35bd8a23a38fd7b1be63d3c69489e99b76c6dd) | `` Bump all deps ``  |