### PR TITLE
chore(flake/home-manager): `defbb9c5` -> `5e9d1fe1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -270,11 +270,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702203126,
-        "narHash": "sha256-4BhN2Vji19MzRC7SUfPZGmtZ2WZydQeUk/ogfRBIZMs=",
+        "lastModified": 1702510888,
+        "narHash": "sha256-+7Bd9j47gDjD1DD0K9zKwA+8TjnTdTRGMVCERh6w2L0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "defbb9c5857e157703e8fc7cf3c2ceb01cb95883",
+        "rev": "5e9d1fe19f2d17cdfeb3b7e5e668f763e430cd28",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`5e9d1fe1`](https://github.com/nix-community/home-manager/commit/5e9d1fe19f2d17cdfeb3b7e5e668f763e430cd28) | `` flake.lock: Update ``                                |
| [`7a69b3e7`](https://github.com/nix-community/home-manager/commit/7a69b3e738a587915a374994e05e8e10f1216721) | `` ssh: add addKeysToAgent option ``                    |
| [`d9297efd`](https://github.com/nix-community/home-manager/commit/d9297efd3a1c3ebb9027dc68f9da0ac002ae94db) | `` awscli: only write config files when not empty ``    |
| [`0e7cd646`](https://github.com/nix-community/home-manager/commit/0e7cd646743249c6f4f257e8cfacf73ccf19e0b9) | `` docs: fix nix-darwin module configuration example `` |
| [`01a66e31`](https://github.com/nix-community/home-manager/commit/01a66e313f9386cbde1ed597aeb5c3a08661e2d9) | `` msmtp: add configurable package ``                   |
| [`b3c4e98a`](https://github.com/nix-community/home-manager/commit/b3c4e98aec170c04268451db00d7dbe2dad2f4a5) | `` Translate using Weblate (Portuguese) ``              |
| [`dd5aef0a`](https://github.com/nix-community/home-manager/commit/dd5aef0a794907d581140f181167997f071b48e3) | `` Translate using Weblate (Russian) ``                 |
| [`5be24c74`](https://github.com/nix-community/home-manager/commit/5be24c74d966bfb8fce8fad1ee222affc0e76ebc) | `` Translate using Weblate (Russian) ``                 |
| [`d33e0e74`](https://github.com/nix-community/home-manager/commit/d33e0e7442353c444b62b9b11fb6b84c87903144) | `` Translate using Weblate (Russian) ``                 |
| [`b61fae90`](https://github.com/nix-community/home-manager/commit/b61fae90bada652f816b47b1181c8c3d0208bcbc) | `` Translate using Weblate (Russian) ``                 |
| [`bb202f19`](https://github.com/nix-community/home-manager/commit/bb202f194b67ccbef75e55077fd5153fe0fe2198) | `` Translate using Weblate (Catalan) ``                 |
| [`700002cb`](https://github.com/nix-community/home-manager/commit/700002cbaea52c159682ea733461e025bd687ee8) | `` Translate using Weblate (Russian) ``                 |
| [`c7b84ad0`](https://github.com/nix-community/home-manager/commit/c7b84ad0e82b9551c49881c61fa74abd58190709) | `` Translate using Weblate (Russian) ``                 |