### PR TITLE
chore(flake/hyprland): `a794eecd` -> `11d1c504`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1701945972,
-        "narHash": "sha256-Nvbjtu7FAM5ULS1Z028y1ou3qJR1x606fnyva5kLkuo=",
+        "lastModified": 1702051336,
+        "narHash": "sha256-zfnvorPK5mQpbifc9rCqGH0fOeFMPaVnEsOOtm+NjH0=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "a794eecd6a71e431b654cebb1b28dbff0d6da079",
+        "rev": "11d1c50420cdeaa5426b837a6479455f47368f29",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                 |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
| [`11d1c504`](https://github.com/hyprwm/Hyprland/commit/11d1c50420cdeaa5426b837a6479455f47368f29) | `` windowrules: add focus param ``                                      |
| [`288f1863`](https://github.com/hyprwm/Hyprland/commit/288f1863f0b6886e0cdf85d16bb2460bb042acf2) | `` hyprctl: allow instances without HIS ``                              |
| [`6fb1b89b`](https://github.com/hyprwm/Hyprland/commit/6fb1b89b982eea26ecae75b93f1742537c4f31ae) | `` makefile: add rm hyprpm for uninstall (#4086) ``                     |
| [`004bf94a`](https://github.com/hyprwm/Hyprland/commit/004bf94a23223265c96e348a84d1d044a009c566) | `` keybinds: Keep focus on special when switching workspaces (#4084) `` |
| [`aa020a2a`](https://github.com/hyprwm/Hyprland/commit/aa020a2a1a560bd42f7ddc8c4808fd6db396ee8b) | `` toplevel-export: commence render pass before reading ``              |
| [`d9175a01`](https://github.com/hyprwm/Hyprland/commit/d9175a0181eb54b14e58b9ce655df3bc74e4ae8c) | `` hyprpm: fix with system headers ``                                   |