### PR TITLE
chore(flake/devshell): `c3bd7791` -> `44ddedcb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1701697687,
-        "narHash": "sha256-dLLE5wQBVv+pIb4bWmKFSw2DvLVyuEk0F7ng6hpZPSU=",
+        "lastModified": 1701787589,
+        "narHash": "sha256-ce+oQR4Zq9VOsLoh9bZT8Ip9PaMLcjjBUHVPzW5d7Cw=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "c3bd77911391eb1638af6ce773de86da57ee6df5",
+        "rev": "44ddedcbcfc2d52a76b64fb6122f209881bd3e1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                                |
| ------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
| [`44ddedcb`](https://github.com/numtide/devshell/commit/44ddedcbcfc2d52a76b64fb6122f209881bd3e1e) | `` build(deps): bump cachix/install-nix-action from 23 to 24 (#285) `` |