### PR TITLE
chore(flake/lanzaboote): `cbafc8f8` -> `5655251a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -392,11 +392,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1700811440,
-        "narHash": "sha256-wrJpW3JCJ9egZpYUMne4c3PFEp+vmkTj5VFpPAT4xdY=",
+        "lastModified": 1701686621,
+        "narHash": "sha256-OAR4jhfldEGuXH8DB9w8YrFLcEsZsApWdYPsmJHwM/E=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "cbafc8f8fe388fba6f2c27224276f5f984f9ae47",
+        "rev": "5655251a38f2a31f26aebae3e0d7fe0f5bd74683",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                 |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`627be839`](https://github.com/nix-community/lanzaboote/commit/627be8398df467de774736c803f56ae2b8da47d9) | `` fix(deps): update rust crate clap to 4.4.10 ``       |
| [`d48eac71`](https://github.com/nix-community/lanzaboote/commit/d48eac71a41a517843e960a1ba4c22b67960ac34) | `` flake: remove moving away the `unsupportedChecks` `` |