### PR TITLE
chore(flake/nur): `e45022e0` -> `46e1aa64`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702329480,
-        "narHash": "sha256-htBER66gdscbwDtgh2+aAXeL9ejCr4lMekG9yvag3Fs=",
+        "lastModified": 1702337700,
+        "narHash": "sha256-JawTBHC8XKmQpMJSuz7AFbICZBeHPm6ADrHM+pV1Zg8=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "e45022e0e4959af1106b264205980b11b97f9396",
+        "rev": "46e1aa641b2a4109132b6071c1374cf2690643ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`46e1aa64`](https://github.com/nix-community/NUR/commit/46e1aa641b2a4109132b6071c1374cf2690643ef) | `` automatic update `` |
| [`bc19da80`](https://github.com/nix-community/NUR/commit/bc19da80d49164d27953c60e804095094a74e0c4) | `` automatic update `` |
| [`7c966e4b`](https://github.com/nix-community/NUR/commit/7c966e4b321b0cb4c3ca407007c783d1ec998dfd) | `` automatic update `` |