### PR TITLE
chore(flake/unstable): `d08f6384` -> `9ed8ade7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -894,11 +894,11 @@
     },
     "unstable": {
       "locked": {
-        "lastModified": 1701653742,
-        "narHash": "sha256-9bLa7tsNtFSsXZDC+XVHyT6auJxUY+gObkvnEgSV7TM=",
+        "lastModified": 1701847270,
+        "narHash": "sha256-ttPWHy1NZwJzSzY7OmofFNyrm9kWc+RFFHpJGeQ4kWw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d08f6384a5d8e5cf28ab243752cd83eed2a5d700",
+        "rev": "9ed8ade77aef706a03d8cc3a5ad4f60848ac59a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                            |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| [`e1567f2e`](https://github.com/NixOS/nixpkgs/commit/e1567f2ee091ca3f43b4b41c143c29d0032adf29) | `` yggdrasil: 0.5.2 → 0.5.4 ``                                                                     |
| [`a0841222`](https://github.com/NixOS/nixpkgs/commit/a08412222dad0a4cbd6d41e405779b54a6001652) | `` home-assistant-custom-lovelace-modules.mini-media-player: 1.16.5 -> 1.16.6 ``                   |
| [`01616e53`](https://github.com/NixOS/nixpkgs/commit/01616e5331d2790127aa2e61c126fff9467889f2) | `` buildHomeAssistantComponent: migrate from pname to owner/domain ``                              |
| [`745ee32b`](https://github.com/NixOS/nixpkgs/commit/745ee32b0eaa8e0119d75bcc1649ef68db0e43dd) | `` safeeyes: use the installed share files ``                                                      |
| [`b61b6139`](https://github.com/NixOS/nixpkgs/commit/b61b6139746de96699c3805e43a979500d198312) | `` python311Packages.pymiele: init at 0.1.7 ``                                                     |
| [`19b79e77`](https://github.com/NixOS/nixpkgs/commit/19b79e77c6f2af55aa0d069cd67362be677140e5) | `` noto-fonts-color-emoji: 2.038 -> 2.042 ``                                                       |
| [`21d23ddd`](https://github.com/NixOS/nixpkgs/commit/21d23dddd8b8ecaee8ea2690b7c029d99ceec81e) | `` nixos/windmill: init module ``                                                                  |
| [`93c790ae`](https://github.com/NixOS/nixpkgs/commit/93c790aef367e2f72fd9a9a22741ef1ed7136fc4) | `` nixos/clamav: add scanner service ``                                                            |
| [`6b014e92`](https://github.com/NixOS/nixpkgs/commit/6b014e92def834ffd2101942031e09ac1772760f) | `` nixos/clamav: fix /run/clamav being removed ``                                                  |
| [`04b28d5c`](https://github.com/NixOS/nixpkgs/commit/04b28d5c69bb6abf8a68c9d0619a07fc4b235798) | `` discourse: stop redis (#244037) ``                                                              |
| [`7ad508ad`](https://github.com/NixOS/nixpkgs/commit/7ad508ade792c2a264339d0df92e40563d31db70) | `` fish: 3.6.1 -> 3.6.4 ``                                                                         |
| [`b5ca84b4`](https://github.com/NixOS/nixpkgs/commit/b5ca84b4507550b956a4ba38a8f6ad64d1f201de) | `` npmHooks.npmInstallHook: only overwrite npm cache for `npm pack` rather than for entire hook `` |
| [`b8bf2d1f`](https://github.com/NixOS/nixpkgs/commit/b8bf2d1f0dcd6b8b537e774ecddde372fddb0010) | `` phpPackages.box: 4.5.0 -> 4.5.1 ``                                                              |
| [`9412fe03`](https://github.com/NixOS/nixpkgs/commit/9412fe03490b12b8223ef5ecbe53021a3c690bae) | `` python311Packages.uritemplate: refactor ``                                                      |
| [`6140c13b`](https://github.com/NixOS/nixpkgs/commit/6140c13b3569cf135f92a63f2f86a215522be720) | `` python311Packages.uritemplate: add changelog to meta ``                                         |
| [`18a2e518`](https://github.com/NixOS/nixpkgs/commit/18a2e518cdcef0764cfd7a96c39fdc0e7874e9fd) | `` tiny-cuda-nn: prune runtime closure ``                                                          |
| [`b9635cfa`](https://github.com/NixOS/nixpkgs/commit/b9635cfa4d659ca652ab4c400988d6c8b1e453c0) | `` tiny-cuda-nn: cuda_cccl required with the newer cuda ``                                         |
| [`37ec2cb6`](https://github.com/NixOS/nixpkgs/commit/37ec2cb6b173c7d5b78ec704db533454f9bc84ba) | `` cudaPackages.setupCudaHook: source only from nativeBuildInputs ``                               |
| [`d031523a`](https://github.com/NixOS/nixpkgs/commit/d031523a012688079e3bef68abaab2f8c5d099af) | `` cudaPackages.cuda_nvcc: fix hook's offsets (-1, -1) -> (-1, 0) ``                               |
| [`e084a6c6`](https://github.com/NixOS/nixpkgs/commit/e084a6c648fecd473ff6190a5acac3369b292530) | `` cudaPackages_11_3.saxpy: fallback to the cudatoolkit runfile ``                                 |
| [`182e6b41`](https://github.com/NixOS/nixpkgs/commit/182e6b41d08d37c8eb817212b88b37b671abfb22) | `` cudaPackages.setupCudaHook: rewrite cudartFlags, remove infinite recursion in cudatoolkit ``    |
| [`a7891f2a`](https://github.com/NixOS/nixpkgs/commit/a7891f2adaf409a95b2c0d8e373270993951e69d) | `` cudaPackages.setupCudaHook: fix cudart flags ``                                                 |
| [`b62d471f`](https://github.com/NixOS/nixpkgs/commit/b62d471f62a2042394869922010a713aaa5a3486) | `` nh: init at 3.4.12 ``                                                                           |
| [`44a8d8f0`](https://github.com/NixOS/nixpkgs/commit/44a8d8f0450c47125db0d47e17ffdc8f8cc93834) | `` interception-tools-plugins: Add recurseIntoAttrs ``                                             |
| [`d1964e1d`](https://github.com/NixOS/nixpkgs/commit/d1964e1d2c84f8bed0de41931b107de5f250b7ba) | `` libsForQt5.qtutilities: 6.13.2 -> 6.13.3 ``                                                     |
| [`4d1f6283`](https://github.com/NixOS/nixpkgs/commit/4d1f62836e26369630434fab2e77c4e3336e94b4) | `` scripts/create-amis.sh: Update region list ``                                                   |
| [`b3caa5f5`](https://github.com/NixOS/nixpkgs/commit/b3caa5f50a90a069b1f9596b48be6cb95d94171b) | `` ferretdb: 1.15.0 -> 1.16.0 (#272254) ``                                                         |
| [`f9a2a9f1`](https://github.com/NixOS/nixpkgs/commit/f9a2a9f18aaa3441681a3888cf8b127308eb3682) | `` phpExtensions.php-spx: rename extension and folder ``                                           |
| [`d1de0b1b`](https://github.com/NixOS/nixpkgs/commit/d1de0b1b8a845c1254c1f1489b5e66acb2eb2e76) | `` warp: 0.6.1 -> 0.6.2 ``                                                                         |
| [`26401d46`](https://github.com/NixOS/nixpkgs/commit/26401d463e99de79fda40da1d57ceae7eca8f711) | `` phpExtensions.php-spx: change pname to spx ``                                                   |
| [`7a5f0e94`](https://github.com/NixOS/nixpkgs/commit/7a5f0e9467620884c8be5b87474c63288247faf9) | `` clp: unbreak on aarch64-linux ``                                                                |
| [`7c77b21f`](https://github.com/NixOS/nixpkgs/commit/7c77b21fd949ad0e9b45fb58c2626033f8758895) | `` fishPlugins.fzf-fish: 10.1 -> 10.2 ``                                                           |
| [`ca4fd336`](https://github.com/NixOS/nixpkgs/commit/ca4fd336225d1cebd753007be54669d215bf2ee4) | `` python311Packages.habluetooth: 0.5.1 -> 0.6.1 ``                                                |
| [`2144d651`](https://github.com/NixOS/nixpkgs/commit/2144d651ac707cfd301cab13448d43c167f95d26) | `` symfony-cli: 5.7.3 -> 5.7.4 ``                                                                  |
| [`66447698`](https://github.com/NixOS/nixpkgs/commit/66447698978f2bdc7fbd3ba9b930b6f72f5a9a70) | `` phpPackages.psalm: add `meta.mainProgram` ``                                                    |
| [`254477de`](https://github.com/NixOS/nixpkgs/commit/254477deb4b773a9ba64aed115576d5434f6638b) | `` phpPackages.grumphp: add `meta.mainProgram` ``                                                  |
| [`fbb49362`](https://github.com/NixOS/nixpkgs/commit/fbb493629fa10294f7a2fe8655fac6a4dc49dfcb) | `` phpPackages.composer: add `meta.mainProgram` ``                                                 |
| [`ec05ba5b`](https://github.com/NixOS/nixpkgs/commit/ec05ba5b4e91c28ea1df06ebb70fa8751cfc08d3) | `` phpunit: add `meta.mainProgram` ``                                                              |
| [`9c67d604`](https://github.com/NixOS/nixpkgs/commit/9c67d604249932ec3ae155d73863072e8ef48435) | `` python310Packages.pyomo: update disabled ``                                                     |
| [`46b647b9`](https://github.com/NixOS/nixpkgs/commit/46b647b9e19ca4f00ff534c79d4dc6afc9f602b4) | `` python311Packages.dvc-render: 0.6.0 -> 1.0.0 ``                                                 |
| [`913e9397`](https://github.com/NixOS/nixpkgs/commit/913e939769f335caecd9bcd23dac556b103e4fd6) | `` CODEOWNERS: fix errors ``                                                                       |
| [`64a56afc`](https://github.com/NixOS/nixpkgs/commit/64a56afce4b8629d7a9e9b3958ebbf7eced59c5f) | `` frankenphp: add shyim as maintainer ``                                                          |
| [`49a1283e`](https://github.com/NixOS/nixpkgs/commit/49a1283e137964f00242bafa8f1eb414cda771cf) | `` fscan: 1.8.3 -> 1.8.3-build3 ``                                                                 |
| [`b735b9b2`](https://github.com/NixOS/nixpkgs/commit/b735b9b29fbc88910611adc005408f55288e39f0) | `` maintainers: add viperML ``                                                                     |
| [`d011c93f`](https://github.com/NixOS/nixpkgs/commit/d011c93f7d492b5979f85ca713c4e191308e7321) | `` nixos/hound: adopt, rework, cleanup (#268983) ``                                                |
| [`5d669c5d`](https://github.com/NixOS/nixpkgs/commit/5d669c5d95d7dd2930832e2bce58eddbffe993f5) | `` last: 1499 -> 1518 ``                                                                           |
| [`5c6c35d0`](https://github.com/NixOS/nixpkgs/commit/5c6c35d0f807fdb9562aaf06d0ce8f5bf6924fa0) | `` nixos/prometheus: add enableAgentMode option ``                                                 |
| [`e6c2707a`](https://github.com/NixOS/nixpkgs/commit/e6c2707ab266ca1f0c1a8125d3bcc73929dbbfb1) | `` maid: init at 0.10 ``                                                                           |
| [`25d8ad13`](https://github.com/NixOS/nixpkgs/commit/25d8ad138414ed3aa436b79ab41f1f1d43b1f1f2) | `` open62541: 1.3.8 -> 1.3.9 ``                                                                    |
| [`6b124190`](https://github.com/NixOS/nixpkgs/commit/6b124190b1ebdbf72124a16fed0b0bd2c9dabc3d) | `` matrix-sliding-sync: 0.99.12 -> 0.99.13 ``                                                      |
| [`e812ec2c`](https://github.com/NixOS/nixpkgs/commit/e812ec2c57a4988e20a80d6b3b6d0f89510ab66d) | `` xfce.xfce4-cpugraph-plugin: 1.2.8 -> 1.2.10 ``                                                  |
| [`1db066af`](https://github.com/NixOS/nixpkgs/commit/1db066af566a467177a4e7aba5cc112f30e21039) | `` neil: 0.2.62 -> 0.2.63 ``                                                                       |
| [`6277cae5`](https://github.com/NixOS/nixpkgs/commit/6277cae51b86179b6a8c6d5020f08d199ba4feba) | `` zlog: 1.2.16 -> 1.2.17 ``                                                                       |
| [`0ae57589`](https://github.com/NixOS/nixpkgs/commit/0ae5758951f5abc97dabbd705d1b5a30049113df) | `` stuffbin: 1.1.0 -> 1.2.0 ``                                                                     |
| [`35b11ed9`](https://github.com/NixOS/nixpkgs/commit/35b11ed95d9e6cd8a3208cdb99a1f3c1a539c519) | `` or-tools: fix build on x86_64-darwin ``                                                         |
| [`7b280054`](https://github.com/NixOS/nixpkgs/commit/7b280054add637fc97152447e77b6806122071e2) | `` sqlmap: 1.7.11 -> 1.7.12 ``                                                                     |
| [`68a86ed3`](https://github.com/NixOS/nixpkgs/commit/68a86ed39c8404b0cb15e397a9045e02c775c08d) | `` simdutf: 4.0.5 -> 4.0.8 ``                                                                      |
| [`2aa67111`](https://github.com/NixOS/nixpkgs/commit/2aa67111a851c1ff1f9cfb070ab1d4568e7764a5) | `` elixir: Allow overriding Erlang package ``                                                      |
| [`f6391f45`](https://github.com/NixOS/nixpkgs/commit/f6391f4505e0ddb10e4d208cebd9b8ca81e2f9c9) | `` python311Packages.twilio: 8.10.2 -> 8.10.3 ``                                                   |
| [`6ae57be9`](https://github.com/NixOS/nixpkgs/commit/6ae57be9243f729fd0d2445c8c3cd6afe0c804fc) | `` python311Packages.stim: 1.9.0 -> 1.12.1 ``                                                      |
| [`70668d18`](https://github.com/NixOS/nixpkgs/commit/70668d1892fa326ea1cae4f35f0834f49e0a3041) | `` packer: 1.9.4 -> 1.9.5 ``                                                                       |
| [`0465f280`](https://github.com/NixOS/nixpkgs/commit/0465f2806e56ed038c4fc223ec3e4d6c5dd16885) | `` dnf4: init at 4.18.1 ``                                                                         |
| [`1d845b40`](https://github.com/NixOS/nixpkgs/commit/1d845b40d4cb3e111f0fed7e4fc22af19db4509a) | `` libcomps: init at 0.1.20 ``                                                                     |
| [`4119ae60`](https://github.com/NixOS/nixpkgs/commit/4119ae605a84bd7d2cf3ea9ff3c9d55080a0cd6e) | `` libdnf: add katexochen as maintainer ``                                                         |
| [`77cdfc9f`](https://github.com/NixOS/nixpkgs/commit/77cdfc9f620f1ad07fd25950c55f3919dd82c722) | `` libdnf: enable python bindings ``                                                               |
| [`c1181450`](https://github.com/NixOS/nixpkgs/commit/c1181450243e4e06c93cc1c40917bb1edcf5ead9) | `` mediaelch: 2.10.4 -> 2.10.6 ``                                                                  |
| [`4a8c8831`](https://github.com/NixOS/nixpkgs/commit/4a8c8831f46b494f7613897c36e99b2859f74002) | `` floorp: fix version ``                                                                          |
| [`8d469635`](https://github.com/NixOS/nixpkgs/commit/8d469635e4add3dc3a5bcf3ab4228e0b8f998806) | `` python311Packages.stim: refactor ``                                                             |
| [`f06600f9`](https://github.com/NixOS/nixpkgs/commit/f06600f96d18370ae34449902566bde15b5554fc) | `` Corretto11/17/19: Correctly set corretto.[meta.]pos attribute. ``                               |
| [`46d88a27`](https://github.com/NixOS/nixpkgs/commit/46d88a276cabc9d198607f56dec9660e2095e2ef) | `` libmbd: fix typo ``                                                                             |
| [`151b36a7`](https://github.com/NixOS/nixpkgs/commit/151b36a7df59f0d85475a0f02b0d8e7f0907080a) | `` magic-wormhole-rs: 0.6.0 -> 0.6.1 ``                                                            |
| [`80d540bd`](https://github.com/NixOS/nixpkgs/commit/80d540bd31fb46283151e7a9824cbb7ed550740a) | `` fahclient: wrap in FHS (#271994) ``                                                             |
| [`6159c5ef`](https://github.com/NixOS/nixpkgs/commit/6159c5efc73af23fc507a52803a2f99e4d219d5e) | `` libglibutil: 1.0.74 -> 1.0.75 ``                                                                |
| [`b1b8d824`](https://github.com/NixOS/nixpkgs/commit/b1b8d824fd50aa84c4c4804a6d61448fef50ea61) | `` upscayl: 2.9.4 -> 2.9.5 ``                                                                      |
| [`a3a1a7e2`](https://github.com/NixOS/nixpkgs/commit/a3a1a7e25891916d0eaff5463e2df214d1fdd93b) | `` wrangler: support darwin and arm64 ``                                                           |
| [`b0d972a8`](https://github.com/NixOS/nixpkgs/commit/b0d972a8df5aa5b5cd6581a3ba23d0613d3a6a26) | `` python311Packages.pysnmp-pysmi: add changelog to meta ``                                        |
| [`99981111`](https://github.com/NixOS/nixpkgs/commit/999811113f4031f3c42a100c610fccae093ffb6e) | `` cbc: fix build with clang 16 ``                                                                 |
| [`8090d555`](https://github.com/NixOS/nixpkgs/commit/8090d5556d5eb75bac87cbb2ab33a0a5df746826) | `` ruff: 0.1.6 -> 0.1.7 ``                                                                         |
| [`eb7460ec`](https://github.com/NixOS/nixpkgs/commit/eb7460ec8d1c2fb5ef15624da7dd9fb92c2d4370) | `` cni-plugins: 1.3.0 -> 1.4.0 ``                                                                  |
| [`07b6ba4e`](https://github.com/NixOS/nixpkgs/commit/07b6ba4ee3bcdf9298da201d9ff3dbadc9e8828c) | `` ocamlPackages.eliom: 10.1.0 -> 10.1.2 ``                                                        |
| [`6225a510`](https://github.com/NixOS/nixpkgs/commit/6225a5106080e3c6e150315e0b55c190ccd5044c) | `` coqPackages_8_16: fix evaluation with math-comp ≥ 2.0 ``                                        |
| [`532aff02`](https://github.com/NixOS/nixpkgs/commit/532aff022b717e66c457a91d3c65809638c56141) | `` python310Packages.python-google-nest: 5.1.1 -> 5.2.0 ``                                         |
| [`72fa32ca`](https://github.com/NixOS/nixpkgs/commit/72fa32ca9386dd1b990ee02d5f48ef518cfc9b98) | `` radicle-upstream: add missing sourceProvenance ``                                               |
| [`ab18d1ea`](https://github.com/NixOS/nixpkgs/commit/ab18d1eae2a0c6a2d750536e4cff386624b31d13) | `` python311Packages.awkward: unbreak on darwin ``                                                 |
| [`fa054e52`](https://github.com/NixOS/nixpkgs/commit/fa054e52d8b3f8b65fd43581e46c165db21be4a4) | `` python310Packages.pytapo: 3.3.16 -> 3.3.18 ``                                                   |
| [`4f1c0c67`](https://github.com/NixOS/nixpkgs/commit/4f1c0c6719c6b2128a5f5dea305ac2613e3d0825) | `` python310Packages.pysnmp-pysmi: 1.1.10 -> 1.1.11 ``                                             |
| [`54eaadd9`](https://github.com/NixOS/nixpkgs/commit/54eaadd99f90505006340d80435e20270d055d33) | `` python310Packages.pyorthanc: 1.13.1 -> 1.15.0 ``                                                |
| [`765db197`](https://github.com/NixOS/nixpkgs/commit/765db197af59a2c12e20625a2061eb9619d694da) | `` python311Packages.django_5: 5.0rc1 -> 5.0 ``                                                    |
| [`4608a2e8`](https://github.com/NixOS/nixpkgs/commit/4608a2e805cb42ee26933dbdfd8a52c5bfd7c92e) | `` python310Packages.pyomo: 6.6.2 -> 6.7.0 ``                                                      |
| [`f8c8eafc`](https://github.com/NixOS/nixpkgs/commit/f8c8eafc3bd7bad1495e6e88cb440aa2da2b1f14) | `` libGLU: fix on darwin ``                                                                        |
| [`e3f79691`](https://github.com/NixOS/nixpkgs/commit/e3f79691f277ccea56ce18350e2a829e4328ea0a) | `` windmill: 1.210.1 -> 1.219.1; cleanup ``                                                        |
| [`6d734d11`](https://github.com/NixOS/nixpkgs/commit/6d734d112c3e030a8d478366ef98e238963434f6) | `` python310Packages.pyngrok: 7.0.1 -> 7.0.3 ``                                                    |
| [`628c5366`](https://github.com/NixOS/nixpkgs/commit/628c5366a3f7f265f4437a193e3dcae4d455b6f3) | `` build(deps): bump cachix/cachix-action from 12 to 13 (#272012) ``                               |
| [`e3e5f288`](https://github.com/NixOS/nixpkgs/commit/e3e5f288bfbdfd7cdd990f7c60f4a92d4b37f815) | `` build(deps): bump cachix/install-nix-action from 23 to 24 (#272011) ``                          |
| [`8b685f03`](https://github.com/NixOS/nixpkgs/commit/8b685f0335aa24d53ca07f09fb1eeb03aa0c9e3a) | `` python3Packages.tensorflow: Add aarch64-linux CUDA hash ``                                      |
| [`4d61ec24`](https://github.com/NixOS/nixpkgs/commit/4d61ec245f60540a054b944b912b5659dd3baad0) | `` rectangle: 0.74 -> 0.75 ``                                                                      |
| [`3ae74fd1`](https://github.com/NixOS/nixpkgs/commit/3ae74fd1b2c8c5ae03879a14c2ab5ce4ec4b2e0e) | `` mesa: unbreak on darwin ``                                                                      |
| [`85e14734`](https://github.com/NixOS/nixpkgs/commit/85e147343d78ef96891d0851fc94236fa18e09ec) | `` gitlab-container-registry: 3.85.0 -> 3.86.2 ``                                                  |
| [`03a509bc`](https://github.com/NixOS/nixpkgs/commit/03a509bc80e93604eedeecf4fcd1eef4628f6965) | `` gitlab: 16.5.1 -> 16.5.3 ``                                                                     |
| [`548ddca4`](https://github.com/NixOS/nixpkgs/commit/548ddca4e7fc1fb83013ef10afaff702891bc009) | `` python310Packages.posthog: 3.0.2 -> 3.1.0 ``                                                    |
| [`93cfe804`](https://github.com/NixOS/nixpkgs/commit/93cfe804d407d92c8888b0b9ce53038eda96cca5) | `` element-desktop: add jq to update script ``                                                     |
| [`e72502b9`](https://github.com/NixOS/nixpkgs/commit/e72502b9387d5a71597d8926a8ce6ce05507a239) | `` element-desktop: use electron version 27 ``                                                     |
| [`1d84102f`](https://github.com/NixOS/nixpkgs/commit/1d84102f0373b38e4fd6e0078f22f5f72157c348) | `` python310Packages.ihm: 0.41 -> 0.42 ``                                                          |
| [`0c004ea3`](https://github.com/NixOS/nixpkgs/commit/0c004ea3a9cc7ae89d77e15dee615729b1f5c0d4) | `` gickup: 0.10.22 -> 0.10.23 ``                                                                   |