### PR TITLE
chore(flake/master): `d491c9db` -> `3ff9ed03`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -455,11 +455,11 @@
     },
     "master": {
       "locked": {
-        "lastModified": 1701564279,
-        "narHash": "sha256-gVMqvE65WtowNJUkjIJ46zNKeRrbZGlLZYy8p85arko=",
+        "lastModified": 1701593635,
+        "narHash": "sha256-KS9AXYea70aL2FdzYmRtRitdbdurtvmhasOwoy+DbGU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d491c9dbc4edd30c5f43426cb2d23a3eeca25ec6",
+        "rev": "3ff9ed03fb1e225529d72d7bf29aacb2ae9736c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`ec04772e`](https://github.com/NixOS/nixpkgs/commit/ec04772e7516b6d58d98b491e68b329b7558b14d) | `` python310Packages.grpcio-channelz: 1.59.2 -> 1.59.3 ``                         |
| [`d1109f39`](https://github.com/NixOS/nixpkgs/commit/d1109f39a543c879e14c4d210dfa536ab34523de) | `` python310Packages.grpcio-health-checking: 1.59.0 -> 1.59.3 ``                  |
| [`a7788681`](https://github.com/NixOS/nixpkgs/commit/a7788681eb86fef5f84fd620753c9f28b0b3ea17) | `` python310Packages.grpcio-reflection: 1.59.2 -> 1.59.3 ``                       |
| [`e61cf890`](https://github.com/NixOS/nixpkgs/commit/e61cf890d648e29e39090fcb8ae5fc9b97f46096) | `` yosys: make building with Python binding the default ``                        |
| [`e55ea616`](https://github.com/NixOS/nixpkgs/commit/e55ea6167fffa5303c8baae32bcf78349189325b) | `` yosys: add option to build with Python binding ``                              |
| [`a3006991`](https://github.com/NixOS/nixpkgs/commit/a3006991c3bda39bd1493b370c117be07fd7b078) | `` lib/customisation: fix eval error (attribute "levenshtein" missing) ``         |
| [`52e68919`](https://github.com/NixOS/nixpkgs/commit/52e689197f1e59e2612eadab637937b3167dc869) | `` python310Packages.gptcache: 0.1.42 -> 0.1.43 ``                                |
| [`627de16d`](https://github.com/NixOS/nixpkgs/commit/627de16d7d020d168bcc84c6fd64a8c4a9f3b4ae) | `` python310Packages.google-cloud-runtimeconfig: 0.33.2 -> 0.33.3 ``              |
| [`f2a7764c`](https://github.com/NixOS/nixpkgs/commit/f2a7764cab5799d2a68e6771679780303b5b3afa) | `` gcc{6,7,8,9,10,11}: fix cross-compiler build on x86_64-darwin ``               |
| [`4a538d6b`](https://github.com/NixOS/nixpkgs/commit/4a538d6b3df931c87fb38b14fa1d0038d39f45e5) | `` gcc11: mark as bad on aarch64-darwin when building a cross-compiler ``         |
| [`fe27958a`](https://github.com/NixOS/nixpkgs/commit/fe27958aed65ac531732544dd6a8b9c20da4d813) | `` gcc{6,7,8,9}: use target bintools on Darwin ``                                 |
| [`db208319`](https://github.com/NixOS/nixpkgs/commit/db20831951cebae92b8e630b61bf5ca3c1bdad11) | `` gcc11: drop AVR patch on Darwin (no longer needed) ``                          |
| [`1fde2844`](https://github.com/NixOS/nixpkgs/commit/1fde2844f053ce74ca0b646e7a8524b212b6ed9f) | `` python311Packages.auth0-python: 4.6.0 -> 4.6.1 ``                              |
| [`455fee89`](https://github.com/NixOS/nixpkgs/commit/455fee89c0f5b5730a86a15d84e0508fa5edd15e) | `` python310Packages.garminconnect: modernize ``                                  |
| [`c5df6668`](https://github.com/NixOS/nixpkgs/commit/c5df6668dbd6e339d5a23114ad41d7b2bbda86aa) | `` runelite: fix GPU error (missing libGL.so.1) ``                                |
| [`819d0d6c`](https://github.com/NixOS/nixpkgs/commit/819d0d6cc8e580f94eb9be10b59007317f70891b) | `` agdsn-zsh-config: 0.8.0 -> 0.9.0 ``                                            |
| [`43d0502b`](https://github.com/NixOS/nixpkgs/commit/43d0502b96b6ad2af5cb04ade44734462b70afd1) | `` revup: init at 0.2.1 ``                                                        |
| [`08daa5a2`](https://github.com/NixOS/nixpkgs/commit/08daa5a225b175ba2e50c7b0b99b144e2e990b1f) | `` python310Packages.geopy: 2.4.0 -> 2.4.1 ``                                     |
| [`69fb19a7`](https://github.com/NixOS/nixpkgs/commit/69fb19a73a74988fae7dcae55936b54ef30f30ff) | `` python311Packages.pygls: 1.2.0 -> 1.2.1 ``                                     |
| [`fe8dd76a`](https://github.com/NixOS/nixpkgs/commit/fe8dd76ae036fd5ab5526f2fc933ae2e255877d2) | `` python310Packages.garminconnect: 0.2.9 -> 0.2.11 ``                            |
| [`996367d7`](https://github.com/NixOS/nixpkgs/commit/996367d7eb9fee7b187e3ec068fd3a8bdd4a5592) | `` oauth2c: 1.12.1 -> 1.12.2 ``                                                   |
| [`aa15f506`](https://github.com/NixOS/nixpkgs/commit/aa15f5066d695de4c4027bd8bdcf4cedcf58d058) | `` treewide: use kde mirror everywhere, don't use pname in download urls ``       |
| [`e7d25259`](https://github.com/NixOS/nixpkgs/commit/e7d25259a40287c5bb9a5d236a225c47bb523eda) | `` yuzu: 1611 -> 1639, yuzu-ea: 3966 -> 4003 ``                                   |
| [`96f38588`](https://github.com/NixOS/nixpkgs/commit/96f38588562ff2cf9b0d0333c536bcf87fc7abc8) | `` cargo-update: 13.2.0 -> 13.3.0 ``                                              |
| [`5ec7d5d5`](https://github.com/NixOS/nixpkgs/commit/5ec7d5d574652337423fe9151c29df93451a689a) | `` streamlit: 1.28.2 -> 1.29.0 ``                                                 |
| [`a406725e`](https://github.com/NixOS/nixpkgs/commit/a406725e5925e4eb4853f4f877de35e199b0d371) | `` qrcode: update latest rev to fix compiler errors ``                            |
| [`ecdfa2f4`](https://github.com/NixOS/nixpkgs/commit/ecdfa2f4c7f3374ad695298258e42e85d2bc95b3) | `` luddite: 1.0.2 -> 1.0.3 ``                                                     |
| [`64ceb7ef`](https://github.com/NixOS/nixpkgs/commit/64ceb7ef3fb42c89c83fb0496d5942cd69f2868d) | `` python311Packages.es-client: 8.10.3 -> 8.11.0 ``                               |
| [`74065b18`](https://github.com/NixOS/nixpkgs/commit/74065b1858490a3fc0d2b80033d0a74996844c3e) | `` nixos/rl-2405: Mention Cinnamon 6.0 update ``                                  |
| [`9af32e98`](https://github.com/NixOS/nixpkgs/commit/9af32e98fdb871eed0e8bb9e637383e1afa6454b) | `` wash-cli: init at 0.24.0 ``                                                    |
| [`9247bdfc`](https://github.com/NixOS/nixpkgs/commit/9247bdfce74a8e6b22892c1ad3b3ecf263a727a7) | `` nixos/cinnamon: switch to xdg.portal.configPackages ``                         |
| [`b7fa2ea5`](https://github.com/NixOS/nixpkgs/commit/b7fa2ea58bf49a4cd879ccdd7b58b2727c4784c3) | `` nixosTests.cinnamon-wayland: init ``                                           |
| [`8849d217`](https://github.com/NixOS/nixpkgs/commit/8849d2174e1f34875ee72e85530177286448b801) | `` lightdm-slick-greeter: 1.8.2 -> 2.0.0 ``                                       |
| [`a0822e5c`](https://github.com/NixOS/nixpkgs/commit/a0822e5c0a4ea2aea3995bd94448a4ab597218ee) | `` cinnamon.xviewer: 3.4.1 -> 3.4.2 ``                                            |
| [`75ea2708`](https://github.com/NixOS/nixpkgs/commit/75ea2708c407543df77808a7b07b9863e8cbeecc) | `` cinnamon.xapp: 2.6.1 -> 2.8.0 ``                                               |
| [`7abff913`](https://github.com/NixOS/nixpkgs/commit/7abff9134107ae982936cc446fd3d9fcca6c7fad) | `` cinnamon.pix: 3.0.2 -> 3.2.0 ``                                                |
| [`ade3f1a0`](https://github.com/NixOS/nixpkgs/commit/ade3f1a0309ab7e2e04ae3ed364aa1e06d5dff57) | `` cinnamon.nemo-extensions: 5.8.0 -> 6.0.0 ``                                    |
| [`a72559cd`](https://github.com/NixOS/nixpkgs/commit/a72559cdbe7ddc556341e50c14b202c7dbc9c1d0) | `` cinnamon.nemo: 5.8.5 -> 6.0.0 ``                                               |
| [`08b6183f`](https://github.com/NixOS/nixpkgs/commit/08b6183fb7d488432812d7a6ef41ddf5692e01b2) | `` cinnamon.muffin: 5.8.1 -> 6.0.0 ``                                             |
| [`4253d19b`](https://github.com/NixOS/nixpkgs/commit/4253d19b6431bfe5ce0b41cffe09342a18c8fd47) | `` cinnamon.cjs: 5.8.0 -> 6.0.0 ``                                                |
| [`4155ccd1`](https://github.com/NixOS/nixpkgs/commit/4155ccd1c88f9783dc1afc7aa6f3e2fd53110f73) | `` cinnamon.cinnamon-translations: 5.8.2 -> 6.0.0 ``                              |
| [`2ebb1258`](https://github.com/NixOS/nixpkgs/commit/2ebb12584790647700e930fa92e785c2c7de16df) | `` cinnamon.cinnamon-settings-daemon: 5.8.1 -> 6.0.0 ``                           |
| [`b21bfd8b`](https://github.com/NixOS/nixpkgs/commit/b21bfd8b5dc56c162120d38d874fa05dc0c98c8b) | `` cinnamon.cinnamon-session: 5.8.1 -> 6.0.1 ``                                   |
| [`540072b8`](https://github.com/NixOS/nixpkgs/commit/540072b8a12df72ec31a5a4655491adc9dba82fd) | `` cinnamon.cinnamon-screensaver: 5.8.1 -> 6.0.0 ``                               |
| [`1ddb3ffa`](https://github.com/NixOS/nixpkgs/commit/1ddb3ffa60eb853425dbe83bc37f130f5b87a297) | `` cinnamon.cinnamon-menus: 5.8.0 -> 6.0.0 ``                                     |
| [`a4e2be76`](https://github.com/NixOS/nixpkgs/commit/a4e2be76d7627c7f49159d0e431c29e75c04cec6) | `` cinnamon.cinnamon-desktop: 5.8.0 -> 6.0.0 ``                                   |
| [`4aff26b6`](https://github.com/NixOS/nixpkgs/commit/4aff26b630a12b1422df8d8bff94bdfab0d0f1ce) | `` cinnamon.cinnamon-control-center: 5.8.2 -> 6.0.0 ``                            |
| [`8d209118`](https://github.com/NixOS/nixpkgs/commit/8d209118f54dc98fd4e56e9ef4e3a32ede4473c1) | `` cinnamon.cinnamon-common: 5.8.4 -> 6.0.0 ``                                    |
| [`f9c72bde`](https://github.com/NixOS/nixpkgs/commit/f9c72bdea4556d00d9d37f47ed7dd7885692b943) | `` cinnamon.bulky: 2.10 -> 3.0 ``                                                 |
| [`fb519584`](https://github.com/NixOS/nixpkgs/commit/fb519584dc3c6127570040e78eb3db1465324059) | `` maintainers: add bloveless ``                                                  |
| [`cc3d1c59`](https://github.com/NixOS/nixpkgs/commit/cc3d1c591cdc497927e09aaa5a7cd3f764fee145) | `` python310Packages.flake8-bugbear: 23.9.16 -> 23.11.28 ``                       |
| [`cf5e492c`](https://github.com/NixOS/nixpkgs/commit/cf5e492c145fcb7face33af64f1ae031c94b4dc5) | `` python311Packages.betterproto: 2.0.0b5 -> 2.0.0b6 ``                           |
| [`cb83c7f9`](https://github.com/NixOS/nixpkgs/commit/cb83c7f95cf5b336bf7ac7190c0119cb6082fae2) | `` v2ray-domain-list-community: 20231122065640 -> 20231201183121 ``               |
| [`a45059f3`](https://github.com/NixOS/nixpkgs/commit/a45059f3d561f4fe0ef0c9994ddf97c03c412daf) | `` rsibreak: use kde mirror, switch to pname+version ``                           |
| [`7dd6eadd`](https://github.com/NixOS/nixpkgs/commit/7dd6eadd8e7df96a6a17f93165a67a3b68a62c9b) | `` sdrangel: 7.17.0 -> 7.17.1 ``                                                  |
| [`27adb1a8`](https://github.com/NixOS/nixpkgs/commit/27adb1a85f6a8ee581f47bab37a9c520a613eba7) | `` python311Packages.gehomesdk: 0.5.23 -> 0.5.25 ``                               |
| [`303a0a0b`](https://github.com/NixOS/nixpkgs/commit/303a0a0bc0ddb621f45c2dbe8829ce20015bd2ff) | `` python311Packages.opentsne: refactor ``                                        |
| [`41f513ee`](https://github.com/NixOS/nixpkgs/commit/41f513ee7337c48709ee6658ada0870369110529) | `` python311Packages.opentsne: 1.0.0 -> 1.0.1 ``                                  |
| [`c2e66017`](https://github.com/NixOS/nixpkgs/commit/c2e660173d734b6bc10b9a3995b2a6013ec3bda3) | `` python310Packages.downloader-cli: add changelog to meta ``                     |
| [`494273bf`](https://github.com/NixOS/nixpkgs/commit/494273bfeb1c98e55fee10133ba7bae4575fbeb1) | `` python310Packages.fake-useragent: add pythonImportsCheck ``                    |
| [`9c794a14`](https://github.com/NixOS/nixpkgs/commit/9c794a140b3e88bb398704a4f4a628196eb904b7) | `` python310Packages.fake-useragent: modernize ``                                 |
| [`caaac84a`](https://github.com/NixOS/nixpkgs/commit/caaac84a5ba9514c96be94c4d7c4bc8de9b4e279) | `` python310Packages.fake-useragent: 1.3.0 -> 1.4.0 ``                            |
| [`04d95042`](https://github.com/NixOS/nixpkgs/commit/04d95042f3d66a4d07d839cb7703511d9a944b02) | `` python310Packages.empy: 3.3.4 -> 4.0 ``                                        |
| [`6b0c8452`](https://github.com/NixOS/nixpkgs/commit/6b0c8452c7530eceb87c4398055ea6433923eb79) | `` yq-go: 4.40.1 -> 4.40.3 ``                                                     |
| [`dc592d4c`](https://github.com/NixOS/nixpkgs/commit/dc592d4c22ed7bb4cced11b57cedb272fdf229cd) | `` python310Packages.downloader-cli: 0.3.3 -> 0.3.4 ``                            |
| [`c3cf18b5`](https://github.com/NixOS/nixpkgs/commit/c3cf18b5924e94c8f1f11283420bafb1df5dc4a2) | `` python310Packages.dask-glm: 0.3.0 -> 0.3.2 ``                                  |
| [`2c4abbc9`](https://github.com/NixOS/nixpkgs/commit/2c4abbc902b740c418f10f5185dd5fa5b29fb9d1) | `` python310Packages.cx-freeze: 6.15.10 -> 6.15.11 ``                             |
| [`4cda1cca`](https://github.com/NixOS/nixpkgs/commit/4cda1cca053482797229923f887f3bba80ce3a55) | `` python310Packages.configupdater: 3.1.1 -> 3.2 ``                               |
| [`162c41e8`](https://github.com/NixOS/nixpkgs/commit/162c41e8f4a4c021256b594d0e85711d5ab8fac9) | `` python311Packages.approvaltests: 10.0.0 -> 10.1.0 ``                           |
| [`09081aa8`](https://github.com/NixOS/nixpkgs/commit/09081aa859322fa382c1f106d989b5b4b3b37e74) | `` fetchNpmDeps: add test case where empty default lockfile packages is needed `` |
| [`77571a84`](https://github.com/NixOS/nixpkgs/commit/77571a847f4c6c744a2541b493b2b7e9751a13ce) | `` prefetch-npm-deps: use default value when lockfile has no deps ``              |
| [`daec4bf7`](https://github.com/NixOS/nixpkgs/commit/daec4bf7347a779d5d4a25524e056987c46ea519) | `` prefetch-npm-deps: instrument some logging ``                                  |
| [`81ed58b0`](https://github.com/NixOS/nixpkgs/commit/81ed58b0fef21985242dea442e398b3bb81c9d67) | `` prefetch-npm-deps: make cargo happy ``                                         |
| [`ba656ad8`](https://github.com/NixOS/nixpkgs/commit/ba656ad84ebb89cad244d23bc61002ceff332b15) | `` prefetch-npm-deps: bump deps ``                                                |
| [`764053bc`](https://github.com/NixOS/nixpkgs/commit/764053bc02134c8bc2a936f33b6313f2c67ed518) | `` python311Packages.txtorcon: 23.5.0 -> 23.11.0 ``                               |
| [`0f8084ba`](https://github.com/NixOS/nixpkgs/commit/0f8084ba6bc3d11c2a42744b59fe430a3e2bc127) | `` nixos/doc: add documentation on using FIDO2 tokens in systemd stage1 ``        |