### PR TITLE
chore(flake/nixpkgs): `17572dd7` -> `82787a00`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -578,11 +578,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1702025387,
-        "narHash": "sha256-vf1hTFA9WIWpZeumXi47YQYe6i67qUrYRCxiEfo1m18=",
+        "lastModified": 1702161390,
+        "narHash": "sha256-jyIIiNDyzFoeS6HeizkzEnhwaqqnEndGLnyTaEL32rg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "17572dd79fb56671aeb81780c1161234e3450a7b",
+        "rev": "82787a00628b1c5cabd0d43a657c6304b8451620",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| [`b4706322`](https://github.com/NixOS/nixpkgs/commit/b4706322a14cf3d6d53564afa2a77113dc93691a) | `` bugwarrior: update homepage ``                                                           |
| [`76cdab5a`](https://github.com/NixOS/nixpkgs/commit/76cdab5a1d2528524298b479e38d46ad88e4e785) | `` jujutsu: 0.11.0 -> 0.12.0 ``                                                             |
| [`096639c5`](https://github.com/NixOS/nixpkgs/commit/096639c548e2b0256309c92c53542e052eaa3761) | `` linux: drop XEN on 32-bit ``                                                             |
| [`c12a433c`](https://github.com/NixOS/nixpkgs/commit/c12a433c598cd75284496a724738dee523fe24ff) | `` oxen: drop ``                                                                            |
| [`88901462`](https://github.com/NixOS/nixpkgs/commit/889014629c115ddecb28c12147522c81aa69c359) | `` protonup-ng: add cafkafk to maintainers ``                                               |
| [`e58fea0a`](https://github.com/NixOS/nixpkgs/commit/e58fea0a2bc7d3975d9f02f3983059e4176baff3) | `` protonup-ng: add `mainProgram`, fixing `nix run` ``                                      |
| [`a7622619`](https://github.com/NixOS/nixpkgs/commit/a7622619d63f2f9b48e819909ae15ee243951d82) | `` gnome.pomodoro: 0.24.0 -> 0.24.1 ``                                                      |
| [`ea3391b7`](https://github.com/NixOS/nixpkgs/commit/ea3391b75cef5d4da91714a38b39cb87a794c0b7) | `` vals: 0.28.0 -> 0.30.0 ``                                                                |
| [`34ea942d`](https://github.com/NixOS/nixpkgs/commit/34ea942d3cbfba1d15c2acfb7de60a3bc85a975b) | `` unciv: 4.8.13 -> 4.9.6 ``                                                                |
| [`4edcbb31`](https://github.com/NixOS/nixpkgs/commit/4edcbb313c089ca37ca38f9420bec9baf6e927d3) | `` clucene_core_1: drop ``                                                                  |
| [`2df08863`](https://github.com/NixOS/nixpkgs/commit/2df088631c1e8b767bd3bce3b9f83fe64ccf2f76) | `` nuclei: 3.1.0 -> 3.1.1 ``                                                                |
| [`87c3cdda`](https://github.com/NixOS/nixpkgs/commit/87c3cdda08359066073ced21af39b6c8c6bdc560) | `` python311Packages.boschshcpy: 0.2.79 -> 0.2.83 ``                                        |
| [`7b0db577`](https://github.com/NixOS/nixpkgs/commit/7b0db577aa19abd47f7cdc11aa183094006a3e37) | `` python311Packages.cyclonedx-python-lib: 5.1.1 -> 5.2.0 ``                                |
| [`b132b9f3`](https://github.com/NixOS/nixpkgs/commit/b132b9f36c3cc950da8d82771ea05e4058a7c066) | `` vscodium: 1.84.2.23317 -> 1.84.2.23319 ``                                                |
| [`48ea4703`](https://github.com/NixOS/nixpkgs/commit/48ea4703e99c21bde9adbc316f578a9be2896745) | `` libdatachannel: 0.19.3 -> 0.19.4 ``                                                      |
| [`93ebf2a4`](https://github.com/NixOS/nixpkgs/commit/93ebf2a46eb403481ddacac7bb4d1351da744ace) | `` tippecanoe: 2.35.0 -> 2.37.1 ``                                                          |
| [`66c64fcf`](https://github.com/NixOS/nixpkgs/commit/66c64fcf35be6ee2e5d9db6c2e215646a8522168) | `` typst-lsp: 0.11.0 -> 0.12.0 ``                                                           |
| [`eca45ce2`](https://github.com/NixOS/nixpkgs/commit/eca45ce2a0e79874bd1d1128b11858695b099353) | `` railway: 3.5.1 -> 3.5.2 ``                                                               |
| [`40df077c`](https://github.com/NixOS/nixpkgs/commit/40df077ca2ae78093bd957a13b5b121335c3e765) | `` mongodb-tools: 100.9.1 -> 100.9.3 ``                                                     |
| [`3e919f58`](https://github.com/NixOS/nixpkgs/commit/3e919f5877b5fe8482b696f1258e4094680261d3) | `` starboard: 0.15.17 -> 0.15.18 ``                                                         |
| [`3a743db2`](https://github.com/NixOS/nixpkgs/commit/3a743db2b1ecbebcae880f9396d1afdb4af9a91b) | `` wamr: 1.2.3 -> 1.3.0 ``                                                                  |
| [`6e7e88a3`](https://github.com/NixOS/nixpkgs/commit/6e7e88a37d0b5b518c31ec6ce1de888424400f03) | `` homebank: 5.7.2 -> 5.7.3 ``                                                              |
| [`e467011f`](https://github.com/NixOS/nixpkgs/commit/e467011f9d79e4d48ff17771577ffff061a609b7) | `` openboard: unstable-2022-11-28 -> 1.7.0 ``                                               |
| [`e1301b96`](https://github.com/NixOS/nixpkgs/commit/e1301b96a86e8467e8492e2d2e04bf7312319103) | `` python311Packages.pyschlage: 2023.11.0 -> 2023.12.0 ``                                   |
| [`580a9d57`](https://github.com/NixOS/nixpkgs/commit/580a9d5740cdd145c930fd20bf069d250f062dad) | `` cutter: add qtwayland to build inputs ``                                                 |
| [`06ce9376`](https://github.com/NixOS/nixpkgs/commit/06ce9376defe52095e1c0dd62fc8421148215e7e) | `` steamguard-cli: 0.12.3 -> 0.12.5 ``                                                      |
| [`c5dd7489`](https://github.com/NixOS/nixpkgs/commit/c5dd7489e97f6f5fdd1bebadb6732e9c1df75f6e) | `` mission-center: 0.3.3 -> 0.4.1 ``                                                        |
| [`b70b495b`](https://github.com/NixOS/nixpkgs/commit/b70b495b9a298770f0cf75ace364149779926e16) | `` nextcloud-client: 3.10.1 -> 3.10.2 ``                                                    |
| [`638d9ebd`](https://github.com/NixOS/nixpkgs/commit/638d9ebd5073ce25282a36ce02c82dc59acaee48) | `` convco: 0.4.3 -> 0.5.0 ``                                                                |
| [`d353adfc`](https://github.com/NixOS/nixpkgs/commit/d353adfc069075ddbf253db65cbd61275da851cf) | `` datadog-agent: Remove self from meta.maintainers ``                                      |
| [`73607ace`](https://github.com/NixOS/nixpkgs/commit/73607ace33106e4b2a6218bc6234cad0641db12b) | `` sonata: Remove self from meta.maintainers ``                                             |
| [`c9fbc10b`](https://github.com/NixOS/nixpkgs/commit/c9fbc10b676cf8e9ab836513d18fc60d8aa0f7ce) | `` pythonPackages.*: Remove self from meta.maintainers ``                                   |
| [`32ee8b4c`](https://github.com/NixOS/nixpkgs/commit/32ee8b4c777e223b98aada6dd50d25e3a1403d7c) | `` nixos/tests/mysql-backup: Remove self from maintainers ``                                |
| [`c5710ce2`](https://github.com/NixOS/nixpkgs/commit/c5710ce2749e588493fa42738fd638074294c3be) | `` nixos/tests/mongodb: Remove self from maintainers ``                                     |
| [`b77b2197`](https://github.com/NixOS/nixpkgs/commit/b77b21970517d7a1207416a148b11196aecec45e) | `` rtfm: 0.2.2 -> 0.2.3 ``                                                                  |
| [`f1e938d5`](https://github.com/NixOS/nixpkgs/commit/f1e938d5708698c78ebb780defe85395c82a7890) | `` pinentry-rofi: 2.0.4 -> 2.0.5 ``                                                         |
| [`20fdb8b5`](https://github.com/NixOS/nixpkgs/commit/20fdb8b563d5e324b419a606adb116169e6f6fa9) | `` paho-mqtt-cpp: 1.3.0 → 1.3.2 ``                                                          |
| [`cd26f019`](https://github.com/NixOS/nixpkgs/commit/cd26f019c158b68220927f33f130626ce53c9f9b) | `` hugo: 0.120.4 -> 0.121.1 ``                                                              |
| [`29558c07`](https://github.com/NixOS/nixpkgs/commit/29558c0722ffd40ff625256e16259168b7c03ed1) | `` spotdl: 4.2.2 -> 4.2.4 (#272641) ``                                                      |
| [`6837e5ff`](https://github.com/NixOS/nixpkgs/commit/6837e5ff5c00ab709c11502b10c686debf0808bb) | `` guacamole-server: 1.5.3 -> 1.5.4 ``                                                      |
| [`6433ff0f`](https://github.com/NixOS/nixpkgs/commit/6433ff0fa10d0dc0a049c4e5a6f83cb60324fbcb) | `` guacamole-client: 1.5.3 -> 1.5.4 ``                                                      |
| [`fc79986d`](https://github.com/NixOS/nixpkgs/commit/fc79986dc300ee94f32bf985d604ccce1ff37aba) | `` girara: 0.4.0 -> 0.4.1 ``                                                                |
| [`7950a226`](https://github.com/NixOS/nixpkgs/commit/7950a226f6580beddf86b4b1bca808e0dc053946) | `` tests.trivial-builders.references: specify as empty set instead of null on non-Linux `` |
| [`d0215197`](https://github.com/NixOS/nixpkgs/commit/d02151974acd5d2e1a47cee3245d97e130c3ecfa) | `` datafusion-cli: 32.0.0 -> 33.0.0 ``                                                      |
| [`8ad13826`](https://github.com/NixOS/nixpkgs/commit/8ad13826f02e9c83a0b9fde57801d3598401daef) | `` slint-lsp: 1.3.0 -> 1.3.2 ``                                                             |
| [`197b168f`](https://github.com/NixOS/nixpkgs/commit/197b168f990680ed941900b3673c841b3f729a26) | `` sparkleshare: Remove fallback to Flatpak image ``                                        |
| [`f75eb514`](https://github.com/NixOS/nixpkgs/commit/f75eb5144d6fcbdb71f2f2ad0986f2fc8de21a65) | `` runme: 2.0.2 -> 2.0.5 ``                                                                 |
| [`86448b66`](https://github.com/NixOS/nixpkgs/commit/86448b669925de3ece12fd11981e3e282f4493ff) | `` kaniko: 1.18.0 -> 1.19.0 ``                                                              |
| [`d16f9a2c`](https://github.com/NixOS/nixpkgs/commit/d16f9a2cbd07b2be9c878529ae46c2d3e9eb9942) | `` bruno: 1.3.1 -> 1.4.0 ``                                                                 |
| [`e7acd638`](https://github.com/NixOS/nixpkgs/commit/e7acd638db5a4db816f366288bbb8369ea459042) | `` neomutt: 20230517 -> 20231103 ``                                                         |
| [`a7757a69`](https://github.com/NixOS/nixpkgs/commit/a7757a699d5c5cc34eb2bba47614b5155d6e44eb) | `` terragrunt: 0.53.8 -> 0.54.0 ``                                                          |
| [`b4c8a38c`](https://github.com/NixOS/nixpkgs/commit/b4c8a38c0fc6196ba9a0d8c27ec19f805cbafd7d) | `` nwjs: add NIXOS_OZONE_WL ``                                                              |
| [`e98cf3ea`](https://github.com/NixOS/nixpkgs/commit/e98cf3ea92cdbdec0ce8fca1ad01fd1225232e20) | `` netdata-go-plugins: 0.56.4 -> 0.57.2 ``                                                  |
| [`40f0dd97`](https://github.com/NixOS/nixpkgs/commit/40f0dd978ae16523c2f026cfbaac9210d69f8b2c) | `` netdata: 1.43.2 -> 1.44.0 ``                                                             |
| [`db1e415c`](https://github.com/NixOS/nixpkgs/commit/db1e415c07d808b132345ba6eacbc89c6b75aca2) | `` nixos/netdata: ensure analytics reporting is truly opted-out ``                          |
| [`4a34a5f2`](https://github.com/NixOS/nixpkgs/commit/4a34a5f2d4587892bdc1df6cde4cd1b6c285bdbe) | `` chromedriver: 119.0.6045.105 -> 120.0.6099.71 ``                                         |
| [`db8b5f05`](https://github.com/NixOS/nixpkgs/commit/db8b5f058ef1e7809f5838e86ade81483d304d42) | `` ungoogled-chromium: 119.0.6045.199-1 -> 120.0.6099.71-1 ``                               |
| [`ca726d0a`](https://github.com/NixOS/nixpkgs/commit/ca726d0a8a74bd04568357eee27e6d4ccbdd5733) | `` chromium: 119.0.6045.199 -> 120.0.6099.71 ``                                             |
| [`181cc6ce`](https://github.com/NixOS/nixpkgs/commit/181cc6ce3440fb1a621b0fd5ba6b44c0ec3835a4) | `` electron_28-bin: init at v28.0.0 (#272762) ``                                            |
| [`319a6568`](https://github.com/NixOS/nixpkgs/commit/319a6568c5c69cf0230187c3f70b5d0848de043b) | `` forgejo: 1.21.1-0 -> 1.21.2-0 ``                                                         |
| [`4e9e0905`](https://github.com/NixOS/nixpkgs/commit/4e9e090585ae52dc7b836477dc83c7107052d66b) | `` diffoscope: organize better missing tools and explain why docx2txt cannot be added ``    |
| [`61da111d`](https://github.com/NixOS/nixpkgs/commit/61da111d6f3cce9f81103d584ccf183ab867f463) | `` diffoscope: 252 -> 253 ``                                                                |
| [`c1cd3366`](https://github.com/NixOS/nixpkgs/commit/c1cd33667c5eaa0eec5d9fe1453ab2ab7c86c8f7) | `` diffoscope: add `acl` in the minimal package ``                                          |
| [`bcb89d69`](https://github.com/NixOS/nixpkgs/commit/bcb89d69457c4ac88248ed520223d5813663f42a) | `` sq: 0.42.1 -> 0.46.1 ``                                                                  |
| [`12434ff3`](https://github.com/NixOS/nixpkgs/commit/12434ff3fb98a5cb3645bdfef94bbb462e54d400) | `` i3bar-river: 0.1.5 -> 0.1.6 ``                                                           |
| [`727db88c`](https://github.com/NixOS/nixpkgs/commit/727db88c063586d2f912af26dc3ce19d6f31af05) | `` caddy: 2.7.5 -> 2.7.6 ``                                                                 |
| [`1392efba`](https://github.com/NixOS/nixpkgs/commit/1392efba795617a3e1d6b34abea71f33fd762ade) | `` plexRaw: 1.32.7.7621-871adbd44 -> 1.32.8.7639-fb6452ebf ``                               |
| [`7b3fda9c`](https://github.com/NixOS/nixpkgs/commit/7b3fda9cc1a5a9b2c3ef9b148ab3428bb2fbc130) | `` v2ray-domain-list-community: 20231201183121 -> 20231208065009 ``                         |
| [`e6ca6dc9`](https://github.com/NixOS/nixpkgs/commit/e6ca6dc9a22b34e5a8a50c5b6f22d252855f9800) | `` opentofu: 1.6.0-beta2 -> 1.6.0-beta3 ``                                                  |
| [`50793752`](https://github.com/NixOS/nixpkgs/commit/50793752a71b35bc0dab203db7d6ad18281e2e1e) | `` lib.sort: Make doc consistent with sortOn ``                                             |
| [`7438f4e0`](https://github.com/NixOS/nixpkgs/commit/7438f4e0de4f41a562c4292a035f406129208bfd) | `` nixos/btrbk: Optimize sort ``                                                            |
| [`01699323`](https://github.com/NixOS/nixpkgs/commit/016993237f083abba26f436eb201ac35ecc3ebd3) | `` lib.callPackageWith: Optimize levenshtein sort ``                                        |
| [`67cc7864`](https://github.com/NixOS/nixpkgs/commit/67cc78643d7307b7a4cd783e43c53346fdea18bf) | `` lib.sortOn: init ``                                                                      |
| [`5322e131`](https://github.com/NixOS/nixpkgs/commit/5322e1313e3c2b1458eed014b9f927e751c05a9a) | `` Update nixos/doc/manual/release-notes/rl-2405.section.md ``                              |
| [`28c01eec`](https://github.com/NixOS/nixpkgs/commit/28c01eec853b6f4be3cfdaade9959ae024222dd2) | `` linuxPackages.nvidia_x11_vulkan_beta: 535.43.19 -> 535.43.20 ``                          |
| [`84d8f6ad`](https://github.com/NixOS/nixpkgs/commit/84d8f6ad7a22740390de563626c6ca2ff8c4718f) | `` phpPackages.composer: 2.6.5 -> 2.6.6 ``                                                  |
| [`f58acfc5`](https://github.com/NixOS/nixpkgs/commit/f58acfc56c5454450ac7233869f183e7a32c22f3) | `` netlify-cli: Set meta.mainProgram ``                                                     |
| [`e1e4d22a`](https://github.com/NixOS/nixpkgs/commit/e1e4d22a1b1c0b5f406e0df102f582f54645010f) | `` python310Packages.m2crypto: fix build on darwin ``                                       |
| [`10f05262`](https://github.com/NixOS/nixpkgs/commit/10f05262180062103df2c130b4898e9fe731e7b7) | `` python310Packages.m2crypto: 0.39.0 -> 0.40.1 ``                                          |
| [`8bb34316`](https://github.com/NixOS/nixpkgs/commit/8bb3431638026e47b32b9feaaada6c461a6bba4b) | `` python310Packages.flask-mailman: drop Python 3.6 support ``                              |
| [`d62ee277`](https://github.com/NixOS/nixpkgs/commit/d62ee2774db62b321c35d5dc5d517b2d0161cf89) | `` python311Packages.xattr: drop support for Python 3.7 ``                                  |