### PR TITLE
chore(flake/nur): `d854884a` -> `eeb0b84c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -610,11 +610,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702060431,
-        "narHash": "sha256-8/yGvqBUx/oR2rDhY8+iWZ1nErjpsNCe2O8PvzFaerM=",
+        "lastModified": 1702079139,
+        "narHash": "sha256-P60Q83fiXY4x+pq0mbNAdT5AdiJEpeFLaUZK+hArYVg=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "d854884a8c7d2014ff44a27cfe9cac8dd78cc7ea",
+        "rev": "eeb0b84c55657be1575872467aa5a40835af2dcd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eeb0b84c`](https://github.com/nix-community/NUR/commit/eeb0b84c55657be1575872467aa5a40835af2dcd) | `` automatic update `` |
| [`e4ce6fcf`](https://github.com/nix-community/NUR/commit/e4ce6fcfff92c0491d45607195e96bc8297341b2) | `` automatic update `` |