### PR TITLE
chore(flake/master): `f0814881` -> `0dd12985`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -439,11 +439,11 @@
     },
     "master": {
       "locked": {
-        "lastModified": 1701695441,
-        "narHash": "sha256-xaCkNelgEr2TdtDVGgTSZhZQ1/RYAdgLzGSivhcCTiA=",
+        "lastModified": 1701738320,
+        "narHash": "sha256-R+fmDXwtxYur9RU1WK+vBQkliAx9K0q4MYPInefCU2Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f0814881b9ba1391491768f44b05c1f7e65efbaf",
+        "rev": "0dd12985f2df40d3a7493a2be4d14ff9ce9e7860",
         "type": "github"
       },
       "original": {

--- a/homes/editor/neovim/init.lua
+++ b/homes/editor/neovim/init.lua
@@ -267,12 +267,7 @@ vim.keymap.set("n", "j", "v:count == 0 ? 'gj' : 'j'", { expr = true, silent = tr
 -- Diagnostic keymaps
 vim.keymap.set("n", "[d", vim.diagnostic.goto_prev, { desc = "Go to previous diagnostic message" })
 vim.keymap.set("n", "]d", vim.diagnostic.goto_next, { desc = "Go to next diagnostic message" })
-vim.keymap.set(
-  "n",
-  "<leader>e",
-  vim.diagnostic.open_float,
-  { desc = "Open floating diagnostic message" }
-)
+vim.keymap.set("n", "<leader>e", vim.diagnostic.open_float, { desc = "Open floating diagnostic message" })
 vim.keymap.set("n", "<leader>q", vim.diagnostic.setloclist, { desc = "Open diagnostics list" })
 
 -- [[ Highlight on yank ]]
@@ -318,9 +313,7 @@ local function find_git_root()
   end
 
   -- Find the Git root directory from the current file's path
-  local git_root = vim.fn.systemlist(
-    "git -C " .. vim.fn.escape(current_dir, " ") .. " rev-parse --show-toplevel"
-  )[1]
+  local git_root = vim.fn.systemlist("git -C " .. vim.fn.escape(current_dir, " ") .. " rev-parse --show-toplevel")[1]
   if vim.v.shell_error ~= 0 then
     print("Not a git repository. Searching on current working directory")
     return cwd
@@ -341,18 +334,8 @@ end
 vim.api.nvim_create_user_command("LiveGrepGitRoot", live_grep_git_root, {})
 
 -- See `:help telescope.builtin`
-vim.keymap.set(
-  "n",
-  "<leader>?",
-  require("telescope.builtin").oldfiles,
-  { desc = "[?] Find recently opened files" }
-)
-vim.keymap.set(
-  "n",
-  "<leader><space>",
-  require("telescope.builtin").buffers,
-  { desc = "[ ] Find existing buffers" }
-)
+vim.keymap.set("n", "<leader>?", require("telescope.builtin").oldfiles, { desc = "[?] Find recently opened files" })
+vim.keymap.set("n", "<leader><space>", require("telescope.builtin").buffers, { desc = "[ ] Find existing buffers" })
 vim.keymap.set("n", "<leader>/", function()
   -- You can pass additional configuration to telescope to change theme, layout, etc.
   require("telescope.builtin").current_buffer_fuzzy_find(require("telescope.themes").get_dropdown({
@@ -361,48 +344,13 @@ vim.keymap.set("n", "<leader>/", function()
   }))
 end, { desc = "[/] Fuzzily search in current buffer" })
 
-vim.keymap.set(
-  "n",
-  "<leader>gf",
-  require("telescope.builtin").git_files,
-  { desc = "Search [G]it [F]iles" }
-)
-vim.keymap.set(
-  "n",
-  "<leader>sf",
-  require("telescope.builtin").find_files,
-  { desc = "[S]earch [F]iles" }
-)
-vim.keymap.set(
-  "n",
-  "<leader>sh",
-  require("telescope.builtin").help_tags,
-  { desc = "[S]earch [H]elp" }
-)
-vim.keymap.set(
-  "n",
-  "<leader>sw",
-  require("telescope.builtin").grep_string,
-  { desc = "[S]earch current [W]ord" }
-)
-vim.keymap.set(
-  "n",
-  "<leader>sg",
-  require("telescope.builtin").live_grep,
-  { desc = "[S]earch by [G]rep" }
-)
-vim.keymap.set(
-  "n",
-  "<leader>sG",
-  ":LiveGrepGitRoot<cr>",
-  { desc = "[S]earch by [G]rep on Git Root" }
-)
-vim.keymap.set(
-  "n",
-  "<leader>sd",
-  require("telescope.builtin").diagnostics,
-  { desc = "[S]earch [D]iagnostics" }
-)
+vim.keymap.set("n", "<leader>gf", require("telescope.builtin").git_files, { desc = "Search [G]it [F]iles" })
+vim.keymap.set("n", "<leader>sf", require("telescope.builtin").find_files, { desc = "[S]earch [F]iles" })
+vim.keymap.set("n", "<leader>sh", require("telescope.builtin").help_tags, { desc = "[S]earch [H]elp" })
+vim.keymap.set("n", "<leader>sw", require("telescope.builtin").grep_string, { desc = "[S]earch current [W]ord" })
+vim.keymap.set("n", "<leader>sg", require("telescope.builtin").live_grep, { desc = "[S]earch by [G]rep" })
+vim.keymap.set("n", "<leader>sG", ":LiveGrepGitRoot<cr>", { desc = "[S]earch by [G]rep on Git Root" })
+vim.keymap.set("n", "<leader>sd", require("telescope.builtin").diagnostics, { desc = "[S]earch [D]iagnostics" })
 
 -- [[ Configure Treesitter ]]
 -- See `:help nvim-treesitter`
@@ -515,11 +463,7 @@ local on_attach = function(_, bufnr)
   nmap("gI", require("telescope.builtin").lsp_implementations, "[G]oto [I]mplementation")
   nmap("<leader>D", require("telescope.builtin").lsp_type_definitions, "Type [D]efinition")
   nmap("<leader>ds", require("telescope.builtin").lsp_document_symbols, "[D]ocument [S]ymbols")
-  nmap(
-    "<leader>ws",
-    require("telescope.builtin").lsp_dynamic_workspace_symbols,
-    "[W]orkspace [S]ymbols"
-  )
+  nmap("<leader>ws", require("telescope.builtin").lsp_dynamic_workspace_symbols, "[W]orkspace [S]ymbols")
 
   -- See `:help K` for why this keymap
   nmap("K", vim.lsp.buf.hover, "Hover Documentation")

--- a/homes/graphical/spotify/default.nix
+++ b/homes/graphical/spotify/default.nix
@@ -1,7 +1,6 @@
 {
   pkgs,
   inputs,
-  config,
   ...
 }: let
   spicePkgs = inputs.spicetify-nix.legacyPackages.${pkgs.system};


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`628c5366`](https://github.com/NixOS/nixpkgs/commit/628c5366a3f7f265f4437a193e3dcae4d455b6f3) | `` build(deps): bump cachix/cachix-action from 12 to 13 (#272012) ``                        |
| [`e3e5f288`](https://github.com/NixOS/nixpkgs/commit/e3e5f288bfbdfd7cdd990f7c60f4a92d4b37f815) | `` build(deps): bump cachix/install-nix-action from 23 to 24 (#272011) ``                   |
| [`85e14734`](https://github.com/NixOS/nixpkgs/commit/85e147343d78ef96891d0851fc94236fa18e09ec) | `` gitlab-container-registry: 3.85.0 -> 3.86.2 ``                                           |
| [`03a509bc`](https://github.com/NixOS/nixpkgs/commit/03a509bc80e93604eedeecf4fcd1eef4628f6965) | `` gitlab: 16.5.1 -> 16.5.3 ``                                                              |
| [`548ddca4`](https://github.com/NixOS/nixpkgs/commit/548ddca4e7fc1fb83013ef10afaff702891bc009) | `` python310Packages.posthog: 3.0.2 -> 3.1.0 ``                                             |
| [`93cfe804`](https://github.com/NixOS/nixpkgs/commit/93cfe804d407d92c8888b0b9ce53038eda96cca5) | `` element-desktop: add jq to update script ``                                              |
| [`e72502b9`](https://github.com/NixOS/nixpkgs/commit/e72502b9387d5a71597d8926a8ce6ce05507a239) | `` element-desktop: use electron version 27 ``                                              |
| [`ff5d637a`](https://github.com/NixOS/nixpkgs/commit/ff5d637a73883c7654092279cde34533559d18d6) | `` bun: 1.0.14 -> 1.0.15 ``                                                                 |
| [`ca9bcc2e`](https://github.com/NixOS/nixpkgs/commit/ca9bcc2e2a43eadbaf33f7388c03b3aae3f3bba7) | `` ossec: split into server & agent; 2.6 -> unstable 2023-08-09 ``                          |
| [`886446e1`](https://github.com/NixOS/nixpkgs/commit/886446e1dc0eabce9378c758893c06cd5550a3b6) | `` openobserve: init at 0.7.2 ``                                                            |
| [`00bff935`](https://github.com/NixOS/nixpkgs/commit/00bff935cb14b56a6c268ba149ef16a9f2d8015e) | `` nikto: 2.2.0 -> 2.5.0 ``                                                                 |
| [`541a7505`](https://github.com/NixOS/nixpkgs/commit/541a7505033be5efc5fe76f3efdf6d7325100c70) | `` python310Packages.farm-haystack: 1.22.0 -> 1.22.1 ``                                     |
| [`e6a98c82`](https://github.com/NixOS/nixpkgs/commit/e6a98c8254f4742a7ee102fd55f85387359832b6) | `` nixos/mattermost: fix `mkPackageOption` default name ``                                  |
| [`def748ad`](https://github.com/NixOS/nixpkgs/commit/def748adb46d17b79ade7a2ac0b3a244eb5ac77a) | `` sgfutils: init at unstable-2017-11-27 ``                                                 |
| [`8998288f`](https://github.com/NixOS/nixpkgs/commit/8998288f7bf25c8dedac09a563523f25a47e32ea) | `` luaPackages.fzy: init at 1.0-1 ``                                                        |
| [`d2800c58`](https://github.com/NixOS/nixpkgs/commit/d2800c585b0b69c7f531860331b2a9223065e8a9) | `` cudaPackages.nccl: support building with CUDA < 11.4 with cudatoolkit ``                 |
| [`31607456`](https://github.com/NixOS/nixpkgs/commit/31607456eeb8eff28603e0ee56493b0ac166fec1) | `` python3Packages.tensorflow: move asserts to broken to avoid breaking eval ``             |
| [`d23df73a`](https://github.com/NixOS/nixpkgs/commit/d23df73a07a8cb8a3b8fb0630a8a861a2afc74b6) | `` ctranslate2: enable cuDNN only if it is available ``                                     |
| [`5bf016e1`](https://github.com/NixOS/nixpkgs/commit/5bf016e1e98accfd62c5bbd5a6dea3049af72595) | `` python3Packages.torch: enable cuDNN & NCCL only if available ``                          |
| [`8c59811e`](https://github.com/NixOS/nixpkgs/commit/8c59811e4eabfc15896aea584dfb58f9bd227cf5) | `` root5: broken with clang ``                                                              |
| [`bb5dbaa4`](https://github.com/NixOS/nixpkgs/commit/bb5dbaa4fa0cb3d9ca93372291b57f9844bd71cf) | `` maude: remove clang version special casing ``                                            |
| [`274c1f09`](https://github.com/NixOS/nixpkgs/commit/274c1f0970e715ba4793fcd68b666af03a79a83e) | `` haskell.compiler.ghc865Binary: don't pass llvmPackages_6 ``                              |
| [`bd151aad`](https://github.com/NixOS/nixpkgs/commit/bd151aad5bceba29d3c78f4df848ef9fabe55939) | `` haskell.compiler.ghc865Binary: correct useLLVM condition ``                              |
| [`ea7faf9d`](https://github.com/NixOS/nixpkgs/commit/ea7faf9d9e2add046b819aab954932121a508633) | `` haskell.compiler.ghc865Binary: clean up unused aarch64-linux src ``                      |
| [`ae29d067`](https://github.com/NixOS/nixpkgs/commit/ae29d067ffef9693dcd5b1b9c4c4eafca2f87ac9) | `` llvmPackages_7: remove at 7.1.0 ``                                                       |
| [`01052abf`](https://github.com/NixOS/nixpkgs/commit/01052abf25a9458f7a43a08974dfdb65329923ac) | `` cone: unstable-2021-07-25 -> unstable-2022-12-12 ``                                      |
| [`46f14d30`](https://github.com/NixOS/nixpkgs/commit/46f14d30aa6a57dfdc008901b2d58c54365a0290) | `` haskell.compiler.ghc884: remove at 8.8.4 ``                                              |
| [`87724c94`](https://github.com/NixOS/nixpkgs/commit/87724c94c3950a50c66661c7132254ee13f7370f) | `` mastodon: 4.2.1 -> 4.2.2 ``                                                              |
| [`5ac7bc51`](https://github.com/NixOS/nixpkgs/commit/5ac7bc5197516267524bfc740456f700867745fb) | `` ncurses: gate postFixup related to unicode support (closes #271716) ``                   |
| [`4e40a200`](https://github.com/NixOS/nixpkgs/commit/4e40a200f55a2160fadbfbe37901fe9c65b7c737) | `` haskellPackages: mark builds failing on hydra as broken ``                               |
| [`ebef0c31`](https://github.com/NixOS/nixpkgs/commit/ebef0c31074009f49a7d2e900deff099137ed0fd) | `` cudaPackages.nccl-tests: support building with CUDA < 11.4 with cudatoolkit ``           |
| [`2252b262`](https://github.com/NixOS/nixpkgs/commit/2252b26260f64ab7d21bddd3b6d1ceb2564c30c2) | `` python3Packages.jaxlib-bin: move asserts to broken to avoid breaking eval ``             |
| [`28608b04`](https://github.com/NixOS/nixpkgs/commit/28608b04486f5c9218ba6b74f347456253ea9f4f) | `` nixos/clevis: skip filesystem with null devices ``                                       |
| [`9b6b9349`](https://github.com/NixOS/nixpkgs/commit/9b6b934949a02ef19868f76df0f5dbcef67a8278) | `` nixos/clevis: guard zfs code behind config.clevis.boot.initrd.enable ``                  |
| [`ac3ce007`](https://github.com/NixOS/nixpkgs/commit/ac3ce007c77dff5793eec96b0c3e415d06babc49) | `` vault: 1.14.4 -> 1.14.7 ``                                                               |
| [`e9269d82`](https://github.com/NixOS/nixpkgs/commit/e9269d82f7842c0c3050c402ee98ebfdc20524bb) | `` python311Packages.torchaudio: fix build when cudaSupport is enabled ``                   |
| [`08419410`](https://github.com/NixOS/nixpkgs/commit/084194100c0d39ecfd4b4fb9d21551ceccab9c1b) | `` rure: update Cargo.lock ``                                                               |
| [`c77b10b4`](https://github.com/NixOS/nixpkgs/commit/c77b10b41ba82f1913944bae1504a4120c4efdd6) | `` hydra_unstable: 2023-12-01 -> 2023-12-04 ``                                              |
| [`023cd82d`](https://github.com/NixOS/nixpkgs/commit/023cd82d0402e74886696699f9b681e9dc7194f0) | `` vscode-extensions.elixir-lsp.vscode-elixir-ls: 0.17.5 -> 0.17.10 ``                      |
| [`a449e06d`](https://github.com/NixOS/nixpkgs/commit/a449e06d5fb1aa174ff5e6f7c429d2f02e1b5548) | `` rustc-wasm32: fix build ``                                                               |
| [`66ec462b`](https://github.com/NixOS/nixpkgs/commit/66ec462bfd4d294323db26ed2b1c49a245e79ece) | `` python310Packages.oelint-parser: 2.11.6 -> 2.12.0 ``                                     |
| [`26bb95da`](https://github.com/NixOS/nixpkgs/commit/26bb95dae986aa902d4596287a3a9b37328f7b4b) | `` python311Packages.azure-identity: fix propogatedBuildImports and darwin ``               |
| [`3d00512f`](https://github.com/NixOS/nixpkgs/commit/3d00512fce24402f2d6a3580d1d4238dda7f2139) | `` linuxKernel.kernels.linux_lqx: 6.6.3-lqx1 -> 6.6.4-lqx1 ``                               |
| [`7fba22e3`](https://github.com/NixOS/nixpkgs/commit/7fba22e321209e45d14264da6d169d614d26fbd7) | `` linuxKernel.kernels.linux_zen: 6.6.3-zen1 -> 6.6.4-zen1 ``                               |
| [`00accfe5`](https://github.com/NixOS/nixpkgs/commit/00accfe5651cdd279e9b705f592e387c5fc4e129) | `` vscode-extensions.davidanson.vscode-markdownlint: 0.52.0 -> 0.53.0 ``                    |
| [`406772bf`](https://github.com/NixOS/nixpkgs/commit/406772bf9953775aa19ddadb6abde5681a1d916e) | `` python310Packages.oauthenticator: 16.2.0 -> 16.2.1 ``                                    |
| [`1f3e5702`](https://github.com/NixOS/nixpkgs/commit/1f3e570272d9aa504808fe9c418b36a80f7d4085) | `` python311Packages.syncedlyrics: refactor ``                                              |
| [`451238c2`](https://github.com/NixOS/nixpkgs/commit/451238c21663fd523bf8301fc32a5c8c300b68b6) | `` python311Packages.syncedlyrics: 0.6.1 -> 0.7.0 ``                                        |
| [`a358f634`](https://github.com/NixOS/nixpkgs/commit/a358f6347aae695c52c39f9f54799c67daa855b2) | `` python310Packages.numpy-stl: 3.0.1 -> 3.1.1 ``                                           |
| [`c817976d`](https://github.com/NixOS/nixpkgs/commit/c817976de50d26c5c6593af6dc234ada9245d1f0) | `` pulumi-bin: 3.94.0 -> 3.95.0 ``                                                          |
| [`c8b52e55`](https://github.com/NixOS/nixpkgs/commit/c8b52e55f76f9d75bccc20e9beb33f96af994f0d) | `` kor: initial at 0.3.0 ``                                                                 |
| [`fc8fa7c2`](https://github.com/NixOS/nixpkgs/commit/fc8fa7c26bd4033979de1eddf01fbc8e061121b2) | `` treewide: remove unused qmake and cmake ``                                               |
| [`e4c124c5`](https://github.com/NixOS/nixpkgs/commit/e4c124c5a1741478ba8279951869beec642dfa17) | `` treewide: replace `inherit (libsForQt5)` with `libsForQt5.callPackage` where possible `` |
| [`4e5d8476`](https://github.com/NixOS/nixpkgs/commit/4e5d847614831d79759cdcbfa83b4b5e7f6f1870) | `` python310Packages.mkdocs-swagger-ui-tag: 0.6.6 -> 0.6.7 ``                               |
| [`e76d8d1a`](https://github.com/NixOS/nixpkgs/commit/e76d8d1a326fcbdde58241d4e6d1c9716823c460) | `` python310Packages.meep: 1.27.0 -> 1.28.0 ``                                              |
| [`f9972484`](https://github.com/NixOS/nixpkgs/commit/f997248425ec535993a905f0ad676593103e5182) | `` ocamlPackages.gluten-eio: init at 0.5.0 ``                                               |
| [`f88ba5ea`](https://github.com/NixOS/nixpkgs/commit/f88ba5ea192736529d7b2a1ab1490624953c38f2) | `` ocamlPackages.gluten: 0.3.0 → 0.5.0 ``                                                   |
| [`54557f8b`](https://github.com/NixOS/nixpkgs/commit/54557f8bfa59351354524053d4787ce2ee5c4f90) | `` sshx-server: add web ui ``                                                               |
| [`673c8d72`](https://github.com/NixOS/nixpkgs/commit/673c8d72ca29bc6a3d69008e4ca76947f4b5827a) | `` sshx: split components, unstable-2023-11-04 -> unstable-2023-11-23 ``                    |
| [`1105fa7e`](https://github.com/NixOS/nixpkgs/commit/1105fa7e134a5baa7ad416ac56797e9aab8e9f21) | `` monophony: 2.3.1 -> 2.4.0 ``                                                             |
| [`3768e103`](https://github.com/NixOS/nixpkgs/commit/3768e103ef9786850fb2fdca268f387c03c962f4) | `` pynitrokey: 0.4.42 -> 0.4.43 ``                                                          |
| [`3e320a2a`](https://github.com/NixOS/nixpkgs/commit/3e320a2ada9e43ddd32094c3806b3666d9994a3a) | `` polyml: enable tests ``                                                                  |
| [`69d4020b`](https://github.com/NixOS/nixpkgs/commit/69d4020bbbf061029f80f5956ee5a5064c25d64a) | `` polyml: move definition of `src` attribute to standard location ``                       |
| [`df6a845b`](https://github.com/NixOS/nixpkgs/commit/df6a845b71064dfdde801a0962e1dac76258fa51) | `` aws-workspaces: 4.6.0 include missing xcbutil dependency ``                              |
| [`e8d71f69`](https://github.com/NixOS/nixpkgs/commit/e8d71f6901f728999168b8fbffbed319dff5c27f) | `` handlr-regex: 0.8.5 -> 0.9.0 ``                                                          |
| [`931de380`](https://github.com/NixOS/nixpkgs/commit/931de380e145386b34fd75dd36eee5f61eadd3ad) | `` olive-editor: fix build by pinning openimageio to 2.4.15.0 ``                            |
| [`bbf87577`](https://github.com/NixOS/nixpkgs/commit/bbf875773f5e84913154cf3555dfc5b9e621a294) | `` zsh-vi-mode: set platforms ``                                                            |
| [`e673ae14`](https://github.com/NixOS/nixpkgs/commit/e673ae14059391e00cf2a55cb6611948502c7730) | `` fcitx5-bamboo: init at 1.0.4 ``                                                          |
| [`cbf69c83`](https://github.com/NixOS/nixpkgs/commit/cbf69c83d3b2bdc5eca341aa9e44e0406794af81) | `` nixos/mastodon: clarify the need to set streamingProcesses ``                            |
| [`5bf787f8`](https://github.com/NixOS/nixpkgs/commit/5bf787f8c21c0502e7874abd4cc84ca656a11a1a) | `` pat: 0.15.0 -> 0.15.1 ``                                                                 |
| [`db4ce465`](https://github.com/NixOS/nixpkgs/commit/db4ce465edd23222973fff494b0cc3a522d7a3dc) | `` handlr-regex: migrate to pkgs/by-name ``                                                 |
| [`294645a0`](https://github.com/NixOS/nixpkgs/commit/294645a07a96e2135a3ff43cee7a8585665c8c65) | `` python310Packages.latexify-py: 0.4.1 -> 0.4.2 ``                                         |
| [`5286ff07`](https://github.com/NixOS/nixpkgs/commit/5286ff070a0631800f328ce77172d7b185d59866) | `` grafana: 10.2.0 -> 10.2.2 ``                                                             |
| [`7a553c4d`](https://github.com/NixOS/nixpkgs/commit/7a553c4d2962266fae443c3c17d134e9279d819e) | `` python310Packages.langsmith: 0.0.63 -> 0.0.69 ``                                         |
| [`a9ffe197`](https://github.com/NixOS/nixpkgs/commit/a9ffe1975c063568059a15e863fad7a019cfa8d0) | `` hyfetch: 1.4.10 -> 1.4.11 ``                                                             |
| [`2f96d436`](https://github.com/NixOS/nixpkgs/commit/2f96d436cef9ad44198f7dfb7cd2ab83445bfc0c) | `` istioctl: 1.18.2 -> 1.20.0 ``                                                            |
| [`193f6e7f`](https://github.com/NixOS/nixpkgs/commit/193f6e7fd279dbafd764c0886a6ee952e5b1316e) | `` python310Packages.jplephem: 2.20 -> 2.21 ``                                              |
| [`5568a104`](https://github.com/NixOS/nixpkgs/commit/5568a1043c570f02be9522d0f5aa1acfb6a5156d) | `` python310Packages.intellifire4py: 3.1.30 -> 3.5.0 ``                                     |
| [`edbc1427`](https://github.com/NixOS/nixpkgs/commit/edbc14275838c7d018d2a55a54df40e8ea3189b0) | `` python310Packages.inquirer: 3.1.3 -> 3.1.4 ``                                            |
| [`d873210f`](https://github.com/NixOS/nixpkgs/commit/d873210f1eb182d4dea8e116d291f8d58600ee16) | `` pjsip: 2.13.1 -> 2.14 ``                                                                 |
| [`79567db9`](https://github.com/NixOS/nixpkgs/commit/79567db9149d508c99f03b83b7fed6d32faaa971) | `` pjsip: fix build on clang/darwin ``                                                      |
| [`8667baf1`](https://github.com/NixOS/nixpkgs/commit/8667baf161e3f705f56c1bdd9cc48f187a3627a6) | `` nixos/redmine: Fix database assertions ``                                                |
| [`5f1da6e0`](https://github.com/NixOS/nixpkgs/commit/5f1da6e04566d45c8f8d05d938e619c93e53a4c3) | `` scripts/haskell/hydra-report: use inline emoji ``                                        |
| [`cb7ba3fd`](https://github.com/NixOS/nixpkgs/commit/cb7ba3fde402d65584b888ea354bdaf29bb856b9) | `` gnomeExtensions: autoupdate ``                                                           |
| [`4ed2fdd3`](https://github.com/NixOS/nixpkgs/commit/4ed2fdd34b4cccbf71f8089b6d4c5c043e16f89b) | `` haskell-language-server: fix build with lsp 2.3 ``                                       |
| [`c391b7d4`](https://github.com/NixOS/nixpkgs/commit/c391b7d46cd93df29d35c3a16f7c8ecd92c6a93f) | `` xdg-desktop-portal-xapp: 1.0.3 -> 1.0.4 ``                                               |
| [`1abaa4ce`](https://github.com/NixOS/nixpkgs/commit/1abaa4cea1e6bed2e61e8870aaff8990ffea91c3) | `` python311Packages.picobox: refactor ``                                                   |
| [`76c77fa3`](https://github.com/NixOS/nixpkgs/commit/76c77fa3df80998e0538213311894a52a39d8d86) | `` notmuch: 0.38.1 -> 0.38.2 ``                                                             |
| [`dce34a5b`](https://github.com/NixOS/nixpkgs/commit/dce34a5be43f6b246ea83175f6cf158d62cfe2bb) | `` proxmox-backup-client: reformat input-list to usual style ``                             |
| [`10b8b720`](https://github.com/NixOS/nixpkgs/commit/10b8b720f1706dc3c418f0c21052d68b07f2d50e) | `` proxmox-backup-client: 3.0.1 -> 3.1.2 ``                                                 |
| [`6660f639`](https://github.com/NixOS/nixpkgs/commit/6660f639da24b925e88600be69372d6fdc812308) | `` mlterm: fix build on darwin/clang_16 ``                                                  |
| [`5dda2abb`](https://github.com/NixOS/nixpkgs/commit/5dda2abb3f3395c57ca7a626fb092646f6b7ba64) | `` deltachat-desktop: 1.42.1 -> 1.42.2 ``                                                   |
| [`8a61aa5d`](https://github.com/NixOS/nixpkgs/commit/8a61aa5d37e8025b42ad8843fb7a54214ce2e587) | `` libdeltachat: 1.131.7 -> 1.131.9 ``                                                      |
| [`274f21f1`](https://github.com/NixOS/nixpkgs/commit/274f21f1f49cc10e5ee52e37b497362f62674cb2) | `` mate.mate-panel: 1.26.3 -> 1.26.4 ``                                                     |
| [`cf1efebe`](https://github.com/NixOS/nixpkgs/commit/cf1efebe8ca685e46a11af1d39c5e923dcfa59ce) | `` linuxPackages.nvidia_x11_vulkan_beta: 535.43.16 -> 535.43.19 ``                          |
| [`96012ae1`](https://github.com/NixOS/nixpkgs/commit/96012ae1052638373b08bd9d8b0251e93c9bd570) | `` hypnotix: 3.7 -> 4.0 ``                                                                  |
| [`0b95fc14`](https://github.com/NixOS/nixpkgs/commit/0b95fc140e0281b38e722824153e118318fc2291) | `` fastmod: 0.4.3 -> 0.4.4 ``                                                               |
| [`f69a2325`](https://github.com/NixOS/nixpkgs/commit/f69a2325c77f184f2ac9855d1ee02926ec1a4355) | `` pkcs11helper: 1.29.0 -> 1.30.0 ``                                                        |
| [`2c26073e`](https://github.com/NixOS/nixpkgs/commit/2c26073eaef4bdd14fd263f8f1d8c136b9156155) | `` lanraragi: remove dependency version patch ``                                            |
| [`9d5d8af1`](https://github.com/NixOS/nixpkgs/commit/9d5d8af186d1fe453b88b90ac738ba345663e364) | `` zsa-udev-rules: unstable-2022-10-26 -> unstable-2023-11-30 ``                            |
| [`834d7b76`](https://github.com/NixOS/nixpkgs/commit/834d7b76489ad06a4b6efdb818022d3e0c17d820) | `` trilium-{desktop,server}: 0.62.2 -> 0.62.3 ``                                            |
| [`da82a56a`](https://github.com/NixOS/nixpkgs/commit/da82a56ae50712279f57c451cdde37c544c57fe2) | `` wordpress: default to wordpress6_4 ``                                                    |
| [`507f1dde`](https://github.com/NixOS/nixpkgs/commit/507f1dde5722eb89c5a90a1a98c698c697c04e60) | `` python311Packages.zulip: 0.8.2 -> 0.9.0 ``                                               |
| [`1ccaf0c1`](https://github.com/NixOS/nixpkgs/commit/1ccaf0c1471adc88c2eade131f30ef21a2feaeda) | `` haskell.packages.ghc88.doctest: skip test requiring newer base ``                        |
| [`03058077`](https://github.com/NixOS/nixpkgs/commit/030580776a8e95c0871b5c6acd00c77b1d9fc545) | `` haskell.compiler.ghcHEAD: 9.9.20231014 -> 9.9.20231121 ``                                |
| [`2af613b5`](https://github.com/NixOS/nixpkgs/commit/2af613b58c9401fd7b4d270a46f22a755990fd43) | `` haskell.compiler.ghc*: set abs paths for cctools bintools w/ hadrian ``                  |
| [`d1b3251d`](https://github.com/NixOS/nixpkgs/commit/d1b3251d47c1617f88b03e9ba74a75506a0692a5) | `` python311Packages.picobox: 3.0.0 -> 4.0.0 ``                                             |
| [`5dcd7819`](https://github.com/NixOS/nixpkgs/commit/5dcd7819f7803e0bddcb482507cbd7e9b98cf2e3) | `` haskellPackages: regenerate package set based on current config ``                       |
| [`d984a65c`](https://github.com/NixOS/nixpkgs/commit/d984a65c4d0e34e8312d82ffa576fa69386aae66) | `` haskellPackages.hiedb: remove redundant patch ``                                         |
| [`3ed29a3e`](https://github.com/NixOS/nixpkgs/commit/3ed29a3e852af1cf9c37a66eff574548e828627f) | `` haskellPackages: regenerate transitive broken packages ``                                |
| [`d3291b33`](https://github.com/NixOS/nixpkgs/commit/d3291b33c3c3506f72a82637594a699ec4352105) | `` haskellPackages: hnix-store-core-0.6.1.0 -> hnix-store-core-0.7.0.0 ``                   |
| [`d35fd4d8`](https://github.com/NixOS/nixpkgs/commit/d35fd4d84ea26bf6de6d647225120665add39488) | `` haskellPackages: regenerate package set based on current config ``                       |
| [`479cffe9`](https://github.com/NixOS/nixpkgs/commit/479cffe9cd853eb71e91b81ac8d01445f29d8ce5) | `` all-cabal-hashes: 2023-11-10T11:27:19Z -> 2023-11-20T05:37:18Z ``                        |
| [`e12bd4fd`](https://github.com/NixOS/nixpkgs/commit/e12bd4fd54f6ad7ab166d3f1c1d2d9300852777b) | `` haskellPackages: stackage LTS 21.19 -> LTS 21.21 ``                                      |
| [`84e51c52`](https://github.com/NixOS/nixpkgs/commit/84e51c525d6a39c8d4047a387391faf4c901ee1a) | `` nixos/plasma5: enable dconf by default ``                                                |
| [`d3fe3372`](https://github.com/NixOS/nixpkgs/commit/d3fe3372669808cb49b53925657fe759480e4655) | `` zsh-vi-mode: 0.10.0 -> 0.11.0 ``                                                         |
| [`7dd0a639`](https://github.com/NixOS/nixpkgs/commit/7dd0a639cbd4b3a3f8cf160a6eb372c98ad43b0f) | `` igir: init at 2.0.6 ``                                                                   |
| [`e1370b78`](https://github.com/NixOS/nixpkgs/commit/e1370b78792505fa6a276a29a8e2a0b7d69756a3) | `` sss-cli: init at 0.1.1 ``                                                                |