### PR TITLE
chore(flake/home-manager): `8cedd63e` -> `4a8545f5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -298,11 +298,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700847865,
-        "narHash": "sha256-uWaOIemGl9LF813MW0AEgCBpKwFo2t1Wv3BZc6e5Frw=",
+        "lastModified": 1701433070,
+        "narHash": "sha256-Gf9JStfENaUQ7YWFz3V7x/srIwr4nlnVteqaAxtwpgM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8cedd63eede4c22deb192f1721dd67e7460e1ebe",
+        "rev": "4a8545f5e737a6338814a4676dc8e18c7f43fc57",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                     |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
| [`4a8545f5`](https://github.com/nix-community/home-manager/commit/4a8545f5e737a6338814a4676dc8e18c7f43fc57) | `` swayidle: add systemd suspend to example ``              |
| [`9e869829`](https://github.com/nix-community/home-manager/commit/9e869829c263d611e3ece814ff2b826463833238) | `` swayidle: daemonize swaylock in example configuration `` |
| [`ef908825`](https://github.com/nix-community/home-manager/commit/ef9088253c120d9b4dc26c5e41dd6c3c781ee9f0) | `` Translate using Weblate (Russian) ``                     |
| [`3d154dab`](https://github.com/nix-community/home-manager/commit/3d154dab14aef8fcf510e291030cecc53b02985a) | `` Translate using Weblate (Russian) ``                     |
| [`2a604e61`](https://github.com/nix-community/home-manager/commit/2a604e614f974af7e4f9296f1560ce275d2e3786) | `` Translate using Weblate (Portuguese (Brazil)) ``         |
| [`db1878f0`](https://github.com/nix-community/home-manager/commit/db1878f013b52ba5e4034db7c1b63e8d04173a86) | `` home-manager: add 24.05 as valid state version ``        |
| [`7c97c46d`](https://github.com/nix-community/home-manager/commit/7c97c46dc4f45f2a78df536a6ebe15252831b800) | `` signaturepdf: add service ``                             |
| [`8340c0b4`](https://github.com/nix-community/home-manager/commit/8340c0b4d9986a91ca0ef746637839df99c43d3e) | `` flake.lock: Update ``                                    |
| [`a462e731`](https://github.com/nix-community/home-manager/commit/a462e7315deaa8194b0821f726709bb7e51a850c) | `` yazi: update shell integrations and docs ``              |