### PR TITLE
chore(flake/spicetify-nix): `afe1e6b2` -> `95e7f115`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -801,11 +801,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701576605,
-        "narHash": "sha256-rvW/KKtZDm1q3+3K+Ee0RRgHfHBA50Ezs9hrZkRRhRI=",
+        "lastModified": 1701640850,
+        "narHash": "sha256-AdmEWzOumVURrb0GH8OplNl0EFPv4/XqXUeoqlk+kPU=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "afe1e6b206b45395a97391f09b62dc6d1b95896f",
+        "rev": "95e7f115efd5d55522ceb64452dcc0949878e023",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                        |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`95e7f115`](https://github.com/Gerg-L/spicetify-nix/commit/95e7f115efd5d55522ceb64452dcc0949878e023) | `` big rework in progress ``                                   |
| [`a0e2744d`](https://github.com/Gerg-L/spicetify-nix/commit/a0e2744d04582d0d774dea2f4f36c6afdb697f0b) | `` CI update 2023-12-03 (#7) ``                                |
| [`cb51901e`](https://github.com/Gerg-L/spicetify-nix/commit/cb51901e0cc747c8a7827c6ed394d40e7c211c20) | `` CI update 2023-12-02 (#6) ``                                |
| [`5a8867a0`](https://github.com/Gerg-L/spicetify-nix/commit/5a8867a06cb4e558895878f63f07dd9cd7b377ea) | `` Bump DeterminateSystems/nix-installer-action from 4 to 8 `` |
| [`aa22297b`](https://github.com/Gerg-L/spicetify-nix/commit/aa22297b468ec8cb9754c4d7ab485cc3deba96e3) | `` Bump actions/checkout from 4.0.0 to 4.1.1 ``                |
| [`d9ac0a37`](https://github.com/Gerg-L/spicetify-nix/commit/d9ac0a372a92d2e1087e0def2c0e204370707c68) | `` CI update 2023-12-01 (#3) ``                                |