### PR TITLE
chore(flake/master): `0948b7cd` -> `37baba23`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -439,11 +439,11 @@
     },
     "master": {
       "locked": {
-        "lastModified": 1701619776,
-        "narHash": "sha256-OGc4xHC08Nn/NNQoLbjDATFqF6MZ+0jzkuwvRqzBhJ8=",
+        "lastModified": 1701695261,
+        "narHash": "sha256-a7mmKPoxajPCd/i6g9ahl+H3AN75S3OodgSuVs/mreQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0948b7cd6b9fc4172f4730f3077f35c429c95774",
+        "rev": "37baba238bd5f2660062f6e5174111fd6947c5ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`c64d6957`](https://github.com/NixOS/nixpkgs/commit/c64d69574ac1c00be11d77c72003560c1b522267) | `` python3.pkgs.ariadne: remove opentracing dependency (#271999) ``                            |
| [`43029b50`](https://github.com/NixOS/nixpkgs/commit/43029b506fcf3dc2a346c9ac3003e8ab93348f77) | `` weechat-unwrapped: 4.1.1 -> 4.1.2 ``                                                        |
| [`f729a8e6`](https://github.com/NixOS/nixpkgs/commit/f729a8e68c9e722946127f8d75aa27eda65f79d8) | `` fastgron: 0.6.5 -> 0.7.0 ``                                                                 |
| [`eefffd00`](https://github.com/NixOS/nixpkgs/commit/eefffd003a2c2cac2206e48ea9801bfa5ccee74b) | `` python310Packages.mkdocstrings: refactor ``                                                 |
| [`608e8f6e`](https://github.com/NixOS/nixpkgs/commit/608e8f6e87c385545bf353e069d0e8ea8db00d65) | `` python310Packages.millheater: 0.11.6 -> 0.11.7 ``                                           |
| [`515f0d1b`](https://github.com/NixOS/nixpkgs/commit/515f0d1b59abaa8194c75544eb0d8859915a3edd) | `` python310Packages.mkdocstrings: 0.23.0 -> 0.24.0 ``                                         |
| [`3f916c8d`](https://github.com/NixOS/nixpkgs/commit/3f916c8d59ab7d8e4c9b9cc107f4711064a7b3cf) | `` starsector: added missing build input ``                                                    |
| [`e270b7be`](https://github.com/NixOS/nixpkgs/commit/e270b7beff7c137a8aa0d34867e960febd2a346c) | `` php: use a versioned url for install-pear-nozlib.phar ``                                    |
| [`34deb05e`](https://github.com/NixOS/nixpkgs/commit/34deb05e5599997d5685387e4f44376915f1e561) | `` nixos/buildbot: fix worker package ``                                                       |
| [`9e71df9f`](https://github.com/NixOS/nixpkgs/commit/9e71df9f5ef28c3868430b50c9e532b34a719751) | `` python311Packages.litellm: 0.11.1 -> 1.7.11 ``                                              |
| [`5f69f0ed`](https://github.com/NixOS/nixpkgs/commit/5f69f0ed2eb1751e24e0cb7f4100bd973dd2db69) | `` python311Packages.openai: 0.28.1 -> 1.3.7 ``                                                |
| [`0108269b`](https://github.com/NixOS/nixpkgs/commit/0108269b3882c72e60fa4d24b4ab3d586b8ef8e0) | `` python311Packages.html2image: init at 2.0.4.3 ``                                            |
| [`37a54300`](https://github.com/NixOS/nixpkgs/commit/37a543002cce2fea56ab92ed46baef2abc9df6de) | `` themix-gui: init at 1.15.1 ``                                                               |
| [`6befd082`](https://github.com/NixOS/nixpkgs/commit/6befd082e7c9eceab9fb247c9ee013db680fab7b) | `` ia-writer-quattro: init at unstable-2023-06-16 ``                                           |
| [`78079efb`](https://github.com/NixOS/nixpkgs/commit/78079efb8d5f2185fafb181b3180fb6a92bd1dcb) | `` maintainers: add x0ba ``                                                                    |
| [`de1aca9b`](https://github.com/NixOS/nixpkgs/commit/de1aca9bcf597856fbe22babff3481646195fdb7) | `` vimPlugins.nvim-treesitter: update grammars ``                                              |
| [`393847dd`](https://github.com/NixOS/nixpkgs/commit/393847ddf81675da96fe76b037a03ee2fa170853) | `` vimPlugins: update on 2023-12-03 ``                                                         |
| [`1d17fa36`](https://github.com/NixOS/nixpkgs/commit/1d17fa361b0fe462ecdc67b623e6b68578bf4c18) | `` vimPlugins.wtf-nvim: init at 2023-11-11 ``                                                  |
| [`7e886531`](https://github.com/NixOS/nixpkgs/commit/7e886531a2b9be8ca3fd43bde8e82cbae9b9e4a0) | `` qt6.qtmultimedia: Fix failure to load libva.so ``                                           |
| [`d3de574b`](https://github.com/NixOS/nixpkgs/commit/d3de574b8ccc0e98b4490197265f60b03b36c0e9) | `` qt6.qtmultimedia: Compile hardware-accelerated VAAPI ``                                     |
| [`91b8e472`](https://github.com/NixOS/nixpkgs/commit/91b8e472a5b7661bcc2f930a1abe14881f335a73) | `` qt6.qtmultimedia: Compile ffmpeg multimedia plugin ``                                       |
| [`0ebea895`](https://github.com/NixOS/nixpkgs/commit/0ebea895518328b58d169c27860433d5594f4823) | `` qt6.qtmultimedia: Enable Spatial Audio (Quick3D) ``                                         |
| [`37b106f9`](https://github.com/NixOS/nixpkgs/commit/37b106f9b04cdb35d0b2cecd9858e7fa9c3e6625) | `` postgresql.pkgs.timescaledb_toolkit: 1.16.0 -> 1.18.0 ``                                    |
| [`5aa5b3c1`](https://github.com/NixOS/nixpkgs/commit/5aa5b3c1a7f614c030a9662fe64083818b949336) | `` linux-rt_6_1: 6.1.59-rt16 -> 6.1.64-rt17 ``                                                 |
| [`430fc02b`](https://github.com/NixOS/nixpkgs/commit/430fc02b433acc512d8f676b672e7cc1a821739a) | `` linux_5_15: 5.15.140 -> 5.15.141 ``                                                         |
| [`a7db5f67`](https://github.com/NixOS/nixpkgs/commit/a7db5f67e13e1b83430569b7a1d0278fd0925c17) | `` linux_6_1: 6.1.64 -> 6.1.65 ``                                                              |
| [`518742c7`](https://github.com/NixOS/nixpkgs/commit/518742c78e3a6ef1c2b5dd971bb310673e1ad913) | `` linux_6_6: 6.6.3 -> 6.6.4 ``                                                                |
| [`03de3c5c`](https://github.com/NixOS/nixpkgs/commit/03de3c5c3fda2d9f290117b3675b76c5c5ca2a95) | `` linux_testing: 6.7-rc3 -> 6.7-rc4 ``                                                        |
| [`43b372ab`](https://github.com/NixOS/nixpkgs/commit/43b372ab66e1590de505f4c0ef96be2a75b416bf) | `` virtiofsd.meta.mainProgram: init ``                                                         |
| [`4a6045a4`](https://github.com/NixOS/nixpkgs/commit/4a6045a41b9caff2028a7d37a8d51e25f1aa45f8) | `` emacs: Use lib.withFeature ``                                                               |
| [`b3e34832`](https://github.com/NixOS/nixpkgs/commit/b3e348323eea142b8bdff8a4e693c7de8c8e5039) | `` wireplumber: 0.4.16 -> 0.4.17 ``                                                            |
| [`2d6601b2`](https://github.com/NixOS/nixpkgs/commit/2d6601b2795c9bae574338f7fd67754b47ba46fe) | `` maintainers/team-list: add nialov to geospatial team ``                                     |
| [`642e0543`](https://github.com/NixOS/nixpkgs/commit/642e05439052539ed9053775ae5044da4d481912) | `` maintainers.moni: fix github id ``                                                          |
| [`1769cf41`](https://github.com/NixOS/nixpkgs/commit/1769cf416ed58df2fc5fc9e8e7a0c0284a5ae0c9) | `` contour: 0.3.1.200 -> 0.3.12.262 ``                                                         |
| [`550b95e2`](https://github.com/NixOS/nixpkgs/commit/550b95e22c148071bf155573f9ced0bf96e2d408) | `` bup: Fix build on Darwin with LLVM 16 ``                                                    |
| [`f171058d`](https://github.com/NixOS/nixpkgs/commit/f171058dcc574168b9e683ef1dae2bd97e7b9d8d) | `` mpvScripts.mpv-webm: Set `updateScript` ``                                                  |
| [`ba0dc5b5`](https://github.com/NixOS/nixpkgs/commit/ba0dc5b5d3007816cd0f5b9520d8bbb15365fd93) | `` python311Packages.example-robot-data: 4.0.8 -> 4.0.9 ``                                     |
| [`e8978c7b`](https://github.com/NixOS/nixpkgs/commit/e8978c7baa00ec684ea4c085320542b716060c94) | `` light: Add `meta.mainProgram` ``                                                            |
| [`1ccdf7c3`](https://github.com/NixOS/nixpkgs/commit/1ccdf7c36905a785ba4451973928801cf0a02789) | `` fusuma: 3.1.0 -> 3.3.1 ``                                                                   |
| [`f0362972`](https://github.com/NixOS/nixpkgs/commit/f03629728793cce0025338357105a65e3d9b3bbf) | `` hareThirdParty.hare-json: init at unstable-2023-09-21 ``                                    |
| [`922e4c14`](https://github.com/NixOS/nixpkgs/commit/922e4c14a4112f0da1496fe9478e3e4cac85fe3d) | `` python310Packages.icontract: 2.6.4 -> 2.6.6 ``                                              |
| [`03982f1f`](https://github.com/NixOS/nixpkgs/commit/03982f1ffd811863e8ab82f8abdf66e050333dc9) | `` python310Packages.duecredit: drop dependency on six, raise minimum python version to 3.8 `` |
| [`20f5e3a1`](https://github.com/NixOS/nixpkgs/commit/20f5e3a1374531bec4fa77ab9f54d87ba798f191) | `` addOpenGLRunpath: Add comment for deprecation schedule ``                                   |
| [`05f1bc96`](https://github.com/NixOS/nixpkgs/commit/05f1bc9654f16ec18bfd1518fe441b7a161341e6) | `` nixos/manual: add entry for addDriverRunpath ``                                             |
| [`c7c1388e`](https://github.com/NixOS/nixpkgs/commit/c7c1388e82b88378b46a9d37e7ad2e1adf23961b) | `` addDriverRunpath: init ``                                                                   |
| [`d5f7dd17`](https://github.com/NixOS/nixpkgs/commit/d5f7dd176ec1dfbc195c8f6405c823f37b5903e9) | `` netbox: 3.6.4 -> 3.6.6 ``                                                                   |
| [`a988bde1`](https://github.com/NixOS/nixpkgs/commit/a988bde189a828def4d03a83c6ba3061e2baff15) | `` pywalfox-native: fixup indentation ``                                                       |
| [`43171011`](https://github.com/NixOS/nixpkgs/commit/43171011659348d6e60824d97483942f508c3dd1) | `` netbox: 3.6.3 -> 3.6.4 ``                                                                   |
| [`882a1ae3`](https://github.com/NixOS/nixpkgs/commit/882a1ae334dc8627bb57e722fb72bb8020bfd8e5) | `` python311Packages.scancode-toolkit: 32.0.6 -> 32.0.8 ``                                     |
| [`5779884e`](https://github.com/NixOS/nixpkgs/commit/5779884eeebe7d0ccc7655e27e6f69a711d59182) | `` vulkan-tools: support cross compilation ``                                                  |
| [`9fd3104b`](https://github.com/NixOS/nixpkgs/commit/9fd3104ba2e6017b5560f207d88b93051686779e) | `` python311Packages.dvc-objects: 1.3.0 -> 1.3.2 ``                                            |
| [`71716347`](https://github.com/NixOS/nixpkgs/commit/71716347ffab7d9a50bf543101e7d3214fe90ef9) | `` konstraint: 0.32.0 -> 0.33.0 ``                                                             |
| [`fd448e5c`](https://github.com/NixOS/nixpkgs/commit/fd448e5c0f2d4ba4cc7c05f81b358740ebd3cace) | `` nimmm: 0.2.0 -> 0.3.0 ``                                                                    |
| [`2d89dac4`](https://github.com/NixOS/nixpkgs/commit/2d89dac413f4499164c5efc0d937234c6f4c902d) | `` python310Packages.imapclient: 3.0.0 -> 3.0.1 ``                                             |
| [`a75f149e`](https://github.com/NixOS/nixpkgs/commit/a75f149eb79b54ade90b023b2c2dbceb243a6c71) | `` clipcat: 0.9.0 -> 0.11.0 ``                                                                 |
| [`9ef74b5f`](https://github.com/NixOS/nixpkgs/commit/9ef74b5fc46758c1daa8e2a5c5d05ecf9625e07a) | `` fontbakery: init at 0.10.40 ``                                                              |
| [`6b673ad6`](https://github.com/NixOS/nixpkgs/commit/6b673ad6eb90a07b276fe5f06843b0dee3993de4) | `` python311Packages.shaperglot: init at 0.3.1 ``                                              |
| [`b64e3764`](https://github.com/NixOS/nixpkgs/commit/b64e37642b92fc283bd81d4736dcb826094ee8eb) | `` python311Packages.vharfbuzz: init at 0.2.0 ``                                               |
| [`45606204`](https://github.com/NixOS/nixpkgs/commit/456062045de4cda786a00132c45cb0d6619e63fc) | `` python311Packages.dehinter: init at 4.0.0 ``                                                |
| [`8a17e333`](https://github.com/NixOS/nixpkgs/commit/8a17e333735d06cfbe74b1470945c55c080ee17d) | `` python311Packages.font-v: init at 2.1.0 ``                                                  |
| [`a08c20f4`](https://github.com/NixOS/nixpkgs/commit/a08c20f482d885f85c13c18436bb17be81953bb8) | `` python311Packages.opentypespec: init at 1.9.1 ``                                            |
| [`e5495859`](https://github.com/NixOS/nixpkgs/commit/e54958590fb6f028def967d4570a98f8903622f4) | `` python311Packages.stringbrewer: init at 0.0.1 ``                                            |
| [`5b36e339`](https://github.com/NixOS/nixpkgs/commit/5b36e3394f0270903fe579a012044b89967703b0) | `` python311Packages.sre-yield: init at 1.2 ``                                                 |
| [`b3f0566e`](https://github.com/NixOS/nixpkgs/commit/b3f0566e9ce17c4d8fc687d63cb0bb92b8a1b133) | `` python311Packages.rstr: init at 3.2.2 ``                                                    |
| [`1e5651a8`](https://github.com/NixOS/nixpkgs/commit/1e5651a8c9a87bc93d919d62b9811cea51b8b891) | `` python311Packages.ufolint: init at 1.2.0 ``                                                 |
| [`55aaa1a0`](https://github.com/NixOS/nixpkgs/commit/55aaa1a09e910dce4247a0fd97b8a10c600f56bb) | `` python311Packages.commandlines: init at 0.4.1 ``                                            |
| [`5796bf10`](https://github.com/NixOS/nixpkgs/commit/5796bf10747f97907b78bfd7d72027b540f855ad) | `` python311Packages.ots-python: init at 9.1.0 ``                                              |
| [`4b7e6a63`](https://github.com/NixOS/nixpkgs/commit/4b7e6a634143459bb379d8060fc914716405ea1a) | `` opentype-sanitizer: init at 9.1.0 ``                                                        |
| [`16fc4bb7`](https://github.com/NixOS/nixpkgs/commit/16fc4bb760b4156c1544c468b0f94ad683668bbf) | `` python311Packages.gflanguages: init at 0.5.10 ``                                            |
| [`0e4d426c`](https://github.com/NixOS/nixpkgs/commit/0e4d426cc812f966d8cfbfb3ef9052009726c26c) | `` python311Packages.collidoscope: init at 0.6.5 ``                                            |
| [`f810b9c9`](https://github.com/NixOS/nixpkgs/commit/f810b9c9d0d8987b458a3125cc5f5c6e28a56059) | `` python311Packages.kurbopy: init at 0.10.40 ``                                               |
| [`ff0d76d7`](https://github.com/NixOS/nixpkgs/commit/ff0d76d7e95d9d46d5f2a6b6cb8a47867b0dd505) | `` libsForQt5.accounts-qml-module: 0.7-unstable-2022-10-12 -> 0.7-unstable-2022-10-28 ``       |
| [`ee4d0c8b`](https://github.com/NixOS/nixpkgs/commit/ee4d0c8b556571f2e330a42244c99e0e3905dbb4) | `` libsForQt5.accounts-qml-module: init at 0.7-unstable-2022-10-12 ``                          |
| [`0a672104`](https://github.com/NixOS/nixpkgs/commit/0a67210453cfb72d4db66d2599a8605f3327d235) | `` librda: init at 0.0.5-unstable-2023-09-15 ``                                                |
| [`2bd3807c`](https://github.com/NixOS/nixpkgs/commit/2bd3807c759e070ddc9cfc347672c7d52b7e5868) | `` tuc: 1.0.0 -> 1.1.0 ``                                                                      |
| [`a65c860e`](https://github.com/NixOS/nixpkgs/commit/a65c860ec5df7aa41d506756504556bdad98c504) | `` python311Packages.babelfont: init at 3.0.1 ``                                               |
| [`60553f44`](https://github.com/NixOS/nixpkgs/commit/60553f445ae56b9e05a05a02a34324c165d8712e) | `` python311Packages.fontfeatures: init at 1.8.0 ``                                            |
| [`b863e2ca`](https://github.com/NixOS/nixpkgs/commit/b863e2cab811b56a205306d1580954b36f913452) | `` python311Packages.youseedee: init at 0.4.1 ``                                               |
| [`1e0460a0`](https://github.com/NixOS/nixpkgs/commit/1e0460a072919439562c528758067e4d925dcdc2) | `` python311Packages.glyphtools: init at 0.8.0 ``                                              |
| [`15da1285`](https://github.com/NixOS/nixpkgs/commit/15da12857e2b710b6d0f9eb8cfa8c988519989a5) | `` python311Packages.beziers: init at 0.5.0 ``                                                 |
| [`0678bf43`](https://github.com/NixOS/nixpkgs/commit/0678bf439291f529de2587aefac6508b6a681a6d) | `` python311Packages.glyphsets: init at 0.6.5 ``                                               |
| [`6a1727ac`](https://github.com/NixOS/nixpkgs/commit/6a1727ac06e32a4570ea3a4c63a51510cf24efbe) | `` python311Packages.axisregistry: init at 0.4.5 ``                                            |
| [`69a73973`](https://github.com/NixOS/nixpkgs/commit/69a73973702ad649aaae03bfaa357811fbdf4726) | `` openseachest: 23.03.1 -> 23.12 ``                                                           |
| [`87798ce2`](https://github.com/NixOS/nixpkgs/commit/87798ce2c96feff984e65b087eb8fde95cd17147) | `` eartag: add appstream build input ``                                                        |
| [`43174549`](https://github.com/NixOS/nixpkgs/commit/43174549453c855d47d23ac0db98bf2e50404880) | `` eartag: 0.4.3 -> 0.5.1 ``                                                                   |
| [`a8a5758d`](https://github.com/NixOS/nixpkgs/commit/a8a5758da5b1609aa628b3c7e9aea547a586e703) | `` lomiri.hfd-service: 0.2.0 -> 0.2.1 ``                                                       |
| [`440cd023`](https://github.com/NixOS/nixpkgs/commit/440cd0232deb237fc8d8f59c3e98c2e6ff23bc04) | `` lomiri.hfd-service: init at 0.2.0 ``                                                        |
| [`a7fab38b`](https://github.com/NixOS/nixpkgs/commit/a7fab38bac17bfebf608b1df1a27a5e32932f71f) | `` gridtracker: 1.23.1112 -> 1.23.1202 ``                                                      |
| [`24d9151d`](https://github.com/NixOS/nixpkgs/commit/24d9151d15168867b87669ee663e4d15a23ded91) | `` nixos/keepalived: add openFirewall option ``                                                |
| [`84c284c6`](https://github.com/NixOS/nixpkgs/commit/84c284c656c287e85cb2e653be7f206433a1a863) | `` srm: 1.2.15 -> 1.2.15-unstable-2017-12-18 ``                                                |
| [`e73f3d00`](https://github.com/NixOS/nixpkgs/commit/e73f3d007e456c39bb4e155a5dee42b049a64a28) | `` flask-seasurf: use patch files ``                                                           |
| [`06feb44c`](https://github.com/NixOS/nixpkgs/commit/06feb44c1ab13a2cc42826c1d114f7c16fa00e00) | `` powerdns-admin: use patch files ``                                                          |
| [`ec9f89a8`](https://github.com/NixOS/nixpkgs/commit/ec9f89a840e82ae930af77333ede0d3098105019) | `` powerdns-admin: fix build ``                                                                |
| [`c20ddec0`](https://github.com/NixOS/nixpkgs/commit/c20ddec0fa8e1e80ebadb90e207119d2fa33550c) | `` python310Packages.flask-seasurf: fix build ``                                               |
| [`9118b07e`](https://github.com/NixOS/nixpkgs/commit/9118b07e4aa2480e7e296135de8823e966e7c696) | `` get-google-fonts: init at unstable-2020-06-30 ``                                            |
| [`50948fda`](https://github.com/NixOS/nixpkgs/commit/50948fda77c7a72c105a19c17432ace8092396ba) | `` pocket-updater-utility: remove update.sh script and use nix-update-script ``                |
| [`bdc31fce`](https://github.com/NixOS/nixpkgs/commit/bdc31fce2a6dd7e8d8bd221382e911448fd407cb) | `` pocket-updater-utility: 2.31.0 -> 2.36.2 ``                                                 |
| [`c1885ddd`](https://github.com/NixOS/nixpkgs/commit/c1885ddd44d4be67c123ce06448d55781501f596) | `` collision: 3.5.0 -> 3.6.0 ``                                                                |
| [`838e58d7`](https://github.com/NixOS/nixpkgs/commit/838e58d7c016aabe63045e7362547df070aed925) | `` libmpc: correct meta.homepage ``                                                            |
| [`da0bcb84`](https://github.com/NixOS/nixpkgs/commit/da0bcb8418ab35fbb01ea540a2f542aeefc38ec7) | `` python3Packages.pytikz-allefeld: init at unstable-2022-11-01 ``                             |
| [`40ffdaf0`](https://github.com/NixOS/nixpkgs/commit/40ffdaf0b69b88ff2efe611af631b954df194697) | `` hayabusa: init at unstable-2023-11-29 ``                                                    |
| [`41bea419`](https://github.com/NixOS/nixpkgs/commit/41bea419e73519d81713b4e816c0011bb1cb20bc) | `` sing-box: 1.7.0 -> 1.7.1 ``                                                                 |
| [`035d1e2c`](https://github.com/NixOS/nixpkgs/commit/035d1e2cf9ce2e673db853ec6a8ac6161124189a) | `` trivial-builders: add onlyBin ``                                                            |
| [`124e85ca`](https://github.com/NixOS/nixpkgs/commit/124e85cac82d6c4764ca083ab870c5d0ec9911a5) | `` libnbd: 1.18.0 -> 1.18.1 and apply patch for CVE-2023-5871 ``                               |
| [`d7522e6c`](https://github.com/NixOS/nixpkgs/commit/d7522e6c9bc69f05aa626b2dd695ba10742c0345) | `` heroku: add updateScript ``                                                                 |
| [`6ecbda28`](https://github.com/NixOS/nixpkgs/commit/6ecbda288b4ad9073c177d007d5a2811bbaea1eb) | `` greenfoot: 3.8.1 -> 3.8.2 ``                                                                |
| [`50543cf1`](https://github.com/NixOS/nixpkgs/commit/50543cf1211752b9ab1c598e80a4a23d0ee54097) | `` maintainers: add starzation ``                                                              |
| [`7601067f`](https://github.com/NixOS/nixpkgs/commit/7601067f3034b7c22ec00da81a18fea8fd45537a) | `` majima: init at 0.4.0 ``                                                                    |
| [`fba69bd1`](https://github.com/NixOS/nixpkgs/commit/fba69bd1cfa6ebefb30eae956fcc2770fa1b69f9) | `` intel-graphics-compiler: 1.0.14828.8 -> 1.0.15136.4 ``                                      |
| [`9041c780`](https://github.com/NixOS/nixpkgs/commit/9041c780be345850377db27aaac95630a5f6609d) | `` termbench-pro: init at unstable-2023-01-26 ``                                               |
| [`8f5dd15a`](https://github.com/NixOS/nixpkgs/commit/8f5dd15a66d2481296257dc6e5b91e0a41516943) | `` libunicode: init at 0.3.0-unstable-2023-03-05 ``                                            |
| [`5647d108`](https://github.com/NixOS/nixpkgs/commit/5647d108b3ffaa7e216231081d26a54a7dade5ce) | `` zandronum: 3.0.1 -> 3.1.0 ``                                                                |
| [`7e70d632`](https://github.com/NixOS/nixpkgs/commit/7e70d6327422e339cb9c69616c9720b1bc6d195c) | `` gr-framework: 0.72.10 -> 0.72.11 ``                                                         |
| [`25469dd2`](https://github.com/NixOS/nixpkgs/commit/25469dd2c92f716e8525b7bc3eeabdfa22e89b21) | `` gr-framework: refactor ``                                                                   |
| [`008a32e7`](https://github.com/NixOS/nixpkgs/commit/008a32e74bfd06adbc24014fc1a6a7e574332c75) | `` python3Packages.playwright: fix darwin build ``                                             |
| [`94787d63`](https://github.com/NixOS/nixpkgs/commit/94787d63eb9cbc59fe4698454f8ad66c529e8345) | `` maintainers: add ufUNnxagpM ``                                                              |
| [`9ef9ee88`](https://github.com/NixOS/nixpkgs/commit/9ef9ee885717c8c7a4e93fefcd6e2ca431b166e1) | `` sunshine: add libglvnd to runtimeDependencies ``                                            |
| [`3e385310`](https://github.com/NixOS/nixpkgs/commit/3e3853100ab4c82820322c6c989c3a8f3044f3fa) | `` python310Packages.duecredit: 0.9.2 -> 0.9.3 ``                                              |
| [`2473cdbf`](https://github.com/NixOS/nixpkgs/commit/2473cdbf73f8e3c88fd68e7a2497cd6b5233eef8) | `` dosbox-x: Fix stash smashing when launching Windows 3.0 ``                                  |
| [`11b999c9`](https://github.com/NixOS/nixpkgs/commit/11b999c9a0de1f66f88f3e69a8b0ed0aaa9d5dfc) | `` krill: disable failing tests on darwin ``                                                   |
| [`10f8c544`](https://github.com/NixOS/nixpkgs/commit/10f8c5444adc09e55cb350749bea13bf87da9d24) | `` dosbox: Fix modem & IPX support ``                                                          |
| [`9c4b2329`](https://github.com/NixOS/nixpkgs/commit/9c4b232941b7764c4ebdd77b4cc24c0d8e66c603) | `` dosbox-x: Fix modem & IPX support ``                                                        |
| [`fe9750bf`](https://github.com/NixOS/nixpkgs/commit/fe9750bf1802e6a176d84a0cce98beccb76720ea) | `` frankenphp: 1.0.0-rc3 -> 1.0.0-rc4 ``                                                       |
| [`fb613a96`](https://github.com/NixOS/nixpkgs/commit/fb613a967e6d4df081feb49cc3b65e962b463382) | `` nng: 1.6.0-prerelease -> 1.6.0 ``                                                           |
| [`893a18c4`](https://github.com/NixOS/nixpkgs/commit/893a18c41878d976057b6f47f612ced3c0208c73) | `` jazz2: 2.2.2 -> 2.3.0 ``                                                                    |
| [`dc18dc4a`](https://github.com/NixOS/nixpkgs/commit/dc18dc4a023df9d16f417cf598e53ec484ea41e0) | `` mpvScripts.mpv-webm: unstable-2023-02-23 → 2023-11-18 ``                                    |
| [`b09edde7`](https://github.com/NixOS/nixpkgs/commit/b09edde79e2735cfee92ff3b0a979b0ee120754a) | `` mpvScripts.mpv-webm: Simplify with `buildLua` ``                                            |
| [`cc555148`](https://github.com/NixOS/nixpkgs/commit/cc555148a196f057c9dc785028e3e1f4625c93a8) | `` krill: 0.13.0 -> 0.14.2 ``                                                                  |
| [`18e13ef9`](https://github.com/NixOS/nixpkgs/commit/18e13ef9af6c499b2e0f141e7fb9f69ce1049901) | `` fluidd: 1.26.0 -> 1.26.3 ``                                                                 |
| [`2f3b0cc1`](https://github.com/NixOS/nixpkgs/commit/2f3b0cc1f5bac224a265637c6d749e00ea62b843) | `` goredo: 2.4.0 -> 2.5.0 ``                                                                   |
| [`a3c12b75`](https://github.com/NixOS/nixpkgs/commit/a3c12b75e5437e0537714e309c2f29dee3bcaa12) | `` pynitrokey: 0.4.40 -> 0.4.42 ``                                                             |
| [`f28f26fd`](https://github.com/NixOS/nixpkgs/commit/f28f26fdfa1b497ebc41653e5386271f5b69e26f) | `` python311Packages.nethsm: init at 1.0.0 ``                                                  |
| [`4df5e824`](https://github.com/NixOS/nixpkgs/commit/4df5e8249dce54ea8e2eaafbe78f086bc740852d) | `` python311Packages.robotframework-pythonlibcore: 4.2.0 -> 4.3.0 ``                           |