### PR TITLE
chore(flake/hyprland): `e53134ca` -> `01e5c59d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -294,11 +294,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1702313470,
-        "narHash": "sha256-zwy3Bp8rBSatjOH8WpRLqMWmzhCjJjCRwXseP8dhh70=",
+        "lastModified": 1702488319,
+        "narHash": "sha256-goxBCjjWitvx2Oq4AihpA2OhYEirolMLC48fdA7Iey8=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "e53134ca904e47a24191ea028c019ac9728b7dad",
+        "rev": "01e5c59d752d3fe7fa484330fa48e010054b8fa1",
         "type": "github"
       },
       "original": {
@@ -780,11 +780,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1700508250,
-        "narHash": "sha256-X4o/mifI7Nhu0UKYlxx53wIC+gYDo3pVM9L2u3PE2bE=",
+        "lastModified": 1702334919,
+        "narHash": "sha256-ibOZ3TLjqndGMcj2f+07NFwDWoum4IbzF58byZuJJNg=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "eb120ff25265ecacd0fc13d7dab12131b60d0f47",
+        "rev": "f5c3576c3b6cb1c31a8dfa3e4113f59bfe40cd71",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                        |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
| [`01e5c59d`](https://github.com/hyprwm/Hyprland/commit/01e5c59d752d3fe7fa484330fa48e010054b8fa1) | `` Revert "xwayland: push invisible windows outside layout" ``                 |
| [`b2e5a80e`](https://github.com/hyprwm/Hyprland/commit/b2e5a80e2ff1fcbf8164a45c5ef8ebffbb511fae) | `` hyprpm: Link against tomlplusplus when using cmake (#4145) ``               |
| [`55cb565e`](https://github.com/hyprwm/Hyprland/commit/55cb565e6de201a09bc5a7fb91a9a87448cea321) | `` Nix: expose legacyRenderer package ``                                       |
| [`4190b967`](https://github.com/hyprwm/Hyprland/commit/4190b967186e50d00ea3dc636e9f3ec40639dd03) | `` hyprpm: add duplicate header error and log more verbose in install fails `` |
| [`d9bc2102`](https://github.com/hyprwm/Hyprland/commit/d9bc210285c1971afd9abe9fbe89a5a14c8df2a7) | `` Nix: remove libdrm override ``                                              |
| [`4de98607`](https://github.com/hyprwm/Hyprland/commit/4de986072c12af8081f877f4792d57b4a11a0a6a) | `` layout: Focus a floating window after closing the last tiled (#4137) ``     |
| [`934112af`](https://github.com/hyprwm/Hyprland/commit/934112af5bed36a1273cc0d5588e27ab4825922b) | `` config: Use canonical instead of read_symlink (#4136) ``                    |
| [`ba2af6f8`](https://github.com/hyprwm/Hyprland/commit/ba2af6f86d26fbf4b51aa37bf901e0118f46bbe3) | `` focus: prefer sendMotionEventsToFocused for ensuring cursor image ``        |
| [`1950c3fc`](https://github.com/hyprwm/Hyprland/commit/1950c3fc9c807f10735b0a681aca49fd2d0d2d0b) | `` input: unset resize cursor on empty focus ``                                |
| [`8f384878`](https://github.com/hyprwm/Hyprland/commit/8f3848788422822c2cb36c57b4f3929eec1cc42c) | `` xwayland: don't change workspace on configure for invisible windows ``      |
| [`accb3d8d`](https://github.com/hyprwm/Hyprland/commit/accb3d8d0b339ce83dd36704503253d874c7163b) | `` xwayland: push invisible windows outside layout ``                          |
| [`ea7569d7`](https://github.com/hyprwm/Hyprland/commit/ea7569d7e0941d19f5f469a5fbb79bc0fa62b935) | `` config: improve layoutopt handling for workspacerules ``                    |