### PR TITLE
chore(flake/nur): `8b2db25a` -> `444a9b5c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -610,11 +610,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702226788,
-        "narHash": "sha256-/V9TxMu1apAoVfCgXDwq/ayN1TLyrfp5fXqWOBVM/Zc=",
+        "lastModified": 1702237445,
+        "narHash": "sha256-gCfV7eIdLghN/1NG2xngn4q0SXPO92cZ4/hPJepCw1w=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "8b2db25a3a8a03abca25979e8fb49c4d0d9c1a1f",
+        "rev": "444a9b5c426db74aea5e9dc8123705e4cf757815",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`444a9b5c`](https://github.com/nix-community/NUR/commit/444a9b5c426db74aea5e9dc8123705e4cf757815) | `` automatic update `` |
| [`0a778b28`](https://github.com/nix-community/NUR/commit/0a778b284baf0b846ee42e0effc432a9743949f6) | `` automatic update `` |
| [`4fa0e7e9`](https://github.com/nix-community/NUR/commit/4fa0e7e9638cfd05101f403a9086cd0b422bd7d0) | `` automatic update `` |
| [`e8df0ab9`](https://github.com/nix-community/NUR/commit/e8df0ab92de3616deda58f08c930c3bf29a8a24a) | `` automatic update `` |