### PR TITLE
chore(flake/unstable): `0b62f5ad` -> `d08f6384`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -894,11 +894,11 @@
     },
     "unstable": {
       "locked": {
-        "lastModified": 1701609850,
-        "narHash": "sha256-6oxM84kaQT0H/+aurIcj2ON+asWYQ96zlMUIsfhKpFE=",
+        "lastModified": 1701653742,
+        "narHash": "sha256-9bLa7tsNtFSsXZDC+XVHyT6auJxUY+gObkvnEgSV7TM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0b62f5adfd6635f8013d800ceb0cf39411a8216f",
+        "rev": "d08f6384a5d8e5cf28ab243752cd83eed2a5d700",
         "type": "github"
       },
       "original": {

--- a/homes/editor/neovim/init.lua
+++ b/homes/editor/neovim/init.lua
@@ -267,12 +267,7 @@ vim.keymap.set("n", "j", "v:count == 0 ? 'gj' : 'j'", { expr = true, silent = tr
 -- Diagnostic keymaps
 vim.keymap.set("n", "[d", vim.diagnostic.goto_prev, { desc = "Go to previous diagnostic message" })
 vim.keymap.set("n", "]d", vim.diagnostic.goto_next, { desc = "Go to next diagnostic message" })
-vim.keymap.set(
-  "n",
-  "<leader>e",
-  vim.diagnostic.open_float,
-  { desc = "Open floating diagnostic message" }
-)
+vim.keymap.set("n", "<leader>e", vim.diagnostic.open_float, { desc = "Open floating diagnostic message" })
 vim.keymap.set("n", "<leader>q", vim.diagnostic.setloclist, { desc = "Open diagnostics list" })
 
 -- [[ Highlight on yank ]]
@@ -318,9 +313,7 @@ local function find_git_root()
   end
 
   -- Find the Git root directory from the current file's path
-  local git_root = vim.fn.systemlist(
-    "git -C " .. vim.fn.escape(current_dir, " ") .. " rev-parse --show-toplevel"
-  )[1]
+  local git_root = vim.fn.systemlist("git -C " .. vim.fn.escape(current_dir, " ") .. " rev-parse --show-toplevel")[1]
   if vim.v.shell_error ~= 0 then
     print("Not a git repository. Searching on current working directory")
     return cwd
@@ -341,18 +334,8 @@ end
 vim.api.nvim_create_user_command("LiveGrepGitRoot", live_grep_git_root, {})
 
 -- See `:help telescope.builtin`
-vim.keymap.set(
-  "n",
-  "<leader>?",
-  require("telescope.builtin").oldfiles,
-  { desc = "[?] Find recently opened files" }
-)
-vim.keymap.set(
-  "n",
-  "<leader><space>",
-  require("telescope.builtin").buffers,
-  { desc = "[ ] Find existing buffers" }
-)
+vim.keymap.set("n", "<leader>?", require("telescope.builtin").oldfiles, { desc = "[?] Find recently opened files" })
+vim.keymap.set("n", "<leader><space>", require("telescope.builtin").buffers, { desc = "[ ] Find existing buffers" })
 vim.keymap.set("n", "<leader>/", function()
   -- You can pass additional configuration to telescope to change theme, layout, etc.
   require("telescope.builtin").current_buffer_fuzzy_find(require("telescope.themes").get_dropdown({
@@ -361,48 +344,13 @@ vim.keymap.set("n", "<leader>/", function()
   }))
 end, { desc = "[/] Fuzzily search in current buffer" })
 
-vim.keymap.set(
-  "n",
-  "<leader>gf",
-  require("telescope.builtin").git_files,
-  { desc = "Search [G]it [F]iles" }
-)
-vim.keymap.set(
-  "n",
-  "<leader>sf",
-  require("telescope.builtin").find_files,
-  { desc = "[S]earch [F]iles" }
-)
-vim.keymap.set(
-  "n",
-  "<leader>sh",
-  require("telescope.builtin").help_tags,
-  { desc = "[S]earch [H]elp" }
-)
-vim.keymap.set(
-  "n",
-  "<leader>sw",
-  require("telescope.builtin").grep_string,
-  { desc = "[S]earch current [W]ord" }
-)
-vim.keymap.set(
-  "n",
-  "<leader>sg",
-  require("telescope.builtin").live_grep,
-  { desc = "[S]earch by [G]rep" }
-)
-vim.keymap.set(
-  "n",
-  "<leader>sG",
-  ":LiveGrepGitRoot<cr>",
-  { desc = "[S]earch by [G]rep on Git Root" }
-)
-vim.keymap.set(
-  "n",
-  "<leader>sd",
-  require("telescope.builtin").diagnostics,
-  { desc = "[S]earch [D]iagnostics" }
-)
+vim.keymap.set("n", "<leader>gf", require("telescope.builtin").git_files, { desc = "Search [G]it [F]iles" })
+vim.keymap.set("n", "<leader>sf", require("telescope.builtin").find_files, { desc = "[S]earch [F]iles" })
+vim.keymap.set("n", "<leader>sh", require("telescope.builtin").help_tags, { desc = "[S]earch [H]elp" })
+vim.keymap.set("n", "<leader>sw", require("telescope.builtin").grep_string, { desc = "[S]earch current [W]ord" })
+vim.keymap.set("n", "<leader>sg", require("telescope.builtin").live_grep, { desc = "[S]earch by [G]rep" })
+vim.keymap.set("n", "<leader>sG", ":LiveGrepGitRoot<cr>", { desc = "[S]earch by [G]rep on Git Root" })
+vim.keymap.set("n", "<leader>sd", require("telescope.builtin").diagnostics, { desc = "[S]earch [D]iagnostics" })
 
 -- [[ Configure Treesitter ]]
 -- See `:help nvim-treesitter`
@@ -515,11 +463,7 @@ local on_attach = function(_, bufnr)
   nmap("gI", require("telescope.builtin").lsp_implementations, "[G]oto [I]mplementation")
   nmap("<leader>D", require("telescope.builtin").lsp_type_definitions, "Type [D]efinition")
   nmap("<leader>ds", require("telescope.builtin").lsp_document_symbols, "[D]ocument [S]ymbols")
-  nmap(
-    "<leader>ws",
-    require("telescope.builtin").lsp_dynamic_workspace_symbols,
-    "[W]orkspace [S]ymbols"
-  )
+  nmap("<leader>ws", require("telescope.builtin").lsp_dynamic_workspace_symbols, "[W]orkspace [S]ymbols")
 
   -- See `:help K` for why this keymap
   nmap("K", vim.lsp.buf.hover, "Hover Documentation")

--- a/homes/graphical/spotify/default.nix
+++ b/homes/graphical/spotify/default.nix
@@ -1,7 +1,6 @@
 {
   pkgs,
   inputs,
-  config,
   ...
 }: let
   spicePkgs = inputs.spicetify-nix.legacyPackages.${pkgs.system};


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`37a54300`](https://github.com/NixOS/nixpkgs/commit/37a543002cce2fea56ab92ed46baef2abc9df6de) | `` themix-gui: init at 1.15.1 ``                                                               |
| [`6befd082`](https://github.com/NixOS/nixpkgs/commit/6befd082e7c9eceab9fb247c9ee013db680fab7b) | `` ia-writer-quattro: init at unstable-2023-06-16 ``                                           |
| [`78079efb`](https://github.com/NixOS/nixpkgs/commit/78079efb8d5f2185fafb181b3180fb6a92bd1dcb) | `` maintainers: add x0ba ``                                                                    |
| [`37b106f9`](https://github.com/NixOS/nixpkgs/commit/37b106f9b04cdb35d0b2cecd9858e7fa9c3e6625) | `` postgresql.pkgs.timescaledb_toolkit: 1.16.0 -> 1.18.0 ``                                    |
| [`5aa5b3c1`](https://github.com/NixOS/nixpkgs/commit/5aa5b3c1a7f614c030a9662fe64083818b949336) | `` linux-rt_6_1: 6.1.59-rt16 -> 6.1.64-rt17 ``                                                 |
| [`430fc02b`](https://github.com/NixOS/nixpkgs/commit/430fc02b433acc512d8f676b672e7cc1a821739a) | `` linux_5_15: 5.15.140 -> 5.15.141 ``                                                         |
| [`a7db5f67`](https://github.com/NixOS/nixpkgs/commit/a7db5f67e13e1b83430569b7a1d0278fd0925c17) | `` linux_6_1: 6.1.64 -> 6.1.65 ``                                                              |
| [`518742c7`](https://github.com/NixOS/nixpkgs/commit/518742c78e3a6ef1c2b5dd971bb310673e1ad913) | `` linux_6_6: 6.6.3 -> 6.6.4 ``                                                                |
| [`03de3c5c`](https://github.com/NixOS/nixpkgs/commit/03de3c5c3fda2d9f290117b3675b76c5c5ca2a95) | `` linux_testing: 6.7-rc3 -> 6.7-rc4 ``                                                        |
| [`43b372ab`](https://github.com/NixOS/nixpkgs/commit/43b372ab66e1590de505f4c0ef96be2a75b416bf) | `` virtiofsd.meta.mainProgram: init ``                                                         |
| [`4a6045a4`](https://github.com/NixOS/nixpkgs/commit/4a6045a41b9caff2028a7d37a8d51e25f1aa45f8) | `` emacs: Use lib.withFeature ``                                                               |
| [`b3e34832`](https://github.com/NixOS/nixpkgs/commit/b3e348323eea142b8bdff8a4e693c7de8c8e5039) | `` wireplumber: 0.4.16 -> 0.4.17 ``                                                            |
| [`2d6601b2`](https://github.com/NixOS/nixpkgs/commit/2d6601b2795c9bae574338f7fd67754b47ba46fe) | `` maintainers/team-list: add nialov to geospatial team ``                                     |
| [`642e0543`](https://github.com/NixOS/nixpkgs/commit/642e05439052539ed9053775ae5044da4d481912) | `` maintainers.moni: fix github id ``                                                          |
| [`1769cf41`](https://github.com/NixOS/nixpkgs/commit/1769cf416ed58df2fc5fc9e8e7a0c0284a5ae0c9) | `` contour: 0.3.1.200 -> 0.3.12.262 ``                                                         |
| [`f171058d`](https://github.com/NixOS/nixpkgs/commit/f171058dcc574168b9e683ef1dae2bd97e7b9d8d) | `` mpvScripts.mpv-webm: Set `updateScript` ``                                                  |
| [`e8978c7b`](https://github.com/NixOS/nixpkgs/commit/e8978c7baa00ec684ea4c085320542b716060c94) | `` light: Add `meta.mainProgram` ``                                                            |
| [`f0362972`](https://github.com/NixOS/nixpkgs/commit/f03629728793cce0025338357105a65e3d9b3bbf) | `` hareThirdParty.hare-json: init at unstable-2023-09-21 ``                                    |
| [`922e4c14`](https://github.com/NixOS/nixpkgs/commit/922e4c14a4112f0da1496fe9478e3e4cac85fe3d) | `` python310Packages.icontract: 2.6.4 -> 2.6.6 ``                                              |
| [`03982f1f`](https://github.com/NixOS/nixpkgs/commit/03982f1ffd811863e8ab82f8abdf66e050333dc9) | `` python310Packages.duecredit: drop dependency on six, raise minimum python version to 3.8 `` |
| [`20f5e3a1`](https://github.com/NixOS/nixpkgs/commit/20f5e3a1374531bec4fa77ab9f54d87ba798f191) | `` addOpenGLRunpath: Add comment for deprecation schedule ``                                   |
| [`05f1bc96`](https://github.com/NixOS/nixpkgs/commit/05f1bc9654f16ec18bfd1518fe441b7a161341e6) | `` nixos/manual: add entry for addDriverRunpath ``                                             |
| [`0b3fd4b4`](https://github.com/NixOS/nixpkgs/commit/0b3fd4b4557d73372c9b49c78361f513d492456d) | `` vscode-extensions.vadimcn.vscode-lldb: 1.9.2 -> 1.10.0 ``                                   |
| [`c7c1388e`](https://github.com/NixOS/nixpkgs/commit/c7c1388e82b88378b46a9d37e7ad2e1adf23961b) | `` addDriverRunpath: init ``                                                                   |
| [`d5f7dd17`](https://github.com/NixOS/nixpkgs/commit/d5f7dd176ec1dfbc195c8f6405c823f37b5903e9) | `` netbox: 3.6.4 -> 3.6.6 ``                                                                   |
| [`7958ecca`](https://github.com/NixOS/nixpkgs/commit/7958ecca21e12f71ec8fbbe1643b9af54086a5a2) | `` codeowners: add JulienMalka to systemd-boot ``                                              |
| [`a988bde1`](https://github.com/NixOS/nixpkgs/commit/a988bde189a828def4d03a83c6ba3061e2baff15) | `` pywalfox-native: fixup indentation ``                                                       |
| [`43171011`](https://github.com/NixOS/nixpkgs/commit/43171011659348d6e60824d97483942f508c3dd1) | `` netbox: 3.6.3 -> 3.6.4 ``                                                                   |
| [`882a1ae3`](https://github.com/NixOS/nixpkgs/commit/882a1ae334dc8627bb57e722fb72bb8020bfd8e5) | `` python311Packages.scancode-toolkit: 32.0.6 -> 32.0.8 ``                                     |
| [`11cac0aa`](https://github.com/NixOS/nixpkgs/commit/11cac0aaf80505c9b4461ed7d6570840c98b800a) | `` swaylock-effects: 1.6.11 -> 1.7.0.0 ``                                                      |
| [`5779884e`](https://github.com/NixOS/nixpkgs/commit/5779884eeebe7d0ccc7655e27e6f69a711d59182) | `` vulkan-tools: support cross compilation ``                                                  |
| [`9fd3104b`](https://github.com/NixOS/nixpkgs/commit/9fd3104ba2e6017b5560f207d88b93051686779e) | `` python311Packages.dvc-objects: 1.3.0 -> 1.3.2 ``                                            |
| [`71716347`](https://github.com/NixOS/nixpkgs/commit/71716347ffab7d9a50bf543101e7d3214fe90ef9) | `` konstraint: 0.32.0 -> 0.33.0 ``                                                             |
| [`fd448e5c`](https://github.com/NixOS/nixpkgs/commit/fd448e5c0f2d4ba4cc7c05f81b358740ebd3cace) | `` nimmm: 0.2.0 -> 0.3.0 ``                                                                    |
| [`2d89dac4`](https://github.com/NixOS/nixpkgs/commit/2d89dac413f4499164c5efc0d937234c6f4c902d) | `` python310Packages.imapclient: 3.0.0 -> 3.0.1 ``                                             |
| [`a75f149e`](https://github.com/NixOS/nixpkgs/commit/a75f149eb79b54ade90b023b2c2dbceb243a6c71) | `` clipcat: 0.9.0 -> 0.11.0 ``                                                                 |
| [`9ef74b5f`](https://github.com/NixOS/nixpkgs/commit/9ef74b5fc46758c1daa8e2a5c5d05ecf9625e07a) | `` fontbakery: init at 0.10.40 ``                                                              |
| [`6b673ad6`](https://github.com/NixOS/nixpkgs/commit/6b673ad6eb90a07b276fe5f06843b0dee3993de4) | `` python311Packages.shaperglot: init at 0.3.1 ``                                              |
| [`b64e3764`](https://github.com/NixOS/nixpkgs/commit/b64e37642b92fc283bd81d4736dcb826094ee8eb) | `` python311Packages.vharfbuzz: init at 0.2.0 ``                                               |
| [`45606204`](https://github.com/NixOS/nixpkgs/commit/456062045de4cda786a00132c45cb0d6619e63fc) | `` python311Packages.dehinter: init at 4.0.0 ``                                                |
| [`8a17e333`](https://github.com/NixOS/nixpkgs/commit/8a17e333735d06cfbe74b1470945c55c080ee17d) | `` python311Packages.font-v: init at 2.1.0 ``                                                  |
| [`a08c20f4`](https://github.com/NixOS/nixpkgs/commit/a08c20f482d885f85c13c18436bb17be81953bb8) | `` python311Packages.opentypespec: init at 1.9.1 ``                                            |
| [`e5495859`](https://github.com/NixOS/nixpkgs/commit/e54958590fb6f028def967d4570a98f8903622f4) | `` python311Packages.stringbrewer: init at 0.0.1 ``                                            |
| [`5b36e339`](https://github.com/NixOS/nixpkgs/commit/5b36e3394f0270903fe579a012044b89967703b0) | `` python311Packages.sre-yield: init at 1.2 ``                                                 |
| [`b3f0566e`](https://github.com/NixOS/nixpkgs/commit/b3f0566e9ce17c4d8fc687d63cb0bb92b8a1b133) | `` python311Packages.rstr: init at 3.2.2 ``                                                    |
| [`1e5651a8`](https://github.com/NixOS/nixpkgs/commit/1e5651a8c9a87bc93d919d62b9811cea51b8b891) | `` python311Packages.ufolint: init at 1.2.0 ``                                                 |
| [`55aaa1a0`](https://github.com/NixOS/nixpkgs/commit/55aaa1a09e910dce4247a0fd97b8a10c600f56bb) | `` python311Packages.commandlines: init at 0.4.1 ``                                            |
| [`5796bf10`](https://github.com/NixOS/nixpkgs/commit/5796bf10747f97907b78bfd7d72027b540f855ad) | `` python311Packages.ots-python: init at 9.1.0 ``                                              |
| [`4b7e6a63`](https://github.com/NixOS/nixpkgs/commit/4b7e6a634143459bb379d8060fc914716405ea1a) | `` opentype-sanitizer: init at 9.1.0 ``                                                        |
| [`16fc4bb7`](https://github.com/NixOS/nixpkgs/commit/16fc4bb760b4156c1544c468b0f94ad683668bbf) | `` python311Packages.gflanguages: init at 0.5.10 ``                                            |
| [`0e4d426c`](https://github.com/NixOS/nixpkgs/commit/0e4d426cc812f966d8cfbfb3ef9052009726c26c) | `` python311Packages.collidoscope: init at 0.6.5 ``                                            |
| [`f810b9c9`](https://github.com/NixOS/nixpkgs/commit/f810b9c9d0d8987b458a3125cc5f5c6e28a56059) | `` python311Packages.kurbopy: init at 0.10.40 ``                                               |
| [`ff0d76d7`](https://github.com/NixOS/nixpkgs/commit/ff0d76d7e95d9d46d5f2a6b6cb8a47867b0dd505) | `` libsForQt5.accounts-qml-module: 0.7-unstable-2022-10-12 -> 0.7-unstable-2022-10-28 ``       |
| [`ee4d0c8b`](https://github.com/NixOS/nixpkgs/commit/ee4d0c8b556571f2e330a42244c99e0e3905dbb4) | `` libsForQt5.accounts-qml-module: init at 0.7-unstable-2022-10-12 ``                          |
| [`0a672104`](https://github.com/NixOS/nixpkgs/commit/0a67210453cfb72d4db66d2599a8605f3327d235) | `` librda: init at 0.0.5-unstable-2023-09-15 ``                                                |
| [`2bd3807c`](https://github.com/NixOS/nixpkgs/commit/2bd3807c759e070ddc9cfc347672c7d52b7e5868) | `` tuc: 1.0.0 -> 1.1.0 ``                                                                      |
| [`a65c860e`](https://github.com/NixOS/nixpkgs/commit/a65c860ec5df7aa41d506756504556bdad98c504) | `` python311Packages.babelfont: init at 3.0.1 ``                                               |
| [`60553f44`](https://github.com/NixOS/nixpkgs/commit/60553f445ae56b9e05a05a02a34324c165d8712e) | `` python311Packages.fontfeatures: init at 1.8.0 ``                                            |
| [`b863e2ca`](https://github.com/NixOS/nixpkgs/commit/b863e2cab811b56a205306d1580954b36f913452) | `` python311Packages.youseedee: init at 0.4.1 ``                                               |
| [`1e0460a0`](https://github.com/NixOS/nixpkgs/commit/1e0460a072919439562c528758067e4d925dcdc2) | `` python311Packages.glyphtools: init at 0.8.0 ``                                              |
| [`15da1285`](https://github.com/NixOS/nixpkgs/commit/15da12857e2b710b6d0f9eb8cfa8c988519989a5) | `` python311Packages.beziers: init at 0.5.0 ``                                                 |
| [`0678bf43`](https://github.com/NixOS/nixpkgs/commit/0678bf439291f529de2587aefac6508b6a681a6d) | `` python311Packages.glyphsets: init at 0.6.5 ``                                               |
| [`6a1727ac`](https://github.com/NixOS/nixpkgs/commit/6a1727ac06e32a4570ea3a4c63a51510cf24efbe) | `` python311Packages.axisregistry: init at 0.4.5 ``                                            |
| [`7e4d7bb5`](https://github.com/NixOS/nixpkgs/commit/7e4d7bb5d7a7fa194e9ade809c5df7d131c02a39) | `` bngblaster: init at 0.8.29 ``                                                               |
| [`5f3dbc36`](https://github.com/NixOS/nixpkgs/commit/5f3dbc362268e70e235e411ab5b541a8302444e0) | `` libdict: init at 1.0.3 ``                                                                   |
| [`3c4370ca`](https://github.com/NixOS/nixpkgs/commit/3c4370ca2faba1d6254360d17c72af30c53554ee) | `` prometheus-mongodb-exporter: fix service ExecStart ``                                       |
| [`5b88c07f`](https://github.com/NixOS/nixpkgs/commit/5b88c07f28aa72a3821818662f639c6ad4381bef) | `` rkvm: 0.5.1 -> 0.6.0 ``                                                                     |
| [`69a73973`](https://github.com/NixOS/nixpkgs/commit/69a73973702ad649aaae03bfaa357811fbdf4726) | `` openseachest: 23.03.1 -> 23.12 ``                                                           |
| [`eb1f6671`](https://github.com/NixOS/nixpkgs/commit/eb1f66715a014e97016d5cf4102c6d424dfac20a) | `` moar: 1.18.4 -> 1.18.5 ``                                                                   |
| [`87798ce2`](https://github.com/NixOS/nixpkgs/commit/87798ce2c96feff984e65b087eb8fde95cd17147) | `` eartag: add appstream build input ``                                                        |
| [`43174549`](https://github.com/NixOS/nixpkgs/commit/43174549453c855d47d23ac0db98bf2e50404880) | `` eartag: 0.4.3 -> 0.5.1 ``                                                                   |
| [`f58eceb3`](https://github.com/NixOS/nixpkgs/commit/f58eceb3ac2c90be23e3cc32beb4cc3ee0f98a45) | `` uiua: 0.4.1 -> 0.5.1 ``                                                                     |
| [`ed0cb7cd`](https://github.com/NixOS/nixpkgs/commit/ed0cb7cd8a013b8bbab2b0132490980ed345e4fa) | `` python310Packages.gspread: 5.12.0 -> 5.12.1 ``                                              |
| [`a8a5758d`](https://github.com/NixOS/nixpkgs/commit/a8a5758da5b1609aa628b3c7e9aea547a586e703) | `` lomiri.hfd-service: 0.2.0 -> 0.2.1 ``                                                       |
| [`440cd023`](https://github.com/NixOS/nixpkgs/commit/440cd0232deb237fc8d8f59c3e98c2e6ff23bc04) | `` lomiri.hfd-service: init at 0.2.0 ``                                                        |
| [`a7fab38b`](https://github.com/NixOS/nixpkgs/commit/a7fab38bac17bfebf608b1df1a27a5e32932f71f) | `` gridtracker: 1.23.1112 -> 1.23.1202 ``                                                      |
| [`24d9151d`](https://github.com/NixOS/nixpkgs/commit/24d9151d15168867b87669ee663e4d15a23ded91) | `` nixos/keepalived: add openFirewall option ``                                                |
| [`a6844e11`](https://github.com/NixOS/nixpkgs/commit/a6844e11a39b5815f6a670749fb07161847a070f) | `` python311Packages.adafruit-platformdetect: 3.54.0 -> 3.56.0 ``                              |
| [`1f71820a`](https://github.com/NixOS/nixpkgs/commit/1f71820a54e3991ed38fb409384e527749bd704b) | `` python310Packages.glyphslib: 6.4.1 -> 6.6.0 ``                                              |
| [`760284d2`](https://github.com/NixOS/nixpkgs/commit/760284d28c2f623a7330cb5a81f07d0f6fadeab4) | `` vesktop: 0.4.3 -> 0.4.4 ``                                                                  |
| [`1c0851c4`](https://github.com/NixOS/nixpkgs/commit/1c0851c453f72562b2388aa21d1074d0e880f416) | `` scrcpy: 2.2 -> 2.3.1 ``                                                                     |
| [`b6365e38`](https://github.com/NixOS/nixpkgs/commit/b6365e38f2525416fbc537ef866bf11e8d0fdf9f) | `` python311Packages.types-s3transfer: 0.8.1 -> 0.8.2 ``                                       |
| [`5c6b78a2`](https://github.com/NixOS/nixpkgs/commit/5c6b78a2fff0538aa272fb672dff4bc13ff571fa) | `` python311Packages.mailchecker: 5.0.9 -> 6.0.1 ``                                            |
| [`5f5c8a02`](https://github.com/NixOS/nixpkgs/commit/5f5c8a02ee7731a12a6e626f70d9e213abfe33e6) | `` python311Packages.maison: 1.4.1 -> 1.4.2 ``                                                 |
| [`7d1fe801`](https://github.com/NixOS/nixpkgs/commit/7d1fe801fe93a60280b5849b5ce45f6c6d963fa1) | `` python311Packages.license-expression: refactor ``                                           |
| [`e29640ec`](https://github.com/NixOS/nixpkgs/commit/e29640ec3c68a4994415e987704a0b1ee1663f04) | `` python311Packages.license-expression: 30.1.1 -> 30.2.0 ``                                   |
| [`84c284c6`](https://github.com/NixOS/nixpkgs/commit/84c284c656c287e85cb2e653be7f206433a1a863) | `` srm: 1.2.15 -> 1.2.15-unstable-2017-12-18 ``                                                |
| [`e73f3d00`](https://github.com/NixOS/nixpkgs/commit/e73f3d007e456c39bb4e155a5dee42b049a64a28) | `` flask-seasurf: use patch files ``                                                           |
| [`06feb44c`](https://github.com/NixOS/nixpkgs/commit/06feb44c1ab13a2cc42826c1d114f7c16fa00e00) | `` powerdns-admin: use patch files ``                                                          |
| [`ec9f89a8`](https://github.com/NixOS/nixpkgs/commit/ec9f89a840e82ae930af77333ede0d3098105019) | `` powerdns-admin: fix build ``                                                                |
| [`c20ddec0`](https://github.com/NixOS/nixpkgs/commit/c20ddec0fa8e1e80ebadb90e207119d2fa33550c) | `` python310Packages.flask-seasurf: fix build ``                                               |
| [`9118b07e`](https://github.com/NixOS/nixpkgs/commit/9118b07e4aa2480e7e296135de8823e966e7c696) | `` get-google-fonts: init at unstable-2020-06-30 ``                                            |
| [`50948fda`](https://github.com/NixOS/nixpkgs/commit/50948fda77c7a72c105a19c17432ace8092396ba) | `` pocket-updater-utility: remove update.sh script and use nix-update-script ``                |
| [`bdc31fce`](https://github.com/NixOS/nixpkgs/commit/bdc31fce2a6dd7e8d8bd221382e911448fd407cb) | `` pocket-updater-utility: 2.31.0 -> 2.36.2 ``                                                 |
| [`fb8afb1c`](https://github.com/NixOS/nixpkgs/commit/fb8afb1c019604504be8cef6bae21a4a63f81d69) | `` spotify: 1.2.22.982.g794acc0a -> 1.2.25.1011.g0348b2ea ``                                   |
| [`838e58d7`](https://github.com/NixOS/nixpkgs/commit/838e58d7c016aabe63045e7362547df070aed925) | `` libmpc: correct meta.homepage ``                                                            |
| [`da0bcb84`](https://github.com/NixOS/nixpkgs/commit/da0bcb8418ab35fbb01ea540a2f542aeefc38ec7) | `` python3Packages.pytikz-allefeld: init at unstable-2022-11-01 ``                             |
| [`40ffdaf0`](https://github.com/NixOS/nixpkgs/commit/40ffdaf0b69b88ff2efe611af631b954df194697) | `` hayabusa: init at unstable-2023-11-29 ``                                                    |
| [`41bea419`](https://github.com/NixOS/nixpkgs/commit/41bea419e73519d81713b4e816c0011bb1cb20bc) | `` sing-box: 1.7.0 -> 1.7.1 ``                                                                 |
| [`035d1e2c`](https://github.com/NixOS/nixpkgs/commit/035d1e2cf9ce2e673db853ec6a8ac6161124189a) | `` trivial-builders: add onlyBin ``                                                            |
| [`15f186a4`](https://github.com/NixOS/nixpkgs/commit/15f186a49153d9c7c6373c4a9b147de597e511bf) | `` netbeans: 19 -> 20 ``                                                                       |
| [`75d07edb`](https://github.com/NixOS/nixpkgs/commit/75d07edb328432a0e0cc2aa6db7691e9ec351a97) | `` khard: 0.19.0 -> 0.19.1 ``                                                                  |
| [`72a26c51`](https://github.com/NixOS/nixpkgs/commit/72a26c515988b7250295b29aaaccb93586393f42) | `` ouch: 0.4.2 -> 0.5.0 ``                                                                     |
| [`bc485619`](https://github.com/NixOS/nixpkgs/commit/bc485619fa5556a00d4a39d19c985a766a527080) | `` flarectl: 0.80.0 -> 0.82.0 ``                                                               |
| [`124e85ca`](https://github.com/NixOS/nixpkgs/commit/124e85cac82d6c4764ca083ab870c5d0ec9911a5) | `` libnbd: 1.18.0 -> 1.18.1 and apply patch for CVE-2023-5871 ``                               |
| [`4054f6a9`](https://github.com/NixOS/nixpkgs/commit/4054f6a9e7c322cea980d457ffcf89c0c12feee3) | `` cucumber: 9.0.2 -> 9.1.0 ``                                                                 |
| [`23bf262e`](https://github.com/NixOS/nixpkgs/commit/23bf262ee5ae7dc5bae0d9720f283055f969650a) | `` elf2uf2-rs: 1.3.7 -> 1.3.8 ``                                                               |
| [`e3a3e517`](https://github.com/NixOS/nixpkgs/commit/e3a3e517080d45f472afbe0978e5ef97149bee78) | `` python3Packages.pyunpack: migrate to pyproject ``                                           |
| [`d7522e6c`](https://github.com/NixOS/nixpkgs/commit/d7522e6c9bc69f05aa626b2dd695ba10742c0345) | `` heroku: add updateScript ``                                                                 |
| [`6ecbda28`](https://github.com/NixOS/nixpkgs/commit/6ecbda288b4ad9073c177d007d5a2811bbaea1eb) | `` greenfoot: 3.8.1 -> 3.8.2 ``                                                                |
| [`eb379802`](https://github.com/NixOS/nixpkgs/commit/eb379802fae64541a7ed63e6b4a39d69a7ca52a0) | `` alsa-scarlett-gui: 0.3.2 -> 0.3.3 ``                                                        |
| [`36e22ae5`](https://github.com/NixOS/nixpkgs/commit/36e22ae5d91aa4acc4106da0eb88479f5d1d3514) | `` python3Packages.pyunpack: fix build ``                                                      |
| [`20a9a21b`](https://github.com/NixOS/nixpkgs/commit/20a9a21b246ca684e4e5a45e543a8a53be46e1d2) | `` nixos/tsm-client: add migration code for freeform settings ``                               |
| [`98c03bf8`](https://github.com/NixOS/nixpkgs/commit/98c03bf8c6b173a9eb4eb0296a9abadcb9a65873) | `` nixos/tsm-client: stricter assertions ``                                                    |
| [`3fb29fec`](https://github.com/NixOS/nixpkgs/commit/3fb29fecd5ebeb84432bb693d678a39f6104fe85) | `` nixos/tsm-client: use `freeformType` for server config ``                                   |
| [`8b918ed8`](https://github.com/NixOS/nixpkgs/commit/8b918ed8ab43d9f99b2673c0ac5c56e55ef93b25) | `` nixos/tsm-client: submodule doesn't need singleton list ``                                  |
| [`5bc6eb73`](https://github.com/NixOS/nixpkgs/commit/5bc6eb731ea5a3824e7e45e1641098198475f62f) | `` nixos/tsm-client: server alias names cannot have spaces ``                                  |
| [`fe96d79a`](https://github.com/NixOS/nixpkgs/commit/fe96d79adf3ff2ca15d21163972639fd4964f589) | `` nixos/tsm-client: drop own `checkIUnique` for `allUnique` ``                                |
| [`363cf1e3`](https://github.com/NixOS/nixpkgs/commit/363cf1e363cdf948f11bdc46596df5b2a4bec30b) | `` nixos/tsm-client: use `mkPackageOption` for `wrappedPackage` ``                             |
| [`d5f33780`](https://github.com/NixOS/nixpkgs/commit/d5f337809e92aad743c683d3be47051052f096eb) | `` nixos/backup/tsm: use `lib.getExe'` for service command line ``                             |
| [`cec6d7f5`](https://github.com/NixOS/nixpkgs/commit/cec6d7f51a32d6085caa8636ba3003aa1f4c3be6) | `` nixos/tsm*: update product name and URLs ``                                                 |
| [`50543cf1`](https://github.com/NixOS/nixpkgs/commit/50543cf1211752b9ab1c598e80a4a23d0ee54097) | `` maintainers: add starzation ``                                                              |
| [`dda679cc`](https://github.com/NixOS/nixpkgs/commit/dda679ccabbedc7f9ccacd234b935fa933c8b402) | `` python310Packages.frozendict: 2.3.9 -> 2.3.10 ``                                            |
| [`7601067f`](https://github.com/NixOS/nixpkgs/commit/7601067f3034b7c22ec00da81a18fea8fd45537a) | `` majima: init at 0.4.0 ``                                                                    |
| [`bb29472c`](https://github.com/NixOS/nixpkgs/commit/bb29472c5f26cdb3690c743adebf218bf9fed440) | `` pinentry-bemenu: 0.12.0 -> 0.13.1 ``                                                        |
| [`9f5801ea`](https://github.com/NixOS/nixpkgs/commit/9f5801ea66756edcffec85bc784aabb45f824233) | `` dbip-country-lite: 2023-11 -> 2023-12 ``                                                    |
| [`fba69bd1`](https://github.com/NixOS/nixpkgs/commit/fba69bd1cfa6ebefb30eae956fcc2770fa1b69f9) | `` intel-graphics-compiler: 1.0.14828.8 -> 1.0.15136.4 ``                                      |
| [`9041c780`](https://github.com/NixOS/nixpkgs/commit/9041c780be345850377db27aaac95630a5f6609d) | `` termbench-pro: init at unstable-2023-01-26 ``                                               |
| [`8f5dd15a`](https://github.com/NixOS/nixpkgs/commit/8f5dd15a66d2481296257dc6e5b91e0a41516943) | `` libunicode: init at 0.3.0-unstable-2023-03-05 ``                                            |
| [`5647d108`](https://github.com/NixOS/nixpkgs/commit/5647d108b3ffaa7e216231081d26a54a7dade5ce) | `` zandronum: 3.0.1 -> 3.1.0 ``                                                                |