### PR TITLE
chore(flake/chaotic): `76101810` -> `bb23b9a8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1701943344,
-        "narHash": "sha256-CNZG1dJCBeFpv99jXv2lhFbDnHoW4X36uQZkq9oddGI=",
+        "lastModified": 1702060383,
+        "narHash": "sha256-XMMBRB3RoygT+lvQOlZHQI04VbhxpJkDQ3pa75aQiZg=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "76101810b33c875a90f0a002edfc6a0744529a5c",
+        "rev": "bb23b9a821adf19ed91bc4651c5d8689cfee1707",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                      |
| ----------------------------------------------------------------------------------------------- | ---------------------------- |
| [`bb23b9a8`](https://github.com/chaotic-cx/nyx/commit/bb23b9a821adf19ed91bc4651c5d8689cfee1707) | `` Bump 20231208-1 (#475) `` |
| [`4e6d94c4`](https://github.com/chaotic-cx/nyx/commit/4e6d94c4035d1ce87916f1a10d7f993db019b826) | `` scx: init (#474) ``       |
| [`b84815aa`](https://github.com/chaotic-cx/nyx/commit/b84815aa19e7342787a6729a310888c109870af2) | `` Bump 20231207-1 (#473) `` |