### PR TITLE
chore(flake/master): `5271b9c1` -> `1a009a93`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -439,11 +439,11 @@
     },
     "master": {
       "locked": {
-        "lastModified": 1701954864,
-        "narHash": "sha256-ifkbEvIwlhD9b1Haupp5EJW0J0ivz9mgJQUX1oojLok=",
+        "lastModified": 1701998002,
+        "narHash": "sha256-+SiAafMZPS1N2I3kyvOHYOlw8w1StxBogoor3hX18lk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5271b9c12d3ab792a5f8bb15f8f86c37c1b278b4",
+        "rev": "1a009a93fcd7bc47ffb621cee759e0e11c569e75",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`49cd2f2d`](https://github.com/NixOS/nixpkgs/commit/49cd2f2d1f1aeff17376d3ab52d4fc6e4caa7ed9) | `` Revert "emacs: set 29 as default version and remove 28" (#272785) ``                          |
| [`9acd37f5`](https://github.com/NixOS/nixpkgs/commit/9acd37f5deb57301206f7cbbc248a765446ed66e) | `` vimPlugins.modus-themes-nvim: init at 2023-11-07 ``                                           |
| [`2732b087`](https://github.com/NixOS/nixpkgs/commit/2732b08781e2fdec34cd8d7c08dabedcd569aff3) | `` unstructured-api: 0.0.57 -> 0.0.59 ``                                                         |
| [`b4e7f004`](https://github.com/NixOS/nixpkgs/commit/b4e7f0049e2f9f05b870913786bf71606f960f79) | `` python311Packages.unstructured: 0.10.30 -> 0.11.2 ``                                          |
| [`39696977`](https://github.com/NixOS/nixpkgs/commit/3969697767f97ec6f66e394ca634bccef3da0cd2) | `` python311Packagges.unstructured-inference: 0.7.11 -> 0.7.18 ``                                |
| [`b31d979c`](https://github.com/NixOS/nixpkgs/commit/b31d979c26854fa62cc59b5b5649012666169e5c) | `` surrealdb-migrations: 1.0.0-preview.1 -> 1.0.0 ``                                             |
| [`89d4c2fc`](https://github.com/NixOS/nixpkgs/commit/89d4c2fc4b3c896ee5ccf32a8441e8bf89590b1b) | `` gh: 2.39.2 -> 2.40.0 ``                                                                       |
| [`ecfbff96`](https://github.com/NixOS/nixpkgs/commit/ecfbff960af960e424a5fbe36298e8372def0c71) | `` bloop: 1.5.12 -> 1.5.13 ``                                                                    |
| [`7b8be9c3`](https://github.com/NixOS/nixpkgs/commit/7b8be9c3351eea950086054036993e21134e07ee) | `` nixos/wyoming/{faster-whisper,piper}: hook up enable option ``                                |
| [`855a7ba0`](https://github.com/NixOS/nixpkgs/commit/855a7ba029eaf78c959c88b36fdf5760742b2b1e) | `` caffe: fix eval when CUDNN is not available ``                                                |
| [`3ca8becb`](https://github.com/NixOS/nixpkgs/commit/3ca8becb81083bccba226382f0d255505208f087) | `` frankenphp: 1.0.0-rc.4 -> 1.0.0 ``                                                            |
| [`6179d88b`](https://github.com/NixOS/nixpkgs/commit/6179d88b7d98b7114840facfafb709b1f37b9aa8) | `` cuda-modules: tidy generic-builder/manifest installPhase and postPatchelf ``                  |
| [`ab1da0d9`](https://github.com/NixOS/nixpkgs/commit/ab1da0d9bc106c17e2041f99393b8a8cda2b9b44) | `` python310Packages.python-telegram-bot: 20.6 -> 20.7 ``                                        |
| [`220e163c`](https://github.com/NixOS/nixpkgs/commit/220e163cdec211485c724aea144954b83e6f4e23) | `` linuxPackages.nvidiaPackages.production: 535.129.03 -> 535.146.02 ``                          |
| [`9f1f87b6`](https://github.com/NixOS/nixpkgs/commit/9f1f87b6125c229e199a874ea4be90a2ea06c185) | `` Revert "wordpress: fixed installing of languages" ``                                          |
| [`42da68c4`](https://github.com/NixOS/nixpkgs/commit/42da68c40fb677791c10b1fff8f8febc87bba88e) | `` home-assistant-custom-lovelace-modules.zigbee2mqtt-networkmap: init at unstable-2023-12-06 `` |
| [`02dab4ab`](https://github.com/NixOS/nixpkgs/commit/02dab4ab5ce6cc7a03736f3937650a161f5b3ae4) | `` python3.pkgs.*: Explicitly pass buildPythonPackage format parameter ``                        |
| [`aaf735ea`](https://github.com/NixOS/nixpkgs/commit/aaf735eac97989ee924f2b3296d0d5200a6d734c) | `` cudaPackages.saxpy: only available from CUDA 11.4 and on ``                                   |
| [`0a7dacf9`](https://github.com/NixOS/nixpkgs/commit/0a7dacf94d879f7040c67ff7c3b0540ffe8a8782) | `` cudaPackages_12_3: init at 12.3.0 ``                                                          |
| [`bfaefd08`](https://github.com/NixOS/nixpkgs/commit/bfaefd0873a91aaffaae4254da5734f2fb311f48) | `` cudaPackages: add docs ``                                                                     |
| [`8e800ced`](https://github.com/NixOS/nixpkgs/commit/8e800cedaf24f5ad9717463b809b0beef7677000) | `` cudaPackages: move derivations to cuda-modules & support aarch64 ``                           |
| [`397d95d0`](https://github.com/NixOS/nixpkgs/commit/397d95d07fd095a3fba459a694bd284be3c47899) | `` cudaPackages: move config expressions to cuda-modules ``                                      |
| [`4a25023c`](https://github.com/NixOS/nixpkgs/commit/4a25023c2ef6f05904d27867aab8e71c034198a9) | `` cudaPackages: regen & move manifests to cuda-modules ``                                       |
| [`e59fe72c`](https://github.com/NixOS/nixpkgs/commit/e59fe72c6d8293676f923c6a244fa979d5f1aa54) | ``  python311Packages.jupyterhub: not broken on aarch64 ``                                       |
| [`330b00b1`](https://github.com/NixOS/nixpkgs/commit/330b00b103978fdb03adcb4554ae676b2f8ebdb6) | `` bitcoin: fix darwin builds ``                                                                 |
| [`ec1bb849`](https://github.com/NixOS/nixpkgs/commit/ec1bb8495034086a7ddda26aefc0302feb08f510) | `` schildichat-{web,desktop}: remove due to lack of maintenance (#272270) ``                     |
| [`be68d344`](https://github.com/NixOS/nixpkgs/commit/be68d3444cedb21b4104dcc0f64459cf9021f8f2) | `` bitcoin-knots: 23.0.knots20220529 -> 25.1.knots20231115 ``                                    |
| [`e816589e`](https://github.com/NixOS/nixpkgs/commit/e816589ee37c8429af497424a7f91ced729ac237) | `` tcllib: use fetchzip ``                                                                       |
| [`94cda6b4`](https://github.com/NixOS/nixpkgs/commit/94cda6b43d0e517caaaf22983c0e6de3830589f0) | `` tcllib: use critcl ``                                                                         |
| [`7e383bf3`](https://github.com/NixOS/nixpkgs/commit/7e383bf3c2f7f5f7ee6d055682f8603bfb1f8620) | `` critcl: init at 3.2 ``                                                                        |
| [`0df63f75`](https://github.com/NixOS/nixpkgs/commit/0df63f75c23a77ad27170d76b2854ffab735b439) | `` arduino-ide: Init at 2.2.1 ``                                                                 |
| [`0415d505`](https://github.com/NixOS/nixpkgs/commit/0415d505bbeb9aaf12b1186aa74cfde2c30ddcae) | `` warzone2100: 4.4.0 -> 4.4.1 ``                                                                |
| [`2453c821`](https://github.com/NixOS/nixpkgs/commit/2453c821f0a89bd579ac06f6a84152f41ee0c68b) | `` home-assistant-custom-components.adaptive_lighting: init at 1.19.1 ``                         |
| [`cf117dbd`](https://github.com/NixOS/nixpkgs/commit/cf117dbdd36b88310b788bf1b1e1ce54e061e39c) | `` maintainers: add mindstorms6 ``                                                               |
| [`7fa9146a`](https://github.com/NixOS/nixpkgs/commit/7fa9146a60b3aaafc390be6f25cb0109601486cf) | `` rke2: 1.28.2+rke2r1 -> 1.28.3+rke2r1 (#272652) ``                                             |
| [`46e35b98`](https://github.com/NixOS/nixpkgs/commit/46e35b98e78b72128a56ed9810dd1a31adcac908) | `` signal-desktop: Adds support for `aarch64-linux` ``                                           |
| [`f802b8ee`](https://github.com/NixOS/nixpkgs/commit/f802b8eeda4f05c6ed0793c4fcb022aecd2c6f97) | `` python311Packages.devialet: init at 1.4.3 ``                                                  |
| [`8ca90ac7`](https://github.com/NixOS/nixpkgs/commit/8ca90ac70f07d1d43a505fdcb8ee4337cfc3d6fe) | `` python311Packages.pyasuswrt: init at 0.1.20 ``                                                |
| [`a0efdd21`](https://github.com/NixOS/nixpkgs/commit/a0efdd21a1c4579642fb2ea1d24e541564ca792a) | `` vulkan-loader: Fix MinGW build ``                                                             |
| [`f8827960`](https://github.com/NixOS/nixpkgs/commit/f88279601db4bbacc24aab8af7f7b743994c9468) | `` checkov: 3.1.26 -> 3.1.27 ``                                                                  |
| [`6cafe736`](https://github.com/NixOS/nixpkgs/commit/6cafe73693c89bfd16c0e5857b37cd1b2f60ce79) | `` exploitdb: 2023-12-05 -> 2023-12-07 ``                                                        |
| [`494910d9`](https://github.com/NixOS/nixpkgs/commit/494910d935e12df59333c4e8d8b6dddd3d4a2b9f) | `` runelite: 2.6.9 -> 2.6.11 ``                                                                  |
| [`dd46a9b4`](https://github.com/NixOS/nixpkgs/commit/dd46a9b4d5e4aa4e0f126ab8bb5bf03cc57460a6) | `` opentofu: fix version output ``                                                               |
| [`1e42700b`](https://github.com/NixOS/nixpkgs/commit/1e42700bb25a9628a43cb88961e3569e37724ad6) | `` clipcat: 0.11.0 -> 0.13.0 ``                                                                  |
| [`56b52117`](https://github.com/NixOS/nixpkgs/commit/56b521174f07eda0f4a89dfbf83e77dc6c7fee5f) | `` rita: init at 4.8.0 ``                                                                        |
| [`eecb779d`](https://github.com/NixOS/nixpkgs/commit/eecb779dbc4d88f32e88bc5f1a019076bdfea33b) | `` mailpit: 1.10.2 -> 1.10.4 ``                                                                  |
| [`6aa7e649`](https://github.com/NixOS/nixpkgs/commit/6aa7e6494a09d73699f532a9288bc031c8d3be71) | `` reindeer: unstable-2023-11-09 -> unstable-2023-12-06 ``                                       |
| [`7e727675`](https://github.com/NixOS/nixpkgs/commit/7e7276752443954870c4ff158f3cf3755781edcc) | `` nats-server: 2.10.4 -> 2.10.7 ``                                                              |
| [`3d3a4f69`](https://github.com/NixOS/nixpkgs/commit/3d3a4f69bb9b43ffb820130cab7f17571d72f19d) | `` cargo-leptos: 0.2.2 -> 0.2.5 ``                                                               |
| [`6ef3f227`](https://github.com/NixOS/nixpkgs/commit/6ef3f227340f61249e5bdc5f3bd0c95d64625923) | `` eza: 0.16.2 -> 0.16.3 ``                                                                      |
| [`3bebb818`](https://github.com/NixOS/nixpkgs/commit/3bebb818eb23af6bf40fb80f2e8247e594e54982) | `` fortune-kind: 0.1.11 -> 0.1.12 ``                                                             |
| [`e8785cea`](https://github.com/NixOS/nixpkgs/commit/e8785ceaafc835b6a24b24da39dd3c2e97e6c153) | `` opentofu: 1.6.0-beta1 -> 1.6.0-beta2 ``                                                       |
| [`cf1edac5`](https://github.com/NixOS/nixpkgs/commit/cf1edac54736c3d95a3ec35bbf8285837e830859) | `` bzip3: 1.3.2 -> 1.4.0 ``                                                                      |
| [`209c66f3`](https://github.com/NixOS/nixpkgs/commit/209c66f3b775f326db43cbe0c907051e800c191c) | `` pkg-config: Fix MinGW build ``                                                                |
| [`34cfc9e2`](https://github.com/NixOS/nixpkgs/commit/34cfc9e26125727e4fed0c5ca4d2aa9c99ea3db1) | `` enscript: use system getopt for all builds; fix darwin ``                                     |
| [`410851ef`](https://github.com/NixOS/nixpkgs/commit/410851effcdf2b5d696304ff54d67b4dae67bc83) | `` ngtcp2-gnutls: 1.0.1 -> 1.1.0 ``                                                              |
| [`0f19ad62`](https://github.com/NixOS/nixpkgs/commit/0f19ad62883af222355b09dfdd5030e34b394b6a) | `` d2: 0.6.1 -> 0.6.2 ``                                                                         |
| [`fdb1afed`](https://github.com/NixOS/nixpkgs/commit/fdb1afed1942720b53c479cc2a97aa317b6d00ef) | `` vscode: add libGL.so.1 and libEGL.so.1 to vscode ``                                           |
| [`6bbe7d4d`](https://github.com/NixOS/nixpkgs/commit/6bbe7d4d0715409a86b3663c0fa90c1b3982c4ef) | `` python310Packages.transaction: 3.1.0 -> 4.0 ``                                                |
| [`6f2be7c0`](https://github.com/NixOS/nixpkgs/commit/6f2be7c0951f7c975000fed96431feae17eba3e6) | `` pkgs/by-name: Mention possibility of avoiding alternate callPackage's ``                      |
| [`ba88ebec`](https://github.com/NixOS/nixpkgs/commit/ba88ebec30f9110b5f354e31acd7f703cb0db018) | `` python310Packages.stripe: 7.5.0 -> 7.7.0 ``                                                   |
| [`79284393`](https://github.com/NixOS/nixpkgs/commit/79284393c8d4d7fbcb0162413cb118520d51b5e0) | `` python310Packages.sphinx-autoapi: 2.1.1 -> 3.0.0 ``                                           |
| [`45437720`](https://github.com/NixOS/nixpkgs/commit/45437720520dbfa9a2e460ef6da0d70f171620b7) | `` python310Packages.spectral-cube: 0.6.3 -> 0.6.5 ``                                            |
| [`3ae06c38`](https://github.com/NixOS/nixpkgs/commit/3ae06c380004ab1bb4146c986f38ed75ac3ec677) | `` lagrange: 1.17.4 → 1.17.5 ``                                                                  |
| [`0f153484`](https://github.com/NixOS/nixpkgs/commit/0f153484c30af24a8d0867955c90579dddca21ab) | `` dua: 2.20.3 -> 2.21.0 ``                                                                      |
| [`f1403ce9`](https://github.com/NixOS/nixpkgs/commit/f1403ce92f18f95906f2a3a4a4a2a9d463236a46) | `` typstfmt: 0.2.6 -> 0.2.7 ``                                                                   |
| [`0baf0d2e`](https://github.com/NixOS/nixpkgs/commit/0baf0d2ec679848340ffb065363e2c14a7a5083b) | `` rustypaste: 0.14.1 -> 0.14.2 ``                                                               |
| [`01dafe37`](https://github.com/NixOS/nixpkgs/commit/01dafe37ad052f50f6c14cdec2b31c5cc732a6f4) | `` planify: 4.1.1 -> 4.1.4 ``                                                                    |
| [`e0da2fb1`](https://github.com/NixOS/nixpkgs/commit/e0da2fb1623ade5bde7275071e22676de5769a5e) | `` cinnamon.warpinator: 1.6.4 -> 1.8.1 ``                                                        |
| [`2df7ccfa`](https://github.com/NixOS/nixpkgs/commit/2df7ccfa1498f5038b15acd50bc9277ad768dcbf) | `` python311Packages.torch: enable_language(CUDA) wants to -lcudart_static? ``                   |
| [`44611c4a`](https://github.com/NixOS/nixpkgs/commit/44611c4a6d16b0eeb1488e9557b6a11e45193a46) | `` cctag: unbreak the cuda variant ``                                                            |
| [`3ececb9e`](https://github.com/NixOS/nixpkgs/commit/3ececb9efafd80058525571d77d881767de6f5b8) | `` openvino: use opencv4.cxxdev in case cuda is enabled ``                                       |
| [`71c248ec`](https://github.com/NixOS/nixpkgs/commit/71c248ec1309381136bf74339d453a58b400b2a9) | `` torch: add the cxxdev output for cmake consumers ``                                           |
| [`55af9329`](https://github.com/NixOS/nixpkgs/commit/55af9329429a30ce81f7ad01da95406e1d62f785) | `` opencv4: discard build-time cuda deps ``                                                      |
| [`45698380`](https://github.com/NixOS/nixpkgs/commit/45698380295187b35f3872542b71efc2223f8201) | `` opencv4: propagate optical flow sdk same as cuda ``                                           |
| [`ada39913`](https://github.com/NixOS/nixpkgs/commit/ada3991349beb5880e3994f25c65a0cf68941b83) | `` opencv4: expose cxxdev, propagating optional cuda deps ``                                     |
| [`be9c779d`](https://github.com/NixOS/nixpkgs/commit/be9c779deba0e898802dd341a1ba9c04c4e9abe8) | `` cudaPackages.setupCudaHook: propagate buildInputs and self ``                                 |
| [`c62ba742`](https://github.com/NixOS/nixpkgs/commit/c62ba7424b0e3c1b7aec0f8d2f425cfea19e9ca0) | `` nb: 7.8.0 -> 7.9.0 ``                                                                         |
| [`97290cef`](https://github.com/NixOS/nixpkgs/commit/97290cef936c715ab59e64033623672abe270401) | `` libsolv: 0.7.26 -> 0.7.27 ``                                                                  |
| [`a54ae775`](https://github.com/NixOS/nixpkgs/commit/a54ae775396a717ce9c66a5bf4f5ebe1f5575c4e) | `` catppuccin: add qt5ct ``                                                                      |
| [`efdec260`](https://github.com/NixOS/nixpkgs/commit/efdec26090fe6c61327b67d933e39d694da36bc2) | `` treewide: install missing desktopItems ``                                                     |
| [`64502c3e`](https://github.com/NixOS/nixpkgs/commit/64502c3e091692b4cecbfdf7936d402c2ab67dcb) | `` serverless: use buildNpmPackage ``                                                            |
| [`6d2c0458`](https://github.com/NixOS/nixpkgs/commit/6d2c0458b8982619d53b8aa092697d7184cb676b) | `` nexttrace: 1.2.3.1 -> 1.2.6 ``                                                                |
| [`e3695de8`](https://github.com/NixOS/nixpkgs/commit/e3695de873a9dffea44632fe17cc4cc8fa1bb9ab) | `` ocamlPackages.iter: 1.7 -> 1.8 ``                                                             |
| [`38232bc5`](https://github.com/NixOS/nixpkgs/commit/38232bc5288375fb46099cf0665bf8d736e948c4) | `` ocamlPackages.inotify: 2.4.1 -> 2.5 ``                                                        |
| [`d768bf69`](https://github.com/NixOS/nixpkgs/commit/d768bf69a1ee47c8483273b9373763f88d434eb3) | `` maptool: extract application JARs from package ``                                             |