### PR TITLE
chore(flake/home-manager): `948703f3` -> `ac721691`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -282,11 +282,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701676655,
-        "narHash": "sha256-wP8i7hO2aLNJhYoTK3kqoymaCLgt4QcwWcO8d/A1CjQ=",
+        "lastModified": 1701728041,
+        "narHash": "sha256-x0pyrI1vC8evVDxCxyO6olOyr4wlFg9+VS3C3p4xFYQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "948703f3e71f1332a0cb535ebaf5cb14946e3724",
+        "rev": "ac7216918cd65f3824ba7817dea8f22e61221eaf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`ac721691`](https://github.com/nix-community/home-manager/commit/ac7216918cd65f3824ba7817dea8f22e61221eaf) | `` firefox: fix folders not showing in toolbar `` |