### PR TITLE
chore(flake/treefmt-nix): `affe7fc3` -> `e8cea581`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -879,11 +879,11 @@
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
-        "lastModified": 1701682826,
-        "narHash": "sha256-2lxeTUGs8Jzz/wjLgWYmZoXn60BYNRMzwHFtxNFUDLU=",
+        "lastModified": 1701958734,
+        "narHash": "sha256-3h3EH1FXQkIeAuzaWB+nK0XK54uSD46pp+dMD3gAcB4=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "affe7fc3f5790e1d0b5ba51bcff0f7ebe465e92d",
+        "rev": "e8cea581dd2b7c9998c1e6662db2c1dc30e7fdb0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                        |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
| [`e8cea581`](https://github.com/numtide/treefmt-nix/commit/e8cea581dd2b7c9998c1e6662db2c1dc30e7fdb0) | `` Revert "feat(programs): add golangci-lint (#134)" (#135) `` |