### PR TITLE
chore(flake/hyprland): `3bb9c7c5` -> `8bd86cf3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1701737536,
-        "narHash": "sha256-xSmfHhhCL9mAta5jKfcbJxYjCoD2MdLPBMjBUWvYAJI=",
+        "lastModified": 1701819597,
+        "narHash": "sha256-X0K2v/SOMQj18/O9daDlizlnlGRDMWuuGoU3jm06b7k=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "3bb9c7c5cf4f2ee30bf821501499f2308d616f94",
+        "rev": "8bd86cf37e245088433156796f1bc72542ca09ad",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                   |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
| [`8bd86cf3`](https://github.com/hyprwm/Hyprland/commit/8bd86cf37e245088433156796f1bc72542ca09ad) | `` hyprctl: order commands alphabetically (#4061) ``                      |
| [`cfd94c5b`](https://github.com/hyprwm/Hyprland/commit/cfd94c5b30719c1c512b0d0ef4366a0cb64793e0) | `` input: Stop propagating axis events after valid binds (#4059) ``       |
| [`ab66fa43`](https://github.com/hyprwm/Hyprland/commit/ab66fa430efd1e8b9b6a0220b896998215fff8c3) | `` screencopy: fix glReadPixels offset ``                                 |
| [`37d7a8c6`](https://github.com/hyprwm/Hyprland/commit/37d7a8c64dfabfe81330c819c24fd6b13b292194) | `` framebuffer: ignore addStencil on legacyRenderer ``                    |
| [`da863459`](https://github.com/hyprwm/Hyprland/commit/da863459c49c8b9a82e6a1180c2592a2b63feccd) | `` screencopy: fix legacyrenderer builds ``                               |
| [`83248b69`](https://github.com/hyprwm/Hyprland/commit/83248b6936c00ddef6a39fa31a37949ca1a34ffe) | `` toplevelexport: fix getPreferredReadFormat param in captureToplevel `` |