### PR TITLE
chore(flake/home-manager): `4a8545f5` -> `948703f3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701433070,
-        "narHash": "sha256-Gf9JStfENaUQ7YWFz3V7x/srIwr4nlnVteqaAxtwpgM=",
+        "lastModified": 1701676655,
+        "narHash": "sha256-wP8i7hO2aLNJhYoTK3kqoymaCLgt4QcwWcO8d/A1CjQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4a8545f5e737a6338814a4676dc8e18c7f43fc57",
+        "rev": "948703f3e71f1332a0cb535ebaf5cb14946e3724",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                      |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`948703f3`](https://github.com/nix-community/home-manager/commit/948703f3e71f1332a0cb535ebaf5cb14946e3724) | `` broot: Add nushell integration (#4714) `` |
| [`e504e8d0`](https://github.com/nix-community/home-manager/commit/e504e8d01f950776c3a3160ba38c5957a1b89e66) | `` Translate using Weblate (Dutch) ``        |
| [`efe28e24`](https://github.com/nix-community/home-manager/commit/efe28e24f36b4852a3df2c6a518941208e095b04) | `` Translate using Weblate (Italian) ``      |
| [`ce67b37c`](https://github.com/nix-community/home-manager/commit/ce67b37cabbdaef7bfd614130b182f61867f4c42) | `` Translate using Weblate (Russian) ``      |
| [`0d401071`](https://github.com/nix-community/home-manager/commit/0d4010711922388c80a115d62cdb7ba04c2ed738) | `` flake.lock: Update ``                     |