### PR TITLE
chore(flake/nur): `34c38401` -> `d854884a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -610,11 +610,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702024792,
-        "narHash": "sha256-ikWMhlQ5ovO0kviI511kEGUANnE3nest8OIm8uRkWS0=",
+        "lastModified": 1702060431,
+        "narHash": "sha256-8/yGvqBUx/oR2rDhY8+iWZ1nErjpsNCe2O8PvzFaerM=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "34c384017ea9808356c1d1f91525e7a17044d982",
+        "rev": "d854884a8c7d2014ff44a27cfe9cac8dd78cc7ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d854884a`](https://github.com/nix-community/NUR/commit/d854884a8c7d2014ff44a27cfe9cac8dd78cc7ea) | `` automatic update `` |
| [`748792dd`](https://github.com/nix-community/NUR/commit/748792dd53008a084e877fd530e0701693291186) | `` automatic update `` |
| [`1a57d132`](https://github.com/nix-community/NUR/commit/1a57d132af8e014fb4c2f30588ab61b3655d665e) | `` automatic update `` |
| [`4ca441c5`](https://github.com/nix-community/NUR/commit/4ca441c58bbfaa1728c4a5b4115f79569f6ff186) | `` automatic update `` |
| [`cd84eb75`](https://github.com/nix-community/NUR/commit/cd84eb75ea45a711d2d3cddd6936d42b336e26af) | `` automatic update `` |
| [`1dd4ced2`](https://github.com/nix-community/NUR/commit/1dd4ced2bd92ec2d4c53a6507d6b569efa7cd3b2) | `` automatic update `` |
| [`6fef751d`](https://github.com/nix-community/NUR/commit/6fef751d5a53a52182e1136a636b1fae539ecede) | `` automatic update `` |
| [`486672da`](https://github.com/nix-community/NUR/commit/486672da7b0f7e5f3148ab704b5a8a133bc369c5) | `` automatic update `` |
| [`27a43dd7`](https://github.com/nix-community/NUR/commit/27a43dd7fd3b8e0fe854400c6b34d3bb4b9df400) | `` automatic update `` |
| [`9ef7dada`](https://github.com/nix-community/NUR/commit/9ef7dadafd3b461ca5ef3a43cc3a072292c6b53d) | `` automatic update `` |
| [`f346d21a`](https://github.com/nix-community/NUR/commit/f346d21af439fedcf10ab5b3ce2614858e24b275) | `` automatic update `` |
| [`677cef10`](https://github.com/nix-community/NUR/commit/677cef10a7ae871c821e9169250c7fe86340bffc) | `` automatic update `` |
| [`a846e58f`](https://github.com/nix-community/NUR/commit/a846e58f03cb2e501e421626043b6ad52b3950fd) | `` automatic update `` |