### PR TITLE
chore(flake/chaotic): `76101810` -> `4e6d94c4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,11 +46,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1701943344,
-        "narHash": "sha256-CNZG1dJCBeFpv99jXv2lhFbDnHoW4X36uQZkq9oddGI=",
+        "lastModified": 1701982012,
+        "narHash": "sha256-SnSF/WWHlEgHN20kRxen445+rikGUpqsomyeFmJ/2tM=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "76101810b33c875a90f0a002edfc6a0744529a5c",
+        "rev": "4e6d94c4035d1ce87916f1a10d7f993db019b826",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                      |
| ----------------------------------------------------------------------------------------------- | ---------------------------- |
| [`4e6d94c4`](https://github.com/chaotic-cx/nyx/commit/4e6d94c4035d1ce87916f1a10d7f993db019b826) | `` scx: init (#474) ``       |
| [`b84815aa`](https://github.com/chaotic-cx/nyx/commit/b84815aa19e7342787a6729a310888c109870af2) | `` Bump 20231207-1 (#473) `` |