### PR TITLE
chore(flake/chaotic): `5a9ea054` -> `f1a58727`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1701777779,
-        "narHash": "sha256-pJTdvqt6XedsW+0dDzq363K5oGpkwNd1o4cBe0A2UcY=",
+        "lastModified": 1701907081,
+        "narHash": "sha256-vQOZk96CNip3RWtB0KTLzenun2FtLqKN69K8I6Sc5MQ=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "5a9ea054d7905d2264cbec76181ca48193d6dab9",
+        "rev": "f1a58727be265987587994ca13d96e65a6f250cd",
         "type": "github"
       },
       "original": {
@@ -533,12 +533,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701436327,
-        "narHash": "sha256-tRHbnoNI8SIM5O5xuxOmtSLnswEByzmnQcGGyNRjxsE=",
-        "rev": "91050ea1e57e50388fa87a3302ba12d188ef723a",
-        "revCount": 555097,
+        "lastModified": 1701718080,
+        "narHash": "sha256-6ovz0pG76dE0P170pmmZex1wWcQoeiomUZGggfH9XPs=",
+        "rev": "2c7f3c0fb7c08a0814627611d9d7d45ab6d75335",
+        "revCount": 556224,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.555097%2Brev-91050ea1e57e50388fa87a3302ba12d188ef723a/018c3450-2363-7c34-883b-4ba70b1eb7ae/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.556224%2Brev-2c7f3c0fb7c08a0814627611d9d7d45ab6d75335/018c4130-1dfe-7107-b79c-75c69c756ef4/source.tar.gz"
       },
       "original": {
         "type": "tarball",


### PR DESCRIPTION
| Commit                                                                                          | Message                                                    |
| ----------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`f1a58727`](https://github.com/chaotic-cx/nyx/commit/f1a58727be265987587994ca13d96e65a6f250cd) | `` nixpkgs: bump to 20231206 ``                            |
| [`429d0de6`](https://github.com/chaotic-cx/nyx/commit/429d0de666c3326ac0cbc8807e7e114c79a0af6f) | `` failures: update ``                                     |
| [`b8f8426f`](https://github.com/chaotic-cx/nyx/commit/b8f8426f8369681521ef6f1c56f3ff53f2cde28e) | `` linux_cachyos-sched-ext: restore debug config (#469) `` |
| [`b59a68c4`](https://github.com/chaotic-cx/nyx/commit/b59a68c4371708f7e459ad58bea609c64c37a79d) | `` linux_cachyos-sched-ext: init (#467) ``                 |
| [`1891e8d5`](https://github.com/chaotic-cx/nyx/commit/1891e8d589e3a6225baad499ca0f5444275e8295) | `` Bump 20231206-1 (#468) ``                               |