### PR TITLE
chore(flake/unstable): `9ed8ade7` -> `d030c6eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -894,11 +894,11 @@
     },
     "unstable": {
       "locked": {
-        "lastModified": 1701847270,
-        "narHash": "sha256-ttPWHy1NZwJzSzY7OmofFNyrm9kWc+RFFHpJGeQ4kWw=",
+        "lastModified": 1701936692,
+        "narHash": "sha256-q3ItBV/eCI8V6+OZwNaA/oUKYBpA3F73Cq++llHIxPE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9ed8ade77aef706a03d8cc3a5ad4f60848ac59a7",
+        "rev": "d030c6ebf04aabf73f4cf6a3f71d71f5f0a65655",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`e286d7e6`](https://github.com/NixOS/nixpkgs/commit/e286d7e6e365c052e141f8441b883f0faeb2d7fe) | `` radiotray-ng: add libsoup_3 and glib-networking; fix runtime ``                        |
| [`81e662db`](https://github.com/NixOS/nixpkgs/commit/81e662db078936e86e26246dfe2e88fe6823485c) | `` xe-guest-utilities: 7.30.0 -> 8.3.1 ``                                                 |
| [`964ecc41`](https://github.com/NixOS/nixpkgs/commit/964ecc4155bc01639eed1b4bdc0370e381132149) | `` mozillavpn: 2.18.1 → 2.19.0 ``                                                         |
| [`96e01b7f`](https://github.com/NixOS/nixpkgs/commit/96e01b7f21d84ea87c52331f3dc5b69efdb49fb4) | `` trivy: 0.47.0 -> 0.48.0 ``                                                             |
| [`f6943239`](https://github.com/NixOS/nixpkgs/commit/f694323931316a916b4403cc2f32b0987b9a604a) | `` memray: 1.10.0 -> 1.11.0 ``                                                            |
| [`6be62203`](https://github.com/NixOS/nixpkgs/commit/6be62203abd573b77472606e4848d29e2f1dd961) | `` buildbot: 3.9.2 -> 3.10.0 ``                                                           |
| [`18460b48`](https://github.com/NixOS/nixpkgs/commit/18460b48202bcfea44ea6f7dd4c0b0e2feb55f23) | `` nixos/buildbot: only run nixosTest on x86_64-linux ``                                  |
| [`c8ee4021`](https://github.com/NixOS/nixpkgs/commit/c8ee402168fe78683643e6bd877507d9880f4ac5) | `` gotestwaf: 0.4.8 -> 0.4.9 ``                                                           |
| [`0e909519`](https://github.com/NixOS/nixpkgs/commit/0e909519da62523e97285478d4220b2741bd7149) | `` cfripper: 1.15.1 -> 1.15.2 ``                                                          |
| [`5ec449a6`](https://github.com/NixOS/nixpkgs/commit/5ec449a6bed10615757118d889b97a30614166cb) | `` nixos/borgbackup: add `listOf str` types to `extraArgs` ``                             |
| [`031c0cec`](https://github.com/NixOS/nixpkgs/commit/031c0cec69887e61dade8a9e485c8b2ee8a19445) | `` checkov: 3.1.25 -> 3.1.26 ``                                                           |
| [`4e0981ab`](https://github.com/NixOS/nixpkgs/commit/4e0981ab23c001cfb320b83c3cf5fa9492676355) | `` ledfx: update replace ``                                                               |
| [`8d640bcc`](https://github.com/NixOS/nixpkgs/commit/8d640bcc656f18253ba0843dfc57b7789924b756) | `` python3Packages.livestreamer-curses: drop ``                                           |
| [`b551d2c4`](https://github.com/NixOS/nixpkgs/commit/b551d2c4c4f2c02d8873769fa5c3f483b4a2c096) | `` python3Packages.livestreamer: drop ``                                                  |
| [`3c6b3d71`](https://github.com/NixOS/nixpkgs/commit/3c6b3d71fa696da5c170c0ff44eaa8c51999a80c) | `` nixos/caddy: Use caddyfile adapter by default when explicitly specifying configFile `` |
| [`b18d4386`](https://github.com/NixOS/nixpkgs/commit/b18d4386468bfad10ef0301e2db751d0f500dc89) | `` python311Packages.python-osc: refactor ``                                              |
| [`acf19ab3`](https://github.com/NixOS/nixpkgs/commit/acf19ab36fbee119e0f96d668cb590c7da271c09) | `` prometheus-atlas-exporter: init at 1.0.4 ``                                            |
| [`2bf9847a`](https://github.com/NixOS/nixpkgs/commit/2bf9847a020fa2d0bb62eff51d7e4dac135affce) | `` syntax: init at 0.1.27 ``                                                              |
| [`c40f706d`](https://github.com/NixOS/nixpkgs/commit/c40f706dc41332d20b8d320b9fee0b5666e334fc) | `` nixos/nginx/tailscale-auth: init module ``                                             |
| [`1a6db25b`](https://github.com/NixOS/nixpkgs/commit/1a6db25b7aa58ef7b5e14ee24d950f36e000bb60) | `` tailscale-nginx-auth: init at 1.48.2 ``                                                |
| [`44522d84`](https://github.com/NixOS/nixpkgs/commit/44522d8478969867e555528f2cc555d5b4f58d6f) | `` nixos/vector: align service restart policy with upstream ``                            |
| [`7b050ed2`](https://github.com/NixOS/nixpkgs/commit/7b050ed2769e475033464a143775d69d17e87f9c) | `` elixir: rename erlangPackage option to erlang ``                                       |
| [`1403c32c`](https://github.com/NixOS/nixpkgs/commit/1403c32ceef8a97334130f262603ac53db6919aa) | `` home-assistant-custom-components.miele: init at 0.1.19 ``                              |
| [`ca7139f8`](https://github.com/NixOS/nixpkgs/commit/ca7139f8575be80fed1c1e4015125831254780b8) | `` python311Packages.pymiele: add setuptools dependency ``                                |
| [`a59cb4f4`](https://github.com/NixOS/nixpkgs/commit/a59cb4f44f5c694b9fa548b7b6c5741481141fe9) | `` maintainers: stepbrobd change email and fingerprint ``                                 |
| [`4adcc03b`](https://github.com/NixOS/nixpkgs/commit/4adcc03bb8c48b4792b9006e3f5752d2e2d48c50) | `` josm: 18822 → 18906 ``                                                                 |
| [`321e0682`](https://github.com/NixOS/nixpkgs/commit/321e06827d7e78b041de86b27f9fe1dc0b786bbd) | `` c-ares: update source URL ``                                                           |
| [`725e83eb`](https://github.com/NixOS/nixpkgs/commit/725e83eb3e4c154d7e153edb1451c4cd527eb996) | `` rblake2sum: set mainProgram ``                                                         |
| [`2ff3854c`](https://github.com/NixOS/nixpkgs/commit/2ff3854c5070bb80a8a9a5537107a65524655f06) | `` rblake3sum: init at 0.4.0 ``                                                           |
| [`bca98d95`](https://github.com/NixOS/nixpkgs/commit/bca98d959531c9246a2832041dcc29fb7a2437fa) | `` python311Packages.psycopg: skip refcounting tests ``                                   |
| [`0a21dac1`](https://github.com/NixOS/nixpkgs/commit/0a21dac151c3a6415eb02e95550698f6962c7a3e) | `` path-of-building.data: 2.35.3 -> 2.35.4 ``                                             |
| [`63218392`](https://github.com/NixOS/nixpkgs/commit/6321839227048e22ae81607ebb7063178ca84366) | `` wpscan: 3.8.24 -> 3.8.25 ``                                                            |
| [`39df95c3`](https://github.com/NixOS/nixpkgs/commit/39df95c335154c069d21e190440e90042d97800b) | `` protobuf_25: init at 25.1 ``                                                           |
| [`b4a0178d`](https://github.com/NixOS/nixpkgs/commit/b4a0178df05e5fea4a2382bc111da901d8130ba8) | `` texlab: 5.11.0 -> 5.12.0 ``                                                            |
| [`32054f23`](https://github.com/NixOS/nixpkgs/commit/32054f23092567b08107ab9e53465db297966582) | `` ibus-engines.typing-booster-unwrapped: 2.24.4 -> 2.24.5 ``                             |
| [`a9a9e434`](https://github.com/NixOS/nixpkgs/commit/a9a9e434bdc621ef0895393092859b472dc680a3) | `` paperless-ngx: don't leak checkInputs into final package ``                            |
| [`3c3ba95e`](https://github.com/NixOS/nixpkgs/commit/3c3ba95ecd37524fc471d5599562ab53a5f61540) | `` cuneiform: make install path match rpath; fix runtime ``                               |
| [`d23af28a`](https://github.com/NixOS/nixpkgs/commit/d23af28aa77079e8a383fd923418151655d799a8) | `` yosys: 0.35 -> 0.36 ``                                                                 |
| [`d55c97e7`](https://github.com/NixOS/nixpkgs/commit/d55c97e7b5e85d5b0e551fdfb2705aa9279f628e) | `` qimgv: enable video support ``                                                         |
| [`6f55824d`](https://github.com/NixOS/nixpkgs/commit/6f55824d5e70a3da240b04feff72ca86aa1d6668) | `` python311Packages.habluetooth: 0.8.0 -> 0.9.0 ``                                       |
| [`722791d5`](https://github.com/NixOS/nixpkgs/commit/722791d5f0f09c40a438f541496a95cbefc58d35) | `` python311Packages.habluetooth: 0.6.1 -> 0.8.0 ``                                       |
| [`81e1f42c`](https://github.com/NixOS/nixpkgs/commit/81e1f42ca5e68c18b7b4408fe3d9afbab97280c5) | `` linien: init at 1.0.0 ``                                                               |
| [`eab201d8`](https://github.com/NixOS/nixpkgs/commit/eab201d80de3b43d080a2a63baaf238af232ecf8) | `` presenterm: enable image support ``                                                    |
| [`c8c970bc`](https://github.com/NixOS/nixpkgs/commit/c8c970bccb1364da02d6389381c535803dd21c64) | `` checkov: 3.1.21 -> 3.1.25 ``                                                           |
| [`36180864`](https://github.com/NixOS/nixpkgs/commit/361808645b9e92e12e456c418174331f238ac93a) | `` python311Packages.dbus-fast: 2.15.0 -> 2.20.0 ``                                       |
| [`cdab46e7`](https://github.com/NixOS/nixpkgs/commit/cdab46e79cec66bf48838a087c82d90052ce7463) | `` home-assistant: update component-packages ``                                           |
| [`68a64185`](https://github.com/NixOS/nixpkgs/commit/68a6418503d5c073e3f3af4e576cf90ee6097079) | `` python311Packages.renson-endura-delta: init at 1.7.1 ``                                |
| [`fb1261bc`](https://github.com/NixOS/nixpkgs/commit/fb1261bce44ec6ada416d5a5f3fbe0893500fd0c) | `` houdini: easier runtime version substitution ``                                        |
| [`cf328de9`](https://github.com/NixOS/nixpkgs/commit/cf328de96006766a4af5de3e9c14b3ab80ff8302) | `` chamber: 2.13.4 -> 2.13.5 ``                                                           |
| [`6129a291`](https://github.com/NixOS/nixpkgs/commit/6129a291599cb3bf2619a6ca88ef26229dd15ed6) | `` python311Packages.yolink-api: 0.3.1 -> 0.3.3 ``                                        |
| [`3682d435`](https://github.com/NixOS/nixpkgs/commit/3682d435b4e618a44ec02e55325589e01bf36df3) | `` python311Packages.thermopro-ble: 0.4.5 -> 0.5.0 ``                                     |
| [`604872c8`](https://github.com/NixOS/nixpkgs/commit/604872c829209218e09c938063cfc00ac862eca2) | `` python311Packages.evohome-async: 0.4.13 -> 0.4.15 ``                                   |
| [`69154ed3`](https://github.com/NixOS/nixpkgs/commit/69154ed35b77a4912d5919888368ac273504e426) | `` python311Packages.easyenergy: 1.0.0 -> 2.0.0 ``                                        |
| [`61df0c2d`](https://github.com/NixOS/nixpkgs/commit/61df0c2db241458101c420f508685a959edfe38f) | `` python311Packages.aiounifi: 66 -> 67 ``                                                |
| [`3a7e7b79`](https://github.com/NixOS/nixpkgs/commit/3a7e7b79e7c7f60260f4eda92921c89fd19ea069) | `` python311Packages.energyzero: 1.0.0 -> 2.0.0 ``                                        |
| [`2e04ba65`](https://github.com/NixOS/nixpkgs/commit/2e04ba65285631b9d15930df7e06ebc7f7f4c9c4) | `` python311Packages.types-aiobotocore-*: 2.x.x -> 2.8.0 ``                               |
| [`913b04a7`](https://github.com/NixOS/nixpkgs/commit/913b04a707e4a0c585c1eec31926e485f26fbebe) | `` cargo-hack: 0.6.13 -> 0.6.14 ``                                                        |
| [`bbcc95ec`](https://github.com/NixOS/nixpkgs/commit/bbcc95ec1c749e487c4bbc4cf99ad52785c8cc7d) | `` micromamba: 1.5.3 -> 1.5.4 ``                                                          |
| [`502c9d67`](https://github.com/NixOS/nixpkgs/commit/502c9d673cf1099d9aab992e1d1c61008690033a) | `` python311Packages.types-aiobotocore: 2.7.0 -> 2.8.0 ``                                 |
| [`b0a8d041`](https://github.com/NixOS/nixpkgs/commit/b0a8d0419c983c6ba88cc85b2d491e59db109107) | `` swaysome: 2.0.0 -> 2.1.0 ``                                                            |
| [`673928d3`](https://github.com/NixOS/nixpkgs/commit/673928d3935514edcd0a36f0f8e44bfe6dd1d227) | `` python311Packages.securesystemslib: adjust changelog entry ``                          |
| [`1884f761`](https://github.com/NixOS/nixpkgs/commit/1884f761926744bb194c0ca1e4d9fcc210142329) | `` python311Packages.securesystemslib: 0.30.0 -> 0.31.0 ``                                |
| [`80e4ee36`](https://github.com/NixOS/nixpkgs/commit/80e4ee365609b61bb502783b8c4cd740fd55c7e8) | `` python311Packages.mypy-boto3-*: 1.2x.x -> 1.33.0 ``                                    |
| [`c9f688fe`](https://github.com/NixOS/nixpkgs/commit/c9f688fe7e5c2a9971c3bc64dd3cb7fe5735066a) | `` python311Packages.mypy-boto3: add initial update helper script ``                      |
| [`4628041f`](https://github.com/NixOS/nixpkgs/commit/4628041f4e7491f6eb18ab961cc61f75351de294) | `` svu: 1.11.0 -> 1.12.0 ``                                                               |
| [`22453758`](https://github.com/NixOS/nixpkgs/commit/224537581aa6fc1dd0971f4a250edc4b960bebe2) | `` nixos/harmonia: test if extra-allowed-users works ``                                   |
| [`bd883983`](https://github.com/NixOS/nixpkgs/commit/bd8839836974816f42c940c1dfe3e193b7381aae) | `` nixos/harmonia: allocate user ``                                                       |
| [`09159529`](https://github.com/NixOS/nixpkgs/commit/09159529f97cd4905af4973fbf5b98b85de1b371) | `` electron_26: fix backported patch conflict ``                                          |
| [`0014247e`](https://github.com/NixOS/nixpkgs/commit/0014247e0d59b85f695e70fcfe418ad1dd8feca9) | `` step-kms-plugin: 0.9.1 -> 0.9.2 ``                                                     |
| [`254903f5`](https://github.com/NixOS/nixpkgs/commit/254903f507b934b83e398628260f12e3fd18984d) | `` paperless-ngx: remove not matching substitute ``                                       |
| [`90690083`](https://github.com/NixOS/nixpkgs/commit/90690083814f2743ee9fd714c795e1d8a4e3ff93) | `` python311Packages.botocore-stubs: 1.33.0 -> 1.33.8 ``                                  |
| [`68fee72c`](https://github.com/NixOS/nixpkgs/commit/68fee72c52013e1128aef4a75ac8a6af9299927d) | `` haredo: init at 1.0.5 ``                                                               |
| [`c79b2552`](https://github.com/NixOS/nixpkgs/commit/c79b2552db87a226a3a7e5be50d590900e15067f) | `` flyctl: 0.1.127 -> 0.1.131 ``                                                          |
| [`272fa4a1`](https://github.com/NixOS/nixpkgs/commit/272fa4a1c04e1bb052abb40fe224704508d2c1f7) | `` haskellPackages: refactor csound overrides ``                                          |
| [`3a634a67`](https://github.com/NixOS/nixpkgs/commit/3a634a6714b83cda4aaea052c3219f698c4cfd55) | `` gotktrix: drop ``                                                                      |
| [`21d08552`](https://github.com/NixOS/nixpkgs/commit/21d08552d4a74adafbcccca3d1472020baa96bab) | `` path-of-building.data: 2.35.2 -> 2.35.3 ``                                             |
| [`a40edfc8`](https://github.com/NixOS/nixpkgs/commit/a40edfc8334103e1263f1b78b6aa5bb36cdf537d) | `` ouch: fix build on darwin ``                                                           |
| [`d17443fb`](https://github.com/NixOS/nixpkgs/commit/d17443fb12c5ea78ba1938325a9b1629684a3af6) | `` rclip: init at 1.7.6 ``                                                                |
| [`6a23eb87`](https://github.com/NixOS/nixpkgs/commit/6a23eb87d0c209f30a9a106e173168506980534f) | `` python3Packages.open-clip-torch: init at 2.23.0 ``                                     |
| [`ed6062b5`](https://github.com/NixOS/nixpkgs/commit/ed6062b557577cecb99378cbc0a06b30cff75be9) | `` python311Packages.slack-sdk: 3.26.0 -> 3.26.1 ``                                       |
| [`879a2948`](https://github.com/NixOS/nixpkgs/commit/879a2948a418a7a307ad59e8fa9a378c71baf2f5) | `` python311Packages.exrex: add dontWrapPythonPrograms ``                                 |
| [`e17cf266`](https://github.com/NixOS/nixpkgs/commit/e17cf2665d62cd69e9b8e4aaa65ec253047226bb) | `` python311Packages.exrex: refactor ``                                                   |
| [`a56afd86`](https://github.com/NixOS/nixpkgs/commit/a56afd860cac7a59d5261581410e109a3c67604b) | `` haskellPackages.csound-sampler: unbreak ``                                             |
| [`98426afa`](https://github.com/NixOS/nixpkgs/commit/98426afa72315eff6c46dc998a764e8d56e3694b) | `` haskellPackages.csound-expression-typed: unbreak ``                                    |
| [`80c649c6`](https://github.com/NixOS/nixpkgs/commit/80c649c662a2010689a241737269bac06815fcd2) | `` haskellPackages.csound-expression-opcodes: unbreak ``                                  |
| [`90a4a1d2`](https://github.com/NixOS/nixpkgs/commit/90a4a1d26521cb317744233d2e6f2112754c68f2) | `` haskellPackages.csound-expression: unbreak on recent GHC ``                            |
| [`47d4004a`](https://github.com/NixOS/nixpkgs/commit/47d4004a52e309e8b854bd0d32bd8d6cb594b17d) | `` haskellPackages.csound-expression-dynamic: unbreak ``                                  |
| [`030f4008`](https://github.com/NixOS/nixpkgs/commit/030f4008ecc42ecec985a994c7190784c2056293) | `` path-of-building.data: 2.34.1 -> 2.35.2 ``                                             |
| [`136a332d`](https://github.com/NixOS/nixpkgs/commit/136a332df20c8d088fbd9e6fda6a322db05aaf3f) | `` python311Packages.pynvim: 0.4.3 -> 0.5.0 ``                                            |
| [`3ad1b696`](https://github.com/NixOS/nixpkgs/commit/3ad1b6963c08022c0de54100ad7ca61c39fd6c85) | `` python311Packages.pynvim: switch to github sources ``                                  |
| [`2bf5d1fa`](https://github.com/NixOS/nixpkgs/commit/2bf5d1fa458ffb3487dd230888e8cc0f37e76040) | `` libsForQt5.qcoro: 0.9.0 -> 0.10.0 ``                                                   |
| [`fd0d901b`](https://github.com/NixOS/nixpkgs/commit/fd0d901b59d408e95970901b04019ad6d2025661) | `` plasma: 5.27.9 -> 5.27.10 ``                                                           |
| [`faa46fc8`](https://github.com/NixOS/nixpkgs/commit/faa46fc872d51a8cf1bb824968c85af923afc210) | `` dalfox: 2.9.0 -> 2.9.1 ``                                                              |
| [`5131f19f`](https://github.com/NixOS/nixpkgs/commit/5131f19f5d3ff20b72966eccabc3beeee7da126b) | `` airwindows-lv2: 22.0 -> 26.0 ``                                                        |
| [`105b66ba`](https://github.com/NixOS/nixpkgs/commit/105b66ba4892520f6a7ea6e2910f46c79cdc2b77) | `` mate.mate-applets: Add missing mate-desktop ``                                         |
| [`b687fe31`](https://github.com/NixOS/nixpkgs/commit/b687fe31157561c6e973b66f329cb022051a66af) | `` python310Packages.s3fs: 2023.10.0 -> 2023.12.1 ``                                      |
| [`76671902`](https://github.com/NixOS/nixpkgs/commit/76671902e03c55f6bdf22a74d44818202293bb39) | `` home-assistant-custom-lovelace-modules.light-entity-card: fix entrypoint ``            |
| [`d809a6f9`](https://github.com/NixOS/nixpkgs/commit/d809a6f9c30d6d7dd0a87025553c28067810edf0) | `` nixos/home-automation: fix lovelace card entrypoint ``                                 |
| [`e88fb997`](https://github.com/NixOS/nixpkgs/commit/e88fb997e32982a5f37b933583e618265a32d85d) | `` CONTRIBUTING.md: Dedent warnings until GitHub fixes it ``                              |
| [`28d9f8f0`](https://github.com/NixOS/nixpkgs/commit/28d9f8f0324b799a3e34090e37936361938ef2cd) | `` jadx: add quark-engine dependency ``                                                   |
| [`47694582`](https://github.com/NixOS/nixpkgs/commit/4769458228ad30e1004062efb13f4d63d72fe324) | `` CONTRIBUTING.md: Update markdown emphasising syntax ``                                 |
| [`e9654b3e`](https://github.com/NixOS/nixpkgs/commit/e9654b3ea39a9d170da0e0739119f6d39a07720c) | `` prio: get rid of with lib ``                                                           |
| [`ac6a29c1`](https://github.com/NixOS/nixpkgs/commit/ac6a29c13bfa7560b13fc07329c6203d1d34cf67) | `` pipeworld: unstable-2023-03-02 -> unstable-2023-02-05 ``                               |
| [`b4027b44`](https://github.com/NixOS/nixpkgs/commit/b4027b447f3b98c7cdb70eaa865bacbf8641a404) | `` durden: unstable-2023-08-11 -> unstable-2023-10-23 ``                                  |
| [`a139c5c0`](https://github.com/NixOS/nixpkgs/commit/a139c5c077cb5b2ab01a97b27d9e0af744a5ad9f) | `` cat9: unstable-2023-06-25 -> unstable-2023-11-06 ``                                    |
| [`8eb80d7b`](https://github.com/NixOS/nixpkgs/commit/8eb80d7b8c1b9d2c09930ed172380b0b00defd84) | `` xarcan: unstable-2022-06-14 -> unstable-2023-11-03 ``                                  |
| [`297954c1`](https://github.com/NixOS/nixpkgs/commit/297954c149762aa82ecd1fd2aa60d0cc989e7c8a) | `` arcan: 0.6.2.1-unstable-2023-10-14 -> 0.6.2.1-unstable-2023-11-18 ``                   |
| [`33655ad4`](https://github.com/NixOS/nixpkgs/commit/33655ad4aef922c75c2f3b8f7e9e15ad46fd02ab) | `` arcanPackages: remove ``                                                               |
| [`ad2c6e5e`](https://github.com/NixOS/nixpkgs/commit/ad2c6e5e11542e15032c27618ca976d2c0fc1e5f) | `` xarcan: migrate to by-name ``                                                          |
| [`88fb9b08`](https://github.com/NixOS/nixpkgs/commit/88fb9b080070e5fe0bb125de811a1a7b0c29c4bb) | `` prio: migrate to by-name ``                                                            |
| [`c836ec15`](https://github.com/NixOS/nixpkgs/commit/c836ec1597e3de3f011daccd955cbeea6547d037) | `` pipeworld: migrate to by-name ``                                                       |
| [`d220a1ce`](https://github.com/NixOS/nixpkgs/commit/d220a1ce0ccf96c98569ad2962778f01a735c198) | `` durden: migrate to by-name ``                                                          |
| [`36818353`](https://github.com/NixOS/nixpkgs/commit/36818353563fefdfcaefcf778565d105ee036361) | `` cat9: migrate to by-name ``                                                            |
| [`47e076a8`](https://github.com/NixOS/nixpkgs/commit/47e076a86f6000caf49bd305a51bc805cad8d0e0) | `` arcan: migrate to by-name ``                                                           |
| [`fe2ff1d4`](https://github.com/NixOS/nixpkgs/commit/fe2ff1d4a8b7feb4d0ae979f8b088354ef67fe60) | `` notejot: fix build with newer vala ``                                                  |
| [`02919f76`](https://github.com/NixOS/nixpkgs/commit/02919f768c70af312f40a11cb31f8551248d73e7) | `` exploitdb: 2023-12-02 -> 2023-12-05 ``                                                 |
| [`c19d7326`](https://github.com/NixOS/nixpkgs/commit/c19d7326a7a8cb8b0b2b03b7c3cc32ca03e65781) | `` obs-studio-plugins.obs-vkcapture: 1.4.5 -> 1.4.7 ``                                    |
| [`20623cae`](https://github.com/NixOS/nixpkgs/commit/20623cae409fbe500e89ef23debf6444d46fef34) | `` ledger-live-desktop: 2.71.0 -> 2.71.1 ``                                               |
| [`cef7f450`](https://github.com/NixOS/nixpkgs/commit/cef7f4505fa80cbeda65f95319c2e9cfd5437839) | `` _1password-gui-beta: 8.10.20-1 -> 8.10.22-21 ``                                        |
| [`dec1160f`](https://github.com/NixOS/nixpkgs/commit/dec1160f36d318241325ddf7c18ba17222c80a87) | `` bindfs: 1.17.5 -> 1.17.6 ``                                                            |