### PR TITLE
chore(flake/unstable): `3771eeac` -> `0b62f5ad`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -894,11 +894,11 @@
     },
     "unstable": {
       "locked": {
-        "lastModified": 1701423271,
-        "narHash": "sha256-hgmzOYg8PHeb2scH0vfEGABXX9Eqjn6aZjmpQXbsq64=",
+        "lastModified": 1701609850,
+        "narHash": "sha256-6oxM84kaQT0H/+aurIcj2ON+asWYQ96zlMUIsfhKpFE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3771eeacc933d214af98474db7c4dcf15607ead5",
+        "rev": "0b62f5adfd6635f8013d800ceb0cf39411a8216f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| [`3987aeec`](https://github.com/NixOS/nixpkgs/commit/3987aeec024ad4e9147e14227dc15599f03d83d8) | `` rmfakecloud.ui: migrate to prefetch-yarn-deps ``                                                     |
| [`ec3ae8dd`](https://github.com/NixOS/nixpkgs/commit/ec3ae8ddf699f31aced16ec9e0ef74bef689a9c3) | `` pulumi: 3.90.1 -> 3.93.0 ``                                                                          |
| [`192d953b`](https://github.com/NixOS/nixpkgs/commit/192d953bc2cde8f9ea2d590e99ca154d4cfd8ede) | `` .github: removing "Priorities" heading ``                                                            |
| [`4d139f4f`](https://github.com/NixOS/nixpkgs/commit/4d139f4f0e0b3d6ac2620fcb7ec07d3bc2cbe789) | `` s6-man-pages: 2.11.3.2.4 -> 2.12.0.2.1 ``                                                            |
| [`b2844f89`](https://github.com/NixOS/nixpkgs/commit/b2844f89d10d4a2665aed231144950c354f275a6) | `` avrlibc: hook up libdir for cc-wrapper ``                                                            |
| [`574d1e47`](https://github.com/NixOS/nixpkgs/commit/574d1e47ea9fa29f6a6ad3f2222d982aa48af940) | `` avrlibc: enable parallel builds ``                                                                   |
| [`760c9864`](https://github.com/NixOS/nixpkgs/commit/760c98640866dab95e102b5e70e322773b61dfca) | `` framework-system-tools: init at unstable-2023-11-14 (#267507) ``                                     |
| [`839fe5f2`](https://github.com/NixOS/nixpkgs/commit/839fe5f25f489f0ac729cd7d3501d9fcd8a89e44) | `` snapper: 0.10.6 -> 0.10.7 ``                                                                         |
| [`ec04772e`](https://github.com/NixOS/nixpkgs/commit/ec04772e7516b6d58d98b491e68b329b7558b14d) | `` python310Packages.grpcio-channelz: 1.59.2 -> 1.59.3 ``                                               |
| [`f1e6c664`](https://github.com/NixOS/nixpkgs/commit/f1e6c6641eaabd157e32ba9ada57363b07daded9) | `` nixos/thinkfan: add setting ``                                                                       |
| [`d1109f39`](https://github.com/NixOS/nixpkgs/commit/d1109f39a543c879e14c4d210dfa536ab34523de) | `` python310Packages.grpcio-health-checking: 1.59.0 -> 1.59.3 ``                                        |
| [`a7788681`](https://github.com/NixOS/nixpkgs/commit/a7788681eb86fef5f84fd620753c9f28b0b3ea17) | `` python310Packages.grpcio-reflection: 1.59.2 -> 1.59.3 ``                                             |
| [`e61cf890`](https://github.com/NixOS/nixpkgs/commit/e61cf890d648e29e39090fcb8ae5fc9b97f46096) | `` yosys: make building with Python binding the default ``                                              |
| [`e55ea616`](https://github.com/NixOS/nixpkgs/commit/e55ea6167fffa5303c8baae32bcf78349189325b) | `` yosys: add option to build with Python binding ``                                                    |
| [`a3006991`](https://github.com/NixOS/nixpkgs/commit/a3006991c3bda39bd1493b370c117be07fd7b078) | `` lib/customisation: fix eval error (attribute "levenshtein" missing) ``                               |
| [`6069c244`](https://github.com/NixOS/nixpkgs/commit/6069c24427a965ef4842434566231c4bc9af74e0) | `` vsce: 2.21.1 -> 2.22.0 ``                                                                            |
| [`52e68919`](https://github.com/NixOS/nixpkgs/commit/52e689197f1e59e2612eadab637937b3167dc869) | `` python310Packages.gptcache: 0.1.42 -> 0.1.43 ``                                                      |
| [`6be18c38`](https://github.com/NixOS/nixpkgs/commit/6be18c387c86cc7dc4904d02c28c3f746cbf10aa) | `` anitopy: init at 2.1.1 ``                                                                            |
| [`3fae5c93`](https://github.com/NixOS/nixpkgs/commit/3fae5c931ee9492cac4349f86d9e1e39f5e21f5c) | `` anchor: init at 3 ``                                                                                 |
| [`62beb3db`](https://github.com/NixOS/nixpkgs/commit/62beb3db5bb392af81fa93c5b5c0afe547e7c374) | `` animdl: init at 1.7.27 ``                                                                            |
| [`1063c0ea`](https://github.com/NixOS/nixpkgs/commit/1063c0ea2a7d4d38491f27e50b21e3a7a6461d47) | `` maintainers: add passivelemon ``                                                                     |
| [`29d1b59b`](https://github.com/NixOS/nixpkgs/commit/29d1b59b2d4a7ca462a6ddd86c7214a37eba3631) | `` aba: 0.7.1 -> 0.8.0 ``                                                                               |
| [`97312082`](https://github.com/NixOS/nixpkgs/commit/973120823b5824d426b97a7e9e027191b22f33ac) | `` lib.systems.elaborate: fix passing `rust` (more) (#271707) ``                                        |
| [`0616776a`](https://github.com/NixOS/nixpkgs/commit/0616776a5e4072e9455e3966d1fce58feefa7a58) | `` fastgron: 0.6.4 -> 0.6.5 ``                                                                          |
| [`627de16d`](https://github.com/NixOS/nixpkgs/commit/627de16d7d020d168bcc84c6fd64a8c4a9f3b4ae) | `` python310Packages.google-cloud-runtimeconfig: 0.33.2 -> 0.33.3 ``                                    |
| [`60057270`](https://github.com/NixOS/nixpkgs/commit/600572706589601e291abd818009c0c4a623a523) | `` mlt: 7.20.0 -> 7.22.0 (#270928) ``                                                                   |
| [`f2a7764c`](https://github.com/NixOS/nixpkgs/commit/f2a7764cab5799d2a68e6771679780303b5b3afa) | `` gcc{6,7,8,9,10,11}: fix cross-compiler build on x86_64-darwin ``                                     |
| [`4a538d6b`](https://github.com/NixOS/nixpkgs/commit/4a538d6b3df931c87fb38b14fa1d0038d39f45e5) | `` gcc11: mark as bad on aarch64-darwin when building a cross-compiler ``                               |
| [`fe27958a`](https://github.com/NixOS/nixpkgs/commit/fe27958aed65ac531732544dd6a8b9c20da4d813) | `` gcc{6,7,8,9}: use target bintools on Darwin ``                                                       |
| [`db208319`](https://github.com/NixOS/nixpkgs/commit/db20831951cebae92b8e630b61bf5ca3c1bdad11) | `` gcc11: drop AVR patch on Darwin (no longer needed) ``                                                |
| [`b8617c69`](https://github.com/NixOS/nixpkgs/commit/b8617c69c0c0d2f5a687a05b7415dc840638bf5b) | `` grafana-agent: 0.38.0 -> 0.38.1 ``                                                                   |
| [`1b45f71c`](https://github.com/NixOS/nixpkgs/commit/1b45f71c2efb34ab9db46e4da6bfaf24a3cf6935) | `` elixir: enable Erlang compiler option - deterministic ``                                             |
| [`37445f3c`](https://github.com/NixOS/nixpkgs/commit/37445f3c5c1015a4f8019900e9a23528f7c6bd2a) | `` lib/customisation: fix callPackage error messages ``                                                 |
| [`1fde2844`](https://github.com/NixOS/nixpkgs/commit/1fde2844f053ce74ca0b646e7a8524b212b6ed9f) | `` python311Packages.auth0-python: 4.6.0 -> 4.6.1 ``                                                    |
| [`fba1d733`](https://github.com/NixOS/nixpkgs/commit/fba1d73326c8c355ae6a4ab4ea8559a342d17dcc) | `` exploitdb: 2023-12-01 -> 2023-12-02 ``                                                               |
| [`57bfbc78`](https://github.com/NixOS/nixpkgs/commit/57bfbc781c39b51aa440f0d1aebead78eab9bdf4) | `` nixos/home-assistant: fix error when switching between writable and none writable lovelace config `` |
| [`455fee89`](https://github.com/NixOS/nixpkgs/commit/455fee89c0f5b5730a86a15d84e0508fa5edd15e) | `` python310Packages.garminconnect: modernize ``                                                        |
| [`c5df6668`](https://github.com/NixOS/nixpkgs/commit/c5df6668dbd6e339d5a23114ad41d7b2bbda86aa) | `` runelite: fix GPU error (missing libGL.so.1) ``                                                      |
| [`819d0d6c`](https://github.com/NixOS/nixpkgs/commit/819d0d6cc8e580f94eb9be10b59007317f70891b) | `` agdsn-zsh-config: 0.8.0 -> 0.9.0 ``                                                                  |
| [`13a5743c`](https://github.com/NixOS/nixpkgs/commit/13a5743c442d840284e58cb56958e462671881a4) | `` workflows/periodic-merge: allow manual dispatch ``                                                   |
| [`43d0502b`](https://github.com/NixOS/nixpkgs/commit/43d0502b96b6ad2af5cb04ade44734462b70afd1) | `` revup: init at 0.2.1 ``                                                                              |
| [`c0b23268`](https://github.com/NixOS/nixpkgs/commit/c0b2326892f6f2468522b2062745e8d1cd1fae09) | `` libnss-mysql: add test ``                                                                            |
| [`ac3352a6`](https://github.com/NixOS/nixpkgs/commit/ac3352a65c67adcd2d75d461b31ba02234394180) | `` pam_mysql: add test ``                                                                               |
| [`dffba140`](https://github.com/NixOS/nixpkgs/commit/dffba14043168d767a12ff86c39464b8503d3d29) | `` nixos/matrix-appservice-irc: fix syscall filter ``                                                   |
| [`37ad50cd`](https://github.com/NixOS/nixpkgs/commit/37ad50cdcf38b837929e914b9c2989606ef65917) | `` awscli2: sphinx disable test that is flaky on hydra ``                                               |
| [`08daa5a2`](https://github.com/NixOS/nixpkgs/commit/08daa5a225b175ba2e50c7b0b99b144e2e990b1f) | `` python310Packages.geopy: 2.4.0 -> 2.4.1 ``                                                           |
| [`df0c3c57`](https://github.com/NixOS/nixpkgs/commit/df0c3c570c20eb9aa0075dbf973a731c2fa31bcc) | `` fsautocomplete: fix build ``                                                                         |
| [`69fb19a7`](https://github.com/NixOS/nixpkgs/commit/69fb19a73a74988fae7dcae55936b54ef30f30ff) | `` python311Packages.pygls: 1.2.0 -> 1.2.1 ``                                                           |
| [`22b5fecd`](https://github.com/NixOS/nixpkgs/commit/22b5fecd98c2af980c787e03ea98ead70f7d5a01) | `` nixos/tests/auth-mysql: fix test ``                                                                  |
| [`fe8dd76a`](https://github.com/NixOS/nixpkgs/commit/fe8dd76ae036fd5ab5526f2fc933ae2e255877d2) | `` python310Packages.garminconnect: 0.2.9 -> 0.2.11 ``                                                  |
| [`996367d7`](https://github.com/NixOS/nixpkgs/commit/996367d7eb9fee7b187e3ec068fd3a8bdd4a5592) | `` oauth2c: 1.12.1 -> 1.12.2 ``                                                                         |
| [`5776e40f`](https://github.com/NixOS/nixpkgs/commit/5776e40f8b455972b9f92233180fd25fd7f69aa8) | `` python311Packages.zope-configuration: fix eval without aliases ``                                    |
| [`c36d884e`](https://github.com/NixOS/nixpkgs/commit/c36d884e6aafc55f1ce06cfef41f702cb16ece6f) | `` osinfo-db-tools: 1.10.0 -> 1.11.0 ``                                                                 |
| [`6f33e6e4`](https://github.com/NixOS/nixpkgs/commit/6f33e6e4ab2e47124e8c1160c574f9c60c40a523) | `` nixos/preload: fix log permission ``                                                                 |
| [`298f98bc`](https://github.com/NixOS/nixpkgs/commit/298f98bcd8247e143fe136f280848c48df6d830a) | `` maintainers: add alex-fu27 ``                                                                        |
| [`aa15f506`](https://github.com/NixOS/nixpkgs/commit/aa15f5066d695de4c4027bd8bdcf4cedcf58d058) | `` treewide: use kde mirror everywhere, don't use pname in download urls ``                             |
| [`6a5fcd06`](https://github.com/NixOS/nixpkgs/commit/6a5fcd063ecc08198e8a634a390474ea19516573) | `` python310Packages.fschat: 0.2.32 -> 0.2.33 ``                                                        |
| [`bbc5e5a8`](https://github.com/NixOS/nixpkgs/commit/bbc5e5a859627b28d0d344bcf4882fbb3b7fd492) | `` gnome-firmware: 43.2 → 45.0 ``                                                                       |
| [`1077b799`](https://github.com/NixOS/nixpkgs/commit/1077b799513c6fd9f7b0560d5c6d19540ef7f857) | `` gnome-podcasts: 0.6.0 → 0.6.1 ``                                                                     |
| [`1f628480`](https://github.com/NixOS/nixpkgs/commit/1f628480761c8e7f21380c952e3bea0a9a802ce5) | `` evolution-data-server: 3.50.1 → 3.50.2 ``                                                            |
| [`2e5bd397`](https://github.com/NixOS/nixpkgs/commit/2e5bd3978e929d498aab6f9ff0e7dc6a43ab628b) | `` xdg-desktop-portal-gnome: 45.0 → 45.1 ``                                                             |
| [`22a0523a`](https://github.com/NixOS/nixpkgs/commit/22a0523a86b8046ddf7a3b0e9969c6b57f211398) | `` loupe: 45.1 → 45.2 ``                                                                                |
| [`26e2bd4a`](https://github.com/NixOS/nixpkgs/commit/26e2bd4a824948e4068d13110e22f9554dc88451) | `` libadwaita: 1.4.1 → 1.4.2 ``                                                                         |
| [`de584ff4`](https://github.com/NixOS/nixpkgs/commit/de584ff45d3087439509de6fc347370efcdfe2d6) | `` deja-dup: 44.2 → 45.1 ``                                                                             |
| [`28517a7a`](https://github.com/NixOS/nixpkgs/commit/28517a7a6b8e0c7803a2fe18ccd3be574d65a43e) | `` python310Packages.faster-whisper: 0.9.0 -> 0.10.0 ``                                                 |
| [`e7d25259`](https://github.com/NixOS/nixpkgs/commit/e7d25259a40287c5bb9a5d236a225c47bb523eda) | `` yuzu: 1611 -> 1639, yuzu-ea: 3966 -> 4003 ``                                                         |
| [`8852a858`](https://github.com/NixOS/nixpkgs/commit/8852a858d78169d64e903452311b529761cd131e) | `` gnome.gnome-sudoku: 45.2 → 45.3 ``                                                                   |
| [`5ed6c867`](https://github.com/NixOS/nixpkgs/commit/5ed6c867579d003607b7175c7e691ae2c7f92172) | `` gnome.gnome-software: 45.1 → 45.2 ``                                                                 |
| [`487b33d6`](https://github.com/NixOS/nixpkgs/commit/487b33d61a79d66fa113385f03c5cd71c84fddef) | `` gnome.gnome-disk-utility: 45.0 → 45.1 ``                                                             |
| [`beaaa587`](https://github.com/NixOS/nixpkgs/commit/beaaa587219c15e6713a2928a65021ee7adec213) | `` evolution: 3.50.1 → 3.50.2 ``                                                                        |
| [`3f6f7d6a`](https://github.com/NixOS/nixpkgs/commit/3f6f7d6addc3357b24cee5b1a874e5587bafadbe) | `` pango: fix update version policy ``                                                                  |
| [`96f38588`](https://github.com/NixOS/nixpkgs/commit/96f38588562ff2cf9b0d0333c536bcf87fc7abc8) | `` cargo-update: 13.2.0 -> 13.3.0 ``                                                                    |
| [`d30ab98a`](https://github.com/NixOS/nixpkgs/commit/d30ab98a05c4ef5cd2bc866ed1f3269fc531edae) | `` cargo-deb: 1.42.2 -> 2.0.0 ``                                                                        |
| [`5ec7d5d5`](https://github.com/NixOS/nixpkgs/commit/5ec7d5d574652337423fe9151c29df93451a689a) | `` streamlit: 1.28.2 -> 1.29.0 ``                                                                       |
| [`3aa4ed09`](https://github.com/NixOS/nixpkgs/commit/3aa4ed098504c16c7a6fc801dc9612253b4f72c6) | `` nixos/tests/installer: init clevis tests ``                                                          |
| [`27493b4d`](https://github.com/NixOS/nixpkgs/commit/27493b4d49b6d92f4baa049424cbb2fa48b4c948) | `` nixos/clevis: init ``                                                                                |
| [`fefcf28f`](https://github.com/NixOS/nixpkgs/commit/fefcf28f8260da8be4f344e2a26f14881798a3c5) | `` libadwaita: 1.4.0 -> 1.4.1 ``                                                                        |
| [`c1567ae4`](https://github.com/NixOS/nixpkgs/commit/c1567ae44fbfa593a0bd4c0b7b639eada51db562) | `` argyllcms: 3.0.2 -> 3.1.0 ``                                                                         |
| [`81b362f8`](https://github.com/NixOS/nixpkgs/commit/81b362f89ae04c4696f0ddabc268efe0243794cb) | `` vimPlugins.nvim-treesitter: update grammars ``                                                       |
| [`8293f1a4`](https://github.com/NixOS/nixpkgs/commit/8293f1a4bc7c47cb4cafa88afbb30b3e05310055) | `` vimPlugins: update on 2023-12-02 ``                                                                  |
| [`d00d51e4`](https://github.com/NixOS/nixpkgs/commit/d00d51e45129abc69a22ffdb733cb630f3ee3765) | `` luaPackages.luasnip: init at 2.1.1-1 ``                                                              |
| [`4428fe8f`](https://github.com/NixOS/nixpkgs/commit/4428fe8f0cd8af22fd97efac66127472648e9002) | `` xfce.xfce4-settings: 4.18.3 -> 4.18.4 ``                                                             |
| [`02c2d83d`](https://github.com/NixOS/nixpkgs/commit/02c2d83dc81dee9a99c90db8d6847b57d2400932) | `` xfce.xfce4-power-manager: 4.18.2 -> 4.18.3 ``                                                        |
| [`23075760`](https://github.com/NixOS/nixpkgs/commit/230757608b2eb004b1a8a207c219337bdecd5c51) | `` xfce.tumbler: 4.18.1 -> 4.18.2 ``                                                                    |
| [`c31bc86d`](https://github.com/NixOS/nixpkgs/commit/c31bc86da8753de6575603385dd2e260af056f8e) | `` xfce.parole: 4.18.0 -> 4.18.1 ``                                                                     |
| [`cae7fd99`](https://github.com/NixOS/nixpkgs/commit/cae7fd99c3aaafa170e8a9235e8104e341b5b357) | `` driftctl: 0.39.0 -> 0.40.0 ``                                                                        |
| [`3c9e42e3`](https://github.com/NixOS/nixpkgs/commit/3c9e42e35172ea77d19e95e7a2e14215cc71c001) | `` recoll: fix changelog ``                                                                             |
| [`7084473d`](https://github.com/NixOS/nixpkgs/commit/7084473d63a718467f4e09a491551c399f3874b5) | `` recoll: 1.36.0 -> 1.36.2 ``                                                                          |
| [`a406725e`](https://github.com/NixOS/nixpkgs/commit/a406725e5925e4eb4853f4f877de35e199b0d371) | `` qrcode: update latest rev to fix compiler errors ``                                                  |
| [`18f48f28`](https://github.com/NixOS/nixpkgs/commit/18f48f2852c49e6f9842aca4f8d4f783c37c6228) | `` binocle: 0.3.1 -> 0.3.2 ``                                                                           |
| [`ecdfa2f4`](https://github.com/NixOS/nixpkgs/commit/ecdfa2f4c7f3374ad695298258e42e85d2bc95b3) | `` luddite: 1.0.2 -> 1.0.3 ``                                                                           |
| [`5b7ae356`](https://github.com/NixOS/nixpkgs/commit/5b7ae3565de3cf15882c1304d0dd0771004382c8) | `` sudo: fix meta license information (#269788) ``                                                      |
| [`4ff7f410`](https://github.com/NixOS/nixpkgs/commit/4ff7f410735f9d89f6b35be17a1b994f4eba3422) | `` tiledb: 2.18.0 -> 2.18.2 ``                                                                          |
| [`64ceb7ef`](https://github.com/NixOS/nixpkgs/commit/64ceb7ef3fb42c89c83fb0496d5942cd69f2868d) | `` python311Packages.es-client: 8.10.3 -> 8.11.0 ``                                                     |
| [`f6972351`](https://github.com/NixOS/nixpkgs/commit/f697235162fd6a63de10fa440d5a53b75b2bdb07) | `` etcd_3_4: 3.4.27 -> 3.4.28 ``                                                                        |
| [`5b9f691f`](https://github.com/NixOS/nixpkgs/commit/5b9f691ffe6cc373f581dbdaac4b0a1a074c09b9) | `` python310Packages.fontawesomefree: 6.4.2 -> 6.5.1 ``                                                 |
| [`190d2619`](https://github.com/NixOS/nixpkgs/commit/190d261984d508c694ac2fcca00c58009ecb6069) | `` etcd_3_5: 3.5.9 -> 3.5.10 ``                                                                         |