### PR TITLE
chore(flake/nix-super): `c076362d` -> `cb968c09`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -503,11 +503,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1700941252,
-        "narHash": "sha256-2c8miJcsG24YEtXOSjvgW0ES1ND5DpY+ymGPq3S56YE=",
+        "lastModified": 1701818053,
+        "narHash": "sha256-rEGJx36jULHRIT71ie3lErCawSUaNKqL9+y7toa5EmU=",
         "owner": "privatevoid-net",
         "repo": "nix-super",
-        "rev": "c076362db8b438c921d9bbe196ede50205f788c6",
+        "rev": "cb968c096f50441b50539666f65a7389a47d37a4",
         "type": "github"
       },
       "original": {
@@ -644,11 +644,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1700342017,
-        "narHash": "sha256-HaibwlWH5LuqsaibW3sIVjZQtEM/jWtOHX4Nk93abGE=",
+        "lastModified": 1700748986,
+        "narHash": "sha256-/nqLrNU297h3PCw4QyDpZKZEUHmialJdZW2ceYFobds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "decdf666c833a325cb4417041a90681499e06a41",
+        "rev": "9ba29e2346bc542e9909d1021e8fd7d4b3f64db0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                                                        |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`cb968c09`](https://github.com/privatevoid-net/nix-super/commit/cb968c096f50441b50539666f65a7389a47d37a4) | `` enable Xp::FetchTree by default ``                                          |
| [`61feb891`](https://github.com/privatevoid-net/nix-super/commit/61feb89177b6e799ce01ae55e32579b1740d285b) | `` add binary cache config ``                                                  |
| [`e488a43f`](https://github.com/privatevoid-net/nix-super/commit/e488a43f457f3ef9dba92184428bbe5381fe2634) | `` Bump actions/labeler from 4 to 5 ``                                         |
| [`e6a3cbfc`](https://github.com/privatevoid-net/nix-super/commit/e6a3cbfceb66e06184b625a3913a786f68e71a1f) | `` Bump cachix/cachix-action from 12 to 13 ``                                  |
| [`c446e529`](https://github.com/privatevoid-net/nix-super/commit/c446e5294dbc12729e7bc55ee10b40dbaeeaacf0) | `` Bump cachix/install-nix-action from 23 to 24 ``                             |
| [`823512c1`](https://github.com/privatevoid-net/nix-super/commit/823512c1e705d1fce8dfb8cde65228364c9a8045) | `` Bump zeebe-io/backport-action from 2.1.1 to 2.2.0 ``                        |
| [`5fe2accb`](https://github.com/privatevoid-net/nix-super/commit/5fe2accb754249df6cb8f840330abfcf3bd26695) | `` fix up release note ``                                                      |
| [`3c310bde`](https://github.com/privatevoid-net/nix-super/commit/3c310bde2e492c2dd8bdccdfd80076231905a429) | `` reword description for the `fetch-tree` experimental feature ``             |
| [`2e5abc0f`](https://github.com/privatevoid-net/nix-super/commit/2e5abc0fd0d5d45e125e1d981958149624268090) | `` tests: avoid a chroot store without sandbox support ``                      |
| [`24b78177`](https://github.com/privatevoid-net/nix-super/commit/24b781773f3d24b62b1c36154c36fc98417cbcdb) | `` fix random docs errors ``                                                   |
| [`59c4c82a`](https://github.com/privatevoid-net/nix-super/commit/59c4c82aebb814d864548c3ad2e9128ab6e902bf) | `` fix links in stores overview ``                                             |
| [`91b68336`](https://github.com/privatevoid-net/nix-super/commit/91b6833686a6a6d9eac7f3f66393ec89ef1d3b57) | `` Move tests to separate directories, and document ``                         |
| [`d59bdbe4`](https://github.com/privatevoid-net/nix-super/commit/d59bdbe4fd757d99b6625db1d3560a39a371d9e9) | `` Add two missing `#include "nar-info.hh"` ``                                 |
| [`ea2dd166`](https://github.com/privatevoid-net/nix-super/commit/ea2dd166235e049699cf7f70c243c2b83089f824) | `` Use a proper enum rather than a boolean in runProgramInStore ``             |
| [`333ea684`](https://github.com/privatevoid-net/nix-super/commit/333ea684b065318aa49aec367c995b3d8c5d65ed) | `` Add boost::regex regression test ``                                         |
| [`4781e7fa`](https://github.com/privatevoid-net/nix-super/commit/4781e7fa7048d2861172baaaa04a7be4b8a2b631) | `` Document each store type on its own page ``                                 |
| [`908a011a`](https://github.com/privatevoid-net/nix-super/commit/908a011a4a2fe4e494e5b6e4c94f013f159f3616) | `` Revert "Switch from std::regex to boost::regex" ``                          |
| [`0301b8fc`](https://github.com/privatevoid-net/nix-super/commit/0301b8fc7354a94dc03b57f796bfa6e853758af8) | `` reword the experimental feature notice ``                                   |
| [`39de819e`](https://github.com/privatevoid-net/nix-super/commit/39de819edaef2dc3e308a490bbb2b1622a932771) | `` rename debugging helper environment variable ``                             |
| [`cab41025`](https://github.com/privatevoid-net/nix-super/commit/cab41025d85d3b02f5175cf7ca2611c7a44c2cdd) | `` mention renaming of `nix doctor` ``                                         |
| [`d5ffc94f`](https://github.com/privatevoid-net/nix-super/commit/d5ffc94f336fc4032dd4009c14c148e390e10e16) | `` use lookup paths in helper expressions consistently ``                      |
| [`44d21f6e`](https://github.com/privatevoid-net/nix-super/commit/44d21f6ef9783bed8812d39ff7b1a28a4883f84b) | `` keep generated documentation in a separate directory ``                     |
| [`f99e4686`](https://github.com/privatevoid-net/nix-super/commit/f99e468640ab0eac7f07ac2b328222eb45dee8d8) | `` Avoid `<name>/<name>` in documentation URLs ``                              |
| [`743232bf`](https://github.com/privatevoid-net/nix-super/commit/743232bf04d8ade18cfa2c791ed466ce48519878) | `` Don’t use `execvp` when we know the path ``                                 |
| [`d536c57e`](https://github.com/privatevoid-net/nix-super/commit/d536c57e878a04f795c1ef8ee3232a47035da2cf) | `` Docs build: depend on locally built nix executable and not installed one `` |
| [`a7115a47`](https://github.com/privatevoid-net/nix-super/commit/a7115a47ef0d83ea81b494f6bc5b11d8286e0672) | `` Improve ACL clearing support (fixing FreeBSD build) ``                      |
| [`02bd821f`](https://github.com/privatevoid-net/nix-super/commit/02bd821f2e71372d31bbe6700bd68086cc2ee70a) | `` fix: `nlohmann::adl_serializer` for `std::optional` (#9147) ``              |
| [`52e09113`](https://github.com/privatevoid-net/nix-super/commit/52e0911302b20336c1600b60a98894423e110d7d) | `` Use `buildprefix` in a few more places ``                                   |
| [`6d160581`](https://github.com/privatevoid-net/nix-super/commit/6d1605818c12461edc9f4ee17a7929fdc8fe916c) | `` Rename `nix doctor` to `nix config check` ``                                |
| [`f300e11b`](https://github.com/privatevoid-net/nix-super/commit/f300e11b056dea414d7d77bbc6e5a7dc5d9ddd41) | `` Rename `nix show-config` to `nix config show` ``                            |
| [`20cd5eb2`](https://github.com/privatevoid-net/nix-super/commit/20cd5eb2b3668f5b95b6f020e1c258011c18ea33) | `` nix repl: Only hide the progress bar while waiting for user input ``        |
| [`68c48756`](https://github.com/privatevoid-net/nix-super/commit/68c48756fece5aee77f9b44607afa9248d75e67c) | `` libexpr/local.mk: Make eval compile deps regular ``                         |
| [`f7bfec28`](https://github.com/privatevoid-net/nix-super/commit/f7bfec2806708573798d610cda101f27a24d9218) | `` maintainers/release-notes: Improve DATE check ``                            |
| [`384ffb44`](https://github.com/privatevoid-net/nix-super/commit/384ffb4443fd47d04f36c6bcc6ebf476274673ab) | `` add deprecation warnings in documentation ``                                |
| [`e986d20b`](https://github.com/privatevoid-net/nix-super/commit/e986d20bedfc054663632255388bbd33fec99114) | `` Remove an obsolete comment ``                                               |
| [`75134b75`](https://github.com/privatevoid-net/nix-super/commit/75134b7513eb781074969fc8d6d865cc95063444) | `` libexpr: add missing dependency on 'flake/call-flake.nix.gen.hh' ``         |
| [`f56401a1`](https://github.com/privatevoid-net/nix-super/commit/f56401a114cb5504c3d74b893ce270ed28fd03e3) | `` `nix flake update` add deprecation warnings. ``                             |
| [`2b7016cc`](https://github.com/privatevoid-net/nix-super/commit/2b7016cc56d12e67de9f1f25b18311866a26a5fe) | `` add path based redirects ``                                                 |
| [`e7e21aa0`](https://github.com/privatevoid-net/nix-super/commit/e7e21aa0c839460a62456fa44f31339c187077ff) | `` flake.nix: Use top level changelog-d ``                                     |
| [`c5d49ec7`](https://github.com/privatevoid-net/nix-super/commit/c5d49ec7ab7b9fb33f0336a909ac837e208be807) | `` flake.lock: Update ``                                                       |
| [`d63f7219`](https://github.com/privatevoid-net/nix-super/commit/d63f72197cec6ff95d9ffc83aa8076acd86a3fd1) | `` Don't run changelog-d in the build ``                                       |
| [`f25c06d7`](https://github.com/privatevoid-net/nix-super/commit/f25c06d7a3289343887d09761c82356a3b6b441b) | `` docs: Fix broken link ``                                                    |
| [`d2f5e263`](https://github.com/privatevoid-net/nix-super/commit/d2f5e263e3c095dfe9d874387665b88c4bfff6f1) | `` Switch from std::regex to boost::regex ``                                   |
| [`857f9168`](https://github.com/privatevoid-net/nix-super/commit/857f9168f7b48aa491052f24fb571c21398f9826) | `` Migrate rl-next.md to doc/manual/rl-next directory ``                       |
| [`6971c4ad`](https://github.com/privatevoid-net/nix-super/commit/6971c4adc06d574cbe1e9ab6da19814e11e2ba6c) | `` maintainers/release-notes <- scripts/release-notes ``                       |
| [`7c4ee5c8`](https://github.com/privatevoid-net/nix-super/commit/7c4ee5c8135fae65602791f0b89d0dbae7e94f3e) | `` scripts/release-notes: Avoid mutating variables ``                          |
| [`b1ea30f2`](https://github.com/privatevoid-net/nix-super/commit/b1ea30f21d24df9afc4eb1635eee9a080e4f81f3) | `` scripts/release-notes: Support patch releases ``                            |
| [`2a538c57`](https://github.com/privatevoid-net/nix-super/commit/2a538c571b13877fa426f2cff2749cf17d140216) | `` Add scripts/release-notes ``                                                |
| [`b26038c5`](https://github.com/privatevoid-net/nix-super/commit/b26038c517ed10feae751ad6733244c00b715d34) | `` doc: Rename 2X.XX to "Upcoming release", and only generate if applicable `` |
| [`b7982372`](https://github.com/privatevoid-net/nix-super/commit/b7982372d234b1fd15bab01d09093471c1870bb4) | `` Compile hand-written release notes with changelog-d ``                      |
| [`4e790efa`](https://github.com/privatevoid-net/nix-super/commit/4e790efade0c3073292ff73be44351f29badd935) | `` Use boost::container::small_vector in place of VLAs ``                      |
| [`d6898cd5`](https://github.com/privatevoid-net/nix-super/commit/d6898cd58b1a685404ba6878c317e60be9473a9a) | `` Move applyConfigFile to lambda inside libstore ``                           |
| [`e4cbdd26`](https://github.com/privatevoid-net/nix-super/commit/e4cbdd26e0e6a2a5907dff8e60c3645f7d94423a) | `` Add TODO comment for include try/catch ``                                   |
| [`dde1d863`](https://github.com/privatevoid-net/nix-super/commit/dde1d863388617b3a63db808c125f274c86a3222) | `` Restrict some code to `StoreDirConfig` ``                                   |
| [`e97ac09a`](https://github.com/privatevoid-net/nix-super/commit/e97ac09abeab44fa3d10eb539f0b3d51f8575798) | `` Factor out `StoreDirConfig` ``                                              |
| [`1d28d613`](https://github.com/privatevoid-net/nix-super/commit/1d28d613b1d0447b60de2d2044aeac3e1d543aa6) | `` config: add included files into parsedContents before applying ``           |