### PR TITLE
chore(flake/spicetify-nix): `79d06a59` -> `52fa6b83`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -706,11 +706,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702008628,
-        "narHash": "sha256-rFGTM4T4lWtwW5e0RfTXBWNoNQ1yM6fDc+ix337rkJ4=",
+        "lastModified": 1702181423,
+        "narHash": "sha256-1sajkf0kMRcUS2CjmJQkPBj9c8wHjQmRrV2ku8YMlWM=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "79d06a59034e3196211dc0ba57973a777b15941a",
+        "rev": "52fa6b8355e8fd1dc3cf1371017d0e84de84fb81",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`52fa6b83`](https://github.com/Gerg-L/spicetify-nix/commit/52fa6b8355e8fd1dc3cf1371017d0e84de84fb81) | `` CI update 2023-12-10 (#14) `` |
| [`6514d0d4`](https://github.com/Gerg-L/spicetify-nix/commit/6514d0d42e5bad8e0d73debed8e10f27c0c61a47) | `` CI update 2023-12-09 (#13) `` |