### PR TITLE
chore(flake/hyprland): `a794eecd` -> `6fb1b89b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -306,11 +306,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1701945972,
-        "narHash": "sha256-Nvbjtu7FAM5ULS1Z028y1ou3qJR1x606fnyva5kLkuo=",
+        "lastModified": 1701988578,
+        "narHash": "sha256-44jQ4XMNP5ql3fdXLN+SCEnKfZcK1aY34koIwFLWgYw=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "a794eecd6a71e431b654cebb1b28dbff0d6da079",
+        "rev": "6fb1b89b982eea26ecae75b93f1742537c4f31ae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                 |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
| [`6fb1b89b`](https://github.com/hyprwm/Hyprland/commit/6fb1b89b982eea26ecae75b93f1742537c4f31ae) | `` makefile: add rm hyprpm for uninstall (#4086) ``                     |
| [`004bf94a`](https://github.com/hyprwm/Hyprland/commit/004bf94a23223265c96e348a84d1d044a009c566) | `` keybinds: Keep focus on special when switching workspaces (#4084) `` |
| [`aa020a2a`](https://github.com/hyprwm/Hyprland/commit/aa020a2a1a560bd42f7ddc8c4808fd6db396ee8b) | `` toplevel-export: commence render pass before reading ``              |
| [`d9175a01`](https://github.com/hyprwm/Hyprland/commit/d9175a0181eb54b14e58b9ce655df3bc74e4ae8c) | `` hyprpm: fix with system headers ``                                   |