### PR TITLE
chore(flake/nur): `26c7d7e2` -> `6021d057`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1701953830,
-        "narHash": "sha256-EPqHATJuCh6tz+9Dgc1oJuVf7xMmHcXnP7mlWrVWP9s=",
+        "lastModified": 1701989134,
+        "narHash": "sha256-bGyoaB3XTIfKVsG7u0NKhcC0G5pruAElbLsDRffnZJQ=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "26c7d7e22ffd492dfe4ddcd5b3e6bddee5291854",
+        "rev": "6021d0574cac4d299f25c4e7f32cbc53b6e33571",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`6021d057`](https://github.com/nix-community/NUR/commit/6021d0574cac4d299f25c4e7f32cbc53b6e33571) | `` automatic update `` |
| [`57ddc7c9`](https://github.com/nix-community/NUR/commit/57ddc7c919acf1e41438cf7091c87f013a29b2a7) | `` automatic update `` |
| [`cc0b1a85`](https://github.com/nix-community/NUR/commit/cc0b1a8578f0a9ed6e342f85e6b3ef42ccbfcf33) | `` automatic update `` |
| [`a2374c9f`](https://github.com/nix-community/NUR/commit/a2374c9f722a828b141e7116dc24c0acd81dd093) | `` automatic update `` |
| [`d9095384`](https://github.com/nix-community/NUR/commit/d90953847c55edd3cc21da68760c1f6cb52b4995) | `` automatic update `` |
| [`4d625a25`](https://github.com/nix-community/NUR/commit/4d625a255dcaed7b3670fc0fb7cf4d0159496890) | `` automatic update `` |
| [`dfd318db`](https://github.com/nix-community/NUR/commit/dfd318db13f0a6a152f3ffa0ea0419ba10137753) | `` automatic update `` |
| [`95f40329`](https://github.com/nix-community/NUR/commit/95f4032933ca6b85f97e89495a452921a392460e) | `` automatic update `` |
| [`e84ed059`](https://github.com/nix-community/NUR/commit/e84ed059a4145720429f38352b5852b303888733) | `` automatic update `` |