### PR TITLE
chore(flake/hyprland): `0c10b8ab` -> `167f2ed3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1702225808,
-        "narHash": "sha256-wgkXZB43dWNb3TLwjXIrisgGj9R+aHEenWgAlsrpVOM=",
+        "lastModified": 1702236723,
+        "narHash": "sha256-zIEnimM1vhsFkz+Kubb8kJ6YgHuLe56pALOSJc6CMVY=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "0c10b8ab2dad9851b00c0e99bb1fde3f01d5478c",
+        "rev": "167f2ed3b2bb18ceeabb831ac80b655ef8e16867",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                              |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
| [`167f2ed3`](https://github.com/hyprwm/Hyprland/commit/167f2ed3b2bb18ceeabb831ac80b655ef8e16867) | `` border: fix failed assert on small windows ``                     |
| [`d02ba422`](https://github.com/hyprwm/Hyprland/commit/d02ba422daae97498ffe6cdf84914b74ddf1fd44) | `` hyprpm: guard empty command ``                                    |
| [`359baa02`](https://github.com/hyprwm/Hyprland/commit/359baa02147f0ff91c8c5156c5e83b6ec6976525) | `` ci: use composite action to minimize code duplication (#4112) ``  |
| [`efdf07e2`](https://github.com/hyprwm/Hyprland/commit/efdf07e295d00cf5391a8c0089967a69a76d9b08) | `` renderer: Allocate background texture only if required (#4111) `` |