### PR TITLE
chore(flake/chaotic): `29cd0da2` -> `7369da9b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1702323173,
-        "narHash": "sha256-G/mhFrlBDV6sgyfZ7fbCMlnH0VLKjk+1m7TXSWXaFdc=",
+        "lastModified": 1702495959,
+        "narHash": "sha256-xLYLHlF0wsBNQtC1FMYHhhu13lRUxFh8uEMkv5/427g=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "29cd0da206e1815af2aa5791016baf2ab7055b15",
+        "rev": "7369da9bf46df08ec2d4793f72e7000d511864e4",
         "type": "github"
       },
       "original": {
@@ -251,12 +251,12 @@
         ]
       },
       "locked": {
-        "lastModified": 1702203126,
-        "narHash": "sha256-4BhN2Vji19MzRC7SUfPZGmtZ2WZydQeUk/ogfRBIZMs=",
-        "rev": "defbb9c5857e157703e8fc7cf3c2ceb01cb95883",
-        "revCount": 3178,
+        "lastModified": 1702423270,
+        "narHash": "sha256-3ZA5E+b2XBP+c9qGhWpRApzPq/PZtIPgkeEDpTBV4g8=",
+        "rev": "d9297efd3a1c3ebb9027dc68f9da0ac002ae94db",
+        "revCount": 3189,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/nix-community/home-manager/0.1.3178%2Brev-defbb9c5857e157703e8fc7cf3c2ceb01cb95883/018c5337-b35a-70f9-ab26-b36c9064d16c/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/nix-community/home-manager/0.1.3189%2Brev-d9297efd3a1c3ebb9027dc68f9da0ac002ae94db/018c6056-840b-7cf1-807e-7eba8b631300/source.tar.gz"
       },
       "original": {
         "type": "tarball",


### PR DESCRIPTION
| Commit                                                                                          | Message                                   |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`7369da9b`](https://github.com/chaotic-cx/nyx/commit/7369da9bf46df08ec2d4793f72e7000d511864e4) | `` Bump 20231213-1 (#483) ``              |
| [`57ab5f5b`](https://github.com/chaotic-cx/nyx/commit/57ab5f5b29b5f8f09b52eb64f8ac85651c569804) | `` nixpkgs: bump to 20231212 ``           |
| [`e22c855e`](https://github.com/chaotic-cx/nyx/commit/e22c855e000c91e9f469bbd406e5e3ae125d47f8) | `` ci: fully eval aarch64-linux (#482) `` |
| [`8961d944`](https://github.com/chaotic-cx/nyx/commit/8961d94486bc9cdf22f520297d20e6a4cc9cc67a) | `` modules: separate nyx-cache (#481) ``  |
| [`ca7a924a`](https://github.com/chaotic-cx/nyx/commit/ca7a924af0d78892259c310e26a32e6eb7b90d5f) | `` Bump 20231212-1 (#480) ``              |