### PR TITLE
chore(flake/nixpkgs): `d030c6eb` -> `17572dd7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -578,11 +578,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1701936692,
-        "narHash": "sha256-q3ItBV/eCI8V6+OZwNaA/oUKYBpA3F73Cq++llHIxPE=",
+        "lastModified": 1702025387,
+        "narHash": "sha256-vf1hTFA9WIWpZeumXi47YQYe6i67qUrYRCxiEfo1m18=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d030c6ebf04aabf73f4cf6a3f71d71f5f0a65655",
+        "rev": "17572dd79fb56671aeb81780c1161234e3450a7b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                            |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| [`b64bda66`](https://github.com/NixOS/nixpkgs/commit/b64bda660592159bd6a053fdb1ba96b9d67f204c) | `` python311Packages.fpdf2: init at 2.7.6 (#271076) ``                                             |
| [`2d5053fc`](https://github.com/NixOS/nixpkgs/commit/2d5053fca3de72a8cd5a7c71490bf5158e16094a) | `` beamPackages.mixRelease: Make determinism toggleable ``                                         |
| [`c865c662`](https://github.com/NixOS/nixpkgs/commit/c865c66216c4c71d72fadff797567bd8be1aad07) | `` beamPackages.buildMix: remove erlang references from output ``                                  |
| [`e924d0f5`](https://github.com/NixOS/nixpkgs/commit/e924d0f542496ea026ad8292dd412722aeeec3a2) | `` beamPackages.mixRelease: remove erlang references from output ``                                |
| [`4600a9d6`](https://github.com/NixOS/nixpkgs/commit/4600a9d60782a8832449fead0606f720e40169a1) | `` beamPackages.mixRelease: deterministic erlang builds ``                                         |
| [`26117abb`](https://github.com/NixOS/nixpkgs/commit/26117abbca9b30e96c001d3aaf2eab79c8b3b808) | `` ocamlPackages.hpack: 0.10.0 → 0.11.0 ``                                                         |
| [`f63903a9`](https://github.com/NixOS/nixpkgs/commit/f63903a90faf6cce169eb2bcc93fb45c457b1d31) | `` .github/workflows/update-terraform-providers.yml: use opentofu instead of terraform ``          |
| [`97830cbb`](https://github.com/NixOS/nixpkgs/commit/97830cbb025ce92d58921b12d528afbaa42000c4) | `` opentofu: fix `passthru.full` ``                                                                |
| [`3f7f9dbc`](https://github.com/NixOS/nixpkgs/commit/3f7f9dbcc5d9b923aca3dda806fbb649ed2ae8e9) | `` opentofu: add maintainer ``                                                                     |
| [`807a4c7b`](https://github.com/NixOS/nixpkgs/commit/807a4c7b82731359b9171b951a39b76d91951e7b) | `` openvino: fix build by providing ocl-icd for libOpenCL.so.1 ``                                  |
| [`1d7f1465`](https://github.com/NixOS/nixpkgs/commit/1d7f14656a699e61e549f16e8e3e406241a31c87) | `` maintainers-list.nix: Document (current) invitation process, add get-maintainer.sh (#267084) `` |
| [`49cd2f2d`](https://github.com/NixOS/nixpkgs/commit/49cd2f2d1f1aeff17376d3ab52d4fc6e4caa7ed9) | `` Revert "emacs: set 29 as default version and remove 28" (#272785) ``                            |
| [`9acd37f5`](https://github.com/NixOS/nixpkgs/commit/9acd37f5deb57301206f7cbbc248a765446ed66e) | `` vimPlugins.modus-themes-nvim: init at 2023-11-07 ``                                             |
| [`2732b087`](https://github.com/NixOS/nixpkgs/commit/2732b08781e2fdec34cd8d7c08dabedcd569aff3) | `` unstructured-api: 0.0.57 -> 0.0.59 ``                                                           |
| [`b4e7f004`](https://github.com/NixOS/nixpkgs/commit/b4e7f0049e2f9f05b870913786bf71606f960f79) | `` python311Packages.unstructured: 0.10.30 -> 0.11.2 ``                                            |
| [`39696977`](https://github.com/NixOS/nixpkgs/commit/3969697767f97ec6f66e394ca634bccef3da0cd2) | `` python311Packagges.unstructured-inference: 0.7.11 -> 0.7.18 ``                                  |
| [`b31d979c`](https://github.com/NixOS/nixpkgs/commit/b31d979c26854fa62cc59b5b5649012666169e5c) | `` surrealdb-migrations: 1.0.0-preview.1 -> 1.0.0 ``                                               |
| [`89d4c2fc`](https://github.com/NixOS/nixpkgs/commit/89d4c2fc4b3c896ee5ccf32a8441e8bf89590b1b) | `` gh: 2.39.2 -> 2.40.0 ``                                                                         |
| [`ecfbff96`](https://github.com/NixOS/nixpkgs/commit/ecfbff960af960e424a5fbe36298e8372def0c71) | `` bloop: 1.5.12 -> 1.5.13 ``                                                                      |
| [`2e07fed5`](https://github.com/NixOS/nixpkgs/commit/2e07fed5a92f927893779af4ad4d263fd5d78be2) | `` polybar-pulseaudio-control: init at 3.1.1 ``                                                    |
| [`539939a3`](https://github.com/NixOS/nixpkgs/commit/539939a3c86945e8783377506a243036db49b2de) | `` maintainers: add benlemasurier ``                                                               |
| [`7b8be9c3`](https://github.com/NixOS/nixpkgs/commit/7b8be9c3351eea950086054036993e21134e07ee) | `` nixos/wyoming/{faster-whisper,piper}: hook up enable option ``                                  |
| [`855a7ba0`](https://github.com/NixOS/nixpkgs/commit/855a7ba029eaf78c959c88b36fdf5760742b2b1e) | `` caffe: fix eval when CUDNN is not available ``                                                  |
| [`3ca8becb`](https://github.com/NixOS/nixpkgs/commit/3ca8becb81083bccba226382f0d255505208f087) | `` frankenphp: 1.0.0-rc.4 -> 1.0.0 ``                                                              |
| [`6179d88b`](https://github.com/NixOS/nixpkgs/commit/6179d88b7d98b7114840facfafb709b1f37b9aa8) | `` cuda-modules: tidy generic-builder/manifest installPhase and postPatchelf ``                    |
| [`7264b7fa`](https://github.com/NixOS/nixpkgs/commit/7264b7faf3e833f109ecea81a727c3629d1be8e4) | `` python311Packages.identify: 2.5.32 -> 2.5.33 ``                                                 |
| [`ab1da0d9`](https://github.com/NixOS/nixpkgs/commit/ab1da0d9bc106c17e2041f99393b8a8cda2b9b44) | `` python310Packages.python-telegram-bot: 20.6 -> 20.7 ``                                          |
| [`220e163c`](https://github.com/NixOS/nixpkgs/commit/220e163cdec211485c724aea144954b83e6f4e23) | `` linuxPackages.nvidiaPackages.production: 535.129.03 -> 535.146.02 ``                            |
| [`9f1f87b6`](https://github.com/NixOS/nixpkgs/commit/9f1f87b6125c229e199a874ea4be90a2ea06c185) | `` Revert "wordpress: fixed installing of languages" ``                                            |
| [`42da68c4`](https://github.com/NixOS/nixpkgs/commit/42da68c40fb677791c10b1fff8f8febc87bba88e) | `` home-assistant-custom-lovelace-modules.zigbee2mqtt-networkmap: init at unstable-2023-12-06 ``   |
| [`02dab4ab`](https://github.com/NixOS/nixpkgs/commit/02dab4ab5ce6cc7a03736f3937650a161f5b3ae4) | `` python3.pkgs.*: Explicitly pass buildPythonPackage format parameter ``                          |
| [`aaf735ea`](https://github.com/NixOS/nixpkgs/commit/aaf735eac97989ee924f2b3296d0d5200a6d734c) | `` cudaPackages.saxpy: only available from CUDA 11.4 and on ``                                     |
| [`0a7dacf9`](https://github.com/NixOS/nixpkgs/commit/0a7dacf94d879f7040c67ff7c3b0540ffe8a8782) | `` cudaPackages_12_3: init at 12.3.0 ``                                                            |
| [`bfaefd08`](https://github.com/NixOS/nixpkgs/commit/bfaefd0873a91aaffaae4254da5734f2fb311f48) | `` cudaPackages: add docs ``                                                                       |
| [`8e800ced`](https://github.com/NixOS/nixpkgs/commit/8e800cedaf24f5ad9717463b809b0beef7677000) | `` cudaPackages: move derivations to cuda-modules & support aarch64 ``                             |
| [`397d95d0`](https://github.com/NixOS/nixpkgs/commit/397d95d07fd095a3fba459a694bd284be3c47899) | `` cudaPackages: move config expressions to cuda-modules ``                                        |
| [`4a25023c`](https://github.com/NixOS/nixpkgs/commit/4a25023c2ef6f05904d27867aab8e71c034198a9) | `` cudaPackages: regen & move manifests to cuda-modules ``                                         |
| [`e59fe72c`](https://github.com/NixOS/nixpkgs/commit/e59fe72c6d8293676f923c6a244fa979d5f1aa54) | ``  python311Packages.jupyterhub: not broken on aarch64 ``                                         |
| [`1b5b2ebf`](https://github.com/NixOS/nixpkgs/commit/1b5b2ebfb759a9c517fc2633939b40dd4b1b59af) | `` invidious: unstable-2023-11-21 -> unstable-2023-12-06 ``                                        |
| [`330b00b1`](https://github.com/NixOS/nixpkgs/commit/330b00b103978fdb03adcb4554ae676b2f8ebdb6) | `` bitcoin: fix darwin builds ``                                                                   |
| [`ec1bb849`](https://github.com/NixOS/nixpkgs/commit/ec1bb8495034086a7ddda26aefc0302feb08f510) | `` schildichat-{web,desktop}: remove due to lack of maintenance (#272270) ``                       |
| [`be68d344`](https://github.com/NixOS/nixpkgs/commit/be68d3444cedb21b4104dcc0f64459cf9021f8f2) | `` bitcoin-knots: 23.0.knots20220529 -> 25.1.knots20231115 ``                                      |
| [`e816589e`](https://github.com/NixOS/nixpkgs/commit/e816589ee37c8429af497424a7f91ced729ac237) | `` tcllib: use fetchzip ``                                                                         |
| [`94cda6b4`](https://github.com/NixOS/nixpkgs/commit/94cda6b43d0e517caaaf22983c0e6de3830589f0) | `` tcllib: use critcl ``                                                                           |
| [`7e383bf3`](https://github.com/NixOS/nixpkgs/commit/7e383bf3c2f7f5f7ee6d055682f8603bfb1f8620) | `` critcl: init at 3.2 ``                                                                          |
| [`0df63f75`](https://github.com/NixOS/nixpkgs/commit/0df63f75c23a77ad27170d76b2854ffab735b439) | `` arduino-ide: Init at 2.2.1 ``                                                                   |
| [`0415d505`](https://github.com/NixOS/nixpkgs/commit/0415d505bbeb9aaf12b1186aa74cfde2c30ddcae) | `` warzone2100: 4.4.0 -> 4.4.1 ``                                                                  |
| [`2453c821`](https://github.com/NixOS/nixpkgs/commit/2453c821f0a89bd579ac06f6a84152f41ee0c68b) | `` home-assistant-custom-components.adaptive_lighting: init at 1.19.1 ``                           |
| [`cf117dbd`](https://github.com/NixOS/nixpkgs/commit/cf117dbdd36b88310b788bf1b1e1ce54e061e39c) | `` maintainers: add mindstorms6 ``                                                                 |
| [`79b21df7`](https://github.com/NixOS/nixpkgs/commit/79b21df7c40ea224ce296177fb0033b75cd8b6fa) | `` python311Packages.dvc-objects: 1.3.2 -> 1.4.9 ``                                                |
| [`7fa9146a`](https://github.com/NixOS/nixpkgs/commit/7fa9146a60b3aaafc390be6f25cb0109601486cf) | `` rke2: 1.28.2+rke2r1 -> 1.28.3+rke2r1 (#272652) ``                                               |
| [`46e35b98`](https://github.com/NixOS/nixpkgs/commit/46e35b98e78b72128a56ed9810dd1a31adcac908) | `` signal-desktop: Adds support for `aarch64-linux` ``                                             |
| [`63e5daf5`](https://github.com/NixOS/nixpkgs/commit/63e5daf5f14616fe2ab3bdefba8bf668fa3d2b79) | `` python311Packages.dvc-data: 2.22.3 -> 2.22.6 ``                                                 |
| [`f802b8ee`](https://github.com/NixOS/nixpkgs/commit/f802b8eeda4f05c6ed0793c4fcb022aecd2c6f97) | `` python311Packages.devialet: init at 1.4.3 ``                                                    |
| [`8ca90ac7`](https://github.com/NixOS/nixpkgs/commit/8ca90ac70f07d1d43a505fdcb8ee4337cfc3d6fe) | `` python311Packages.pyasuswrt: init at 0.1.20 ``                                                  |
| [`c93621b2`](https://github.com/NixOS/nixpkgs/commit/c93621b27cb25101aedea831839d0008e25d3384) | `` python311Packages.dvc: 3.30.3 -> 3.33.3 ``                                                      |
| [`a0efdd21`](https://github.com/NixOS/nixpkgs/commit/a0efdd21a1c4579642fb2ea1d24e541564ca792a) | `` vulkan-loader: Fix MinGW build ``                                                               |
| [`f8827960`](https://github.com/NixOS/nixpkgs/commit/f88279601db4bbacc24aab8af7f7b743994c9468) | `` checkov: 3.1.26 -> 3.1.27 ``                                                                    |
| [`6cafe736`](https://github.com/NixOS/nixpkgs/commit/6cafe73693c89bfd16c0e5857b37cd1b2f60ce79) | `` exploitdb: 2023-12-05 -> 2023-12-07 ``                                                          |
| [`cd6f762e`](https://github.com/NixOS/nixpkgs/commit/cd6f762e8b047ca374a7dadac2d4aab88dbe604c) | `` benthos: 4.22.0 -> 4.24.0 ``                                                                    |
| [`9aa6e8c5`](https://github.com/NixOS/nixpkgs/commit/9aa6e8c534a2393d726d2b5785e2864f135760a6) | `` protonvpn-gui_legacy: init at 1.12.0 ``                                                         |
| [`d392a5da`](https://github.com/NixOS/nixpkgs/commit/d392a5dab9f1d7228f0a9d2eeceedb0cb7b2838b) | `` protonvpn-gui: 1.12.0 -> 4.1.0-unstable-2023-10-25 ``                                           |
| [`810da048`](https://github.com/NixOS/nixpkgs/commit/810da0480b8bf24b1a2f2e0278494cceb5f31964) | `` vcpkg: init at 2023.08.09 ``                                                                    |
| [`673432ef`](https://github.com/NixOS/nixpkgs/commit/673432ef6ea14b51d77a11a3abefdadf7b76668e) | `` vcpkg-tool: init at 2023-09-15 ``                                                               |
| [`c56fe286`](https://github.com/NixOS/nixpkgs/commit/c56fe286621d3381924a62af67353d1ab5b6d96f) | `` maintainers: add gracicot ``                                                                    |
| [`84ab2798`](https://github.com/NixOS/nixpkgs/commit/84ab279895d8ffa6be3a436e4548c0f0da132cfe) | `` cmakerc: init at 2.0.1 ``                                                                       |
| [`7dd0fd6d`](https://github.com/NixOS/nixpkgs/commit/7dd0fd6dc650e76b58c83ab2f1356bc9a7e61abb) | `` maintainers: add guekka ``                                                                      |
| [`0eb84808`](https://github.com/NixOS/nixpkgs/commit/0eb84808b9d0b12df65a548d8bb9bc2ea5799660) | `` indiepass-desktop: init at unstable-2023-05-19 ``                                               |
| [`494910d9`](https://github.com/NixOS/nixpkgs/commit/494910d935e12df59333c4e8d8b6dddd3d4a2b9f) | `` runelite: 2.6.9 -> 2.6.11 ``                                                                    |
| [`dd46a9b4`](https://github.com/NixOS/nixpkgs/commit/dd46a9b4d5e4aa4e0f126ab8bb5bf03cc57460a6) | `` opentofu: fix version output ``                                                                 |
| [`1e42700b`](https://github.com/NixOS/nixpkgs/commit/1e42700bb25a9628a43cb88961e3569e37724ad6) | `` clipcat: 0.11.0 -> 0.13.0 ``                                                                    |
| [`56b52117`](https://github.com/NixOS/nixpkgs/commit/56b521174f07eda0f4a89dfbf83e77dc6c7fee5f) | `` rita: init at 4.8.0 ``                                                                          |
| [`1345ba6c`](https://github.com/NixOS/nixpkgs/commit/1345ba6cd28398d878e6c8641a97fbb9c904c65a) | `` lazymc: fix build on aarch64-darwin ``                                                          |
| [`ff20e6c0`](https://github.com/NixOS/nixpkgs/commit/ff20e6c005b97580b8ddaa2b06bd59dc63e9a85f) | `` lazymc: init at 0.2.10 ``                                                                       |
| [`b39187d6`](https://github.com/NixOS/nixpkgs/commit/b39187d6dadaeb511cbb0fbdd087188fc17ed877) | `` python311Packages.wn: disable on unsupported Python releases ``                                 |
| [`eecb779d`](https://github.com/NixOS/nixpkgs/commit/eecb779dbc4d88f32e88bc5f1a019076bdfea33b) | `` mailpit: 1.10.2 -> 1.10.4 ``                                                                    |
| [`96832525`](https://github.com/NixOS/nixpkgs/commit/96832525419ed3730a32ebd3631271c8a4a76900) | `` fastgron: 0.7.0 -> 0.7.7 ``                                                                     |
| [`6aa7e649`](https://github.com/NixOS/nixpkgs/commit/6aa7e6494a09d73699f532a9288bc031c8d3be71) | `` reindeer: unstable-2023-11-09 -> unstable-2023-12-06 ``                                         |
| [`f0ca8e51`](https://github.com/NixOS/nixpkgs/commit/f0ca8e5189c4f00c5cfe0b300fe3f2e23057c80f) | `` reaper: 7.05 -> 7.06 ``                                                                         |
| [`a5f1eb02`](https://github.com/NixOS/nixpkgs/commit/a5f1eb02c42d2c10c744e78ab8eea37bfece3614) | `` path-of-building.data: 2.35.4 -> 2.35.5 ``                                                      |
| [`7e727675`](https://github.com/NixOS/nixpkgs/commit/7e7276752443954870c4ff158f3cf3755781edcc) | `` nats-server: 2.10.4 -> 2.10.7 ``                                                                |
| [`e027ae35`](https://github.com/NixOS/nixpkgs/commit/e027ae351d5286b45e4bda249bb76029ea391082) | `` python310Packages.yfinance: 0.2.32 -> 0.2.33 ``                                                 |
| [`9fff0953`](https://github.com/NixOS/nixpkgs/commit/9fff0953afa415d9aace86707f0abd26ee0ef997) | `` python310Packages.bash-kernel: 0.9.1 -> 0.9.3 ``                                                |
| [`3d3a4f69`](https://github.com/NixOS/nixpkgs/commit/3d3a4f69bb9b43ffb820130cab7f17571d72f19d) | `` cargo-leptos: 0.2.2 -> 0.2.5 ``                                                                 |
| [`164d1afc`](https://github.com/NixOS/nixpkgs/commit/164d1afc5be199c8f997ff9cd77fbe0f4871b6dd) | `` python310Packages.wn: 0.9.4 -> 0.9.5 ``                                                         |
| [`d3f357fa`](https://github.com/NixOS/nixpkgs/commit/d3f357fa800b22b3e873909a716071c46be8e699) | `` python311Packages.celery: 5.3.5 -> 5.3.6 ``                                                     |
| [`30748250`](https://github.com/NixOS/nixpkgs/commit/30748250bc3eb4d8ea6ef83b885c019694ae3fca) | `` sourcehut.*: add format ``                                                                      |
| [`77df474b`](https://github.com/NixOS/nixpkgs/commit/77df474b75017457076a4f7973d45d4aa330b025) | `` python311Packages.celery: 5.3.4 -> 5.3.5 ``                                                     |
| [`72f8cb34`](https://github.com/NixOS/nixpkgs/commit/72f8cb348651b931c5267affce1a00e45c99e59c) | `` python311Packages.aws-xray-sdk: 2.12.0 -> 2.12.1 ``                                             |
| [`8f4b51c2`](https://github.com/NixOS/nixpkgs/commit/8f4b51c2f8cc848ca6f0711d38678116771cb875) | `` python311Packages.aws-xray-sdk: enable tests ``                                                 |
| [`815143af`](https://github.com/NixOS/nixpkgs/commit/815143af0f676f4d4dd97d8655244a99f4b174c6) | `` treewide: use lib.splitVersion ``                                                               |
| [`6ef3f227`](https://github.com/NixOS/nixpkgs/commit/6ef3f227340f61249e5bdc5f3bd0c95d64625923) | `` eza: 0.16.2 -> 0.16.3 ``                                                                        |
| [`3bebb818`](https://github.com/NixOS/nixpkgs/commit/3bebb818eb23af6bf40fb80f2e8247e594e54982) | `` fortune-kind: 0.1.11 -> 0.1.12 ``                                                               |
| [`e8785cea`](https://github.com/NixOS/nixpkgs/commit/e8785ceaafc835b6a24b24da39dd3c2e97e6c153) | `` opentofu: 1.6.0-beta1 -> 1.6.0-beta2 ``                                                         |
| [`cf1edac5`](https://github.com/NixOS/nixpkgs/commit/cf1edac54736c3d95a3ec35bbf8285837e830859) | `` bzip3: 1.3.2 -> 1.4.0 ``                                                                        |
| [`209c66f3`](https://github.com/NixOS/nixpkgs/commit/209c66f3b775f326db43cbe0c907051e800c191c) | `` pkg-config: Fix MinGW build ``                                                                  |
| [`34cfc9e2`](https://github.com/NixOS/nixpkgs/commit/34cfc9e26125727e4fed0c5ca4d2aa9c99ea3db1) | `` enscript: use system getopt for all builds; fix darwin ``                                       |
| [`3f89b2fa`](https://github.com/NixOS/nixpkgs/commit/3f89b2fa958d67eb19a869563f5947caff983c6b) | `` python310Packages.type-infer: 0.0.16 -> 0.0.17 ``                                               |
| [`410851ef`](https://github.com/NixOS/nixpkgs/commit/410851effcdf2b5d696304ff54d67b4dae67bc83) | `` ngtcp2-gnutls: 1.0.1 -> 1.1.0 ``                                                                |
| [`0f19ad62`](https://github.com/NixOS/nixpkgs/commit/0f19ad62883af222355b09dfdd5030e34b394b6a) | `` d2: 0.6.1 -> 0.6.2 ``                                                                           |
| [`fb3f3c9a`](https://github.com/NixOS/nixpkgs/commit/fb3f3c9a27a6a8d625b501e0fa9b216224b01da3) | `` cpu-x: 5.0.1 -> 5.0.2 ``                                                                        |
| [`fdb1afed`](https://github.com/NixOS/nixpkgs/commit/fdb1afed1942720b53c479cc2a97aa317b6d00ef) | `` vscode: add libGL.so.1 and libEGL.so.1 to vscode ``                                             |
| [`6bbe7d4d`](https://github.com/NixOS/nixpkgs/commit/6bbe7d4d0715409a86b3663c0fa90c1b3982c4ef) | `` python310Packages.transaction: 3.1.0 -> 4.0 ``                                                  |
| [`6f2be7c0`](https://github.com/NixOS/nixpkgs/commit/6f2be7c0951f7c975000fed96431feae17eba3e6) | `` pkgs/by-name: Mention possibility of avoiding alternate callPackage's ``                        |
| [`ebbfa918`](https://github.com/NixOS/nixpkgs/commit/ebbfa91857401809e42636fca535877f2587841a) | `` gnomeExtensions.ddterm: fix gjs path ``                                                         |
| [`ba88ebec`](https://github.com/NixOS/nixpkgs/commit/ba88ebec30f9110b5f354e31acd7f703cb0db018) | `` python310Packages.stripe: 7.5.0 -> 7.7.0 ``                                                     |
| [`79284393`](https://github.com/NixOS/nixpkgs/commit/79284393c8d4d7fbcb0162413cb118520d51b5e0) | `` python310Packages.sphinx-autoapi: 2.1.1 -> 3.0.0 ``                                             |
| [`45437720`](https://github.com/NixOS/nixpkgs/commit/45437720520dbfa9a2e460ef6da0d70f171620b7) | `` python310Packages.spectral-cube: 0.6.3 -> 0.6.5 ``                                              |
| [`3ae06c38`](https://github.com/NixOS/nixpkgs/commit/3ae06c380004ab1bb4146c986f38ed75ac3ec677) | `` lagrange: 1.17.4 → 1.17.5 ``                                                                    |
| [`0f153484`](https://github.com/NixOS/nixpkgs/commit/0f153484c30af24a8d0867955c90579dddca21ab) | `` dua: 2.20.3 -> 2.21.0 ``                                                                        |
| [`f1403ce9`](https://github.com/NixOS/nixpkgs/commit/f1403ce92f18f95906f2a3a4a4a2a9d463236a46) | `` typstfmt: 0.2.6 -> 0.2.7 ``                                                                     |
| [`7e371b2c`](https://github.com/NixOS/nixpkgs/commit/7e371b2c9b6fa8764ace6f84a588438a594841ff) | `` yubico-piv-tool: use finalAttrs pattern ``                                                      |
| [`4a538e5e`](https://github.com/NixOS/nixpkgs/commit/4a538e5e7b913b25ac376aa6ac097ad55f0c486f) | `` yubico-piv-tool: use fetchFromGitHub and nix-update-script ``                                   |
| [`de7db40c`](https://github.com/NixOS/nixpkgs/commit/de7db40cfe275c6462407d9dc4bb9fe01c7d682a) | `` yubico-piv-tool: add dev, man outputs ``                                                        |
| [`9db4b1b7`](https://github.com/NixOS/nixpkgs/commit/9db4b1b7bce7b5d057bfeec10f5b3c9192d15230) | `` yubico-piv-tool: 2.3.1 -> 2.4.1 ``                                                              |
| [`0baf0d2e`](https://github.com/NixOS/nixpkgs/commit/0baf0d2ec679848340ffb065363e2c14a7a5083b) | `` rustypaste: 0.14.1 -> 0.14.2 ``                                                                 |
| [`01dafe37`](https://github.com/NixOS/nixpkgs/commit/01dafe37ad052f50f6c14cdec2b31c5cc732a6f4) | `` planify: 4.1.1 -> 4.1.4 ``                                                                      |
| [`e0da2fb1`](https://github.com/NixOS/nixpkgs/commit/e0da2fb1623ade5bde7275071e22676de5769a5e) | `` cinnamon.warpinator: 1.6.4 -> 1.8.1 ``                                                          |
| [`49392292`](https://github.com/NixOS/nixpkgs/commit/4939229242b084d6c0950769aa4dc0de7244fe21) | `` wakelan: code predates c99, use -std=c89; fix darwin ``                                         |
| [`33144bd6`](https://github.com/NixOS/nixpkgs/commit/33144bd6e217ea0366168512fa8628c919f88e76) | `` hwloc: 2.9.3 -> 2.10.0 ``                                                                       |
| [`f7034a98`](https://github.com/NixOS/nixpkgs/commit/f7034a98456e8dca2b57a653afef35c4c1df652a) | `` qq: remove `gjs`, because qq does not depend on it at all ``                                    |
| [`7e394073`](https://github.com/NixOS/nixpkgs/commit/7e3940735af718435c7f34cbc1f0f9c0105e8159) | `` qq: add libGL to runtime path ``                                                                |
| [`4abe5347`](https://github.com/NixOS/nixpkgs/commit/4abe534795daece815600969c867fd9521099329) | `` qq: use makewrapper instead of setting gappsWrapperArgs ``                                      |
| [`9559cea1`](https://github.com/NixOS/nixpkgs/commit/9559cea14a91ffa63f5f90d7719b2c56233517f2) | `` catdvi: fix generated code in configure script; fix darwin ``                                   |
| [`2df7ccfa`](https://github.com/NixOS/nixpkgs/commit/2df7ccfa1498f5038b15acd50bc9277ad768dcbf) | `` python311Packages.torch: enable_language(CUDA) wants to -lcudart_static? ``                     |
| [`44611c4a`](https://github.com/NixOS/nixpkgs/commit/44611c4a6d16b0eeb1488e9557b6a11e45193a46) | `` cctag: unbreak the cuda variant ``                                                              |
| [`3ececb9e`](https://github.com/NixOS/nixpkgs/commit/3ececb9efafd80058525571d77d881767de6f5b8) | `` openvino: use opencv4.cxxdev in case cuda is enabled ``                                         |
| [`71c248ec`](https://github.com/NixOS/nixpkgs/commit/71c248ec1309381136bf74339d453a58b400b2a9) | `` torch: add the cxxdev output for cmake consumers ``                                             |
| [`55af9329`](https://github.com/NixOS/nixpkgs/commit/55af9329429a30ce81f7ad01da95406e1d62f785) | `` opencv4: discard build-time cuda deps ``                                                        |
| [`45698380`](https://github.com/NixOS/nixpkgs/commit/45698380295187b35f3872542b71efc2223f8201) | `` opencv4: propagate optical flow sdk same as cuda ``                                             |
| [`ada39913`](https://github.com/NixOS/nixpkgs/commit/ada3991349beb5880e3994f25c65a0cf68941b83) | `` opencv4: expose cxxdev, propagating optional cuda deps ``                                       |
| [`be9c779d`](https://github.com/NixOS/nixpkgs/commit/be9c779deba0e898802dd341a1ba9c04c4e9abe8) | `` cudaPackages.setupCudaHook: propagate buildInputs and self ``                                   |
| [`c62ba742`](https://github.com/NixOS/nixpkgs/commit/c62ba7424b0e3c1b7aec0f8d2f425cfea19e9ca0) | `` nb: 7.8.0 -> 7.9.0 ``                                                                           |
| [`bbadbae8`](https://github.com/NixOS/nixpkgs/commit/bbadbae8b77ac2fd1e46822fd7932f631e1b767e) | `` python3Packages.proton-keyring-linux-secretservice: init at 0.0.1-unstable-2023-04-14 ``        |
| [`36245fdd`](https://github.com/NixOS/nixpkgs/commit/36245fdd360012e5295b540527ca65f11e0def13) | `` python3Packages.proton-keyring-linux: init at 0.0.1-unstable-2023-04-14 ``                      |
| [`740207e8`](https://github.com/NixOS/nixpkgs/commit/740207e85b713454dcc7e6bc27f11e171ba9c545) | `` python3Packages.proton-vpn-network-manager-openvpn: init at 0.0.4-unstable-2023-07-05 ``        |
| [`5d5343aa`](https://github.com/NixOS/nixpkgs/commit/5d5343aae2924e2aa19be594e95855dec50d83ef) | `` python3Packages.proton-vpn-killswitch-network-manager: init at 0.2.0-unstable-2023-09-05 ``     |
| [`fa25dd81`](https://github.com/NixOS/nixpkgs/commit/fa25dd8118aa2e44655a22d9fd81d32dbc3507e0) | `` python3Packages.proton-vpn-network-manager: init at 0.3.0-unstable-2023-09-05 ``                |
| [`f63489a7`](https://github.com/NixOS/nixpkgs/commit/f63489a7f0a548df967dc58d7d8fd18a0046d37d) | `` python3Packages.proton-vpn-api-core: init at 0.20.1-unstable-2023-10-10 ``                      |
| [`3b470019`](https://github.com/NixOS/nixpkgs/commit/3b4700191799e30e5a2e71ec41c49c244c306b25) | `` python3Packages.proton-vpn-connection: init at 0.11.0-unstable-2023-09-05 ``                    |
| [`ee5c9cc7`](https://github.com/NixOS/nixpkgs/commit/ee5c9cc711474cebdf32df0210d0184ab423428d) | `` python3Packages.proton-vpn-killswitch: init at 0.2.0-unstable-2023-09-05 ``                     |
| [`f119508c`](https://github.com/NixOS/nixpkgs/commit/f119508cf0e99d64d8f3b2c21bafa28b50e1a7bd) | `` python3Packages.proton-vpn-session: init at 0.6.2-unstable-2023-10-24 ``                        |
| [`a8589579`](https://github.com/NixOS/nixpkgs/commit/a85895797539c4fff3891287f07006b334d0c133) | `` python3Packages.proton-vpn-logger: init at 0.2.1-unstable-2023-05-10 ``                         |
| [`f4176dac`](https://github.com/NixOS/nixpkgs/commit/f4176dac0954addbec901a6fbc6712477c4c2eeb) | `` python3Packages.proton-core: init at 0.1.15-unstable-2023-10-24 ``                              |
| [`97290cef`](https://github.com/NixOS/nixpkgs/commit/97290cef936c715ab59e64033623672abe270401) | `` libsolv: 0.7.26 -> 0.7.27 ``                                                                    |
| [`ee6873bd`](https://github.com/NixOS/nixpkgs/commit/ee6873bdbb902ce9ccd8dfb6a43baaa8eacb910f) | `` qq: 3.2.2-18394 -> 3.2.3-19189 ``                                                               |
| [`33b1ba77`](https://github.com/NixOS/nixpkgs/commit/33b1ba774c5ae965cab5aad52874c4f22996e386) | `` dico: disable tests on darwin ``                                                                |
| [`096b7523`](https://github.com/NixOS/nixpkgs/commit/096b7523938b0dc47225c58f2e530078458f29be) | `` libfive: fix build on darwin ``                                                                 |
| [`8e9dcaba`](https://github.com/NixOS/nixpkgs/commit/8e9dcabab736d89d2ba808fa294029b38c6bef08) | `` guile-ncurses: fix build on darwin ``                                                           |
| [`12bcee75`](https://github.com/NixOS/nixpkgs/commit/12bcee759da4967ea9a6db6bf16d6095495a35f3) | `` scheme-bytestructures: don't strip on darwin ``                                                 |
| [`1543cd24`](https://github.com/NixOS/nixpkgs/commit/1543cd24cc75c0cededadd7922ed52b7f71422f7) | `` guile-lzma: don't strip on darwin ``                                                            |
| [`ae250751`](https://github.com/NixOS/nixpkgs/commit/ae25075180c79ddd0da093626af1879051359a4c) | `` guile-gcrypt: don't strip on darwin ``                                                          |
| [`a54ae775`](https://github.com/NixOS/nixpkgs/commit/a54ae775396a717ce9c66a5bf4f5ebe1f5575c4e) | `` catppuccin: add qt5ct ``                                                                        |
| [`3ac584ce`](https://github.com/NixOS/nixpkgs/commit/3ac584ced04c3580cd3a7c3cbdb175eaba4bf22d) | `` x264: Add mingw32 hostPlatform support ``                                                       |
| [`c98f07b4`](https://github.com/NixOS/nixpkgs/commit/c98f07b42223774b8be0b521750a1ec717bd9bf0) | `` compass: use bundlerEnv ``                                                                      |
| [`f6e48acf`](https://github.com/NixOS/nixpkgs/commit/f6e48acfa21ba34298e976c327939567135e1acc) | `` gcc8: support avr cross compilation on aarch64-darwin ``                                        |
| [`efdec260`](https://github.com/NixOS/nixpkgs/commit/efdec26090fe6c61327b67d933e39d694da36bc2) | `` treewide: install missing desktopItems ``                                                       |