### PR TITLE
chore(flake/spicetify-nix): `95e7f115` -> `86b1cab1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -801,11 +801,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1701640850,
-        "narHash": "sha256-AdmEWzOumVURrb0GH8OplNl0EFPv4/XqXUeoqlk+kPU=",
+        "lastModified": 1701859943,
+        "narHash": "sha256-IqUw+25coQZlVO5JME0JqubaK/EvazbwPYjMOUOcjes=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "95e7f115efd5d55522ceb64452dcc0949878e023",
+        "rev": "86b1cab15eb716bd20bd50b4fa745ecb4c52821b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                                                              |
| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`86b1cab1`](https://github.com/Gerg-L/spicetify-nix/commit/86b1cab15eb716bd20bd50b4fa745ecb4c52821b) | `` Bump DeterminateSystems/nix-installer-action from 8 to 9 (#10) `` |
| [`eabd851d`](https://github.com/Gerg-L/spicetify-nix/commit/eabd851dd9455a0e0dfabcdf9a1bc6c8c1699417) | `` CI update 2023-12-06 (#9) ``                                      |
| [`76e11ad2`](https://github.com/Gerg-L/spicetify-nix/commit/76e11ad29711e1c989d3705aa70b0004a4afa490) | `` CI update 2023-12-05 (#8) ``                                      |