### PR TITLE
chore(flake/nur): `46e1aa64` -> `5ced9941`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -555,11 +555,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702337700,
-        "narHash": "sha256-JawTBHC8XKmQpMJSuz7AFbICZBeHPm6ADrHM+pV1Zg8=",
+        "lastModified": 1702511108,
+        "narHash": "sha256-DypYWfpRqMLFX8euXxJ4yzLcemBRMtJdeVcXwEMZ3BA=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "46e1aa641b2a4109132b6071c1374cf2690643ef",
+        "rev": "5ced9941645336c3cca15e4a679d7106625a2c7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5ced9941`](https://github.com/nix-community/NUR/commit/5ced9941645336c3cca15e4a679d7106625a2c7f) | `` automatic update `` |
| [`f5363f3c`](https://github.com/nix-community/NUR/commit/f5363f3c1cae0c91d0e8db76cde3876487869719) | `` automatic update `` |
| [`0ff0cfc6`](https://github.com/nix-community/NUR/commit/0ff0cfc638d7d75b6994d7620fc033ebd6639cd3) | `` automatic update `` |
| [`fbfc9fcd`](https://github.com/nix-community/NUR/commit/fbfc9fcd228c7de006181bef7bdeedc297ede138) | `` automatic update `` |
| [`d5383b67`](https://github.com/nix-community/NUR/commit/d5383b67f4f034bd5a11233c82861da120943914) | `` automatic update `` |
| [`cc42b289`](https://github.com/nix-community/NUR/commit/cc42b2891d6dd40df7d8ba7a73e9fc4c478725db) | `` automatic update `` |
| [`2c5b0c18`](https://github.com/nix-community/NUR/commit/2c5b0c182b06d14e20269c57aa39b7d113b441fb) | `` automatic update `` |
| [`a79b4a62`](https://github.com/nix-community/NUR/commit/a79b4a624fc2773e0ad4d1c93e8722d0b10e6f05) | `` automatic update `` |
| [`deff83b6`](https://github.com/nix-community/NUR/commit/deff83b654473ec574849954dbc2095f7e555a2f) | `` automatic update `` |
| [`658414fd`](https://github.com/nix-community/NUR/commit/658414fdbf10eb42b82b4801e3c80af3be188886) | `` automatic update `` |
| [`391da2e0`](https://github.com/nix-community/NUR/commit/391da2e0ed3b5008c7f2faaf47cc0c2d565cb780) | `` automatic update `` |
| [`9f2fffa2`](https://github.com/nix-community/NUR/commit/9f2fffa26cbe70a7e55942a8de656665e16afa4c) | `` automatic update `` |
| [`beef92b3`](https://github.com/nix-community/NUR/commit/beef92b34992174a653433ebad426ef6e252cae3) | `` automatic update `` |
| [`08fa10b1`](https://github.com/nix-community/NUR/commit/08fa10b13aece35a0c257096c64a473f70a7b852) | `` automatic update `` |
| [`dbde17d4`](https://github.com/nix-community/NUR/commit/dbde17d4cc015851cb63657908f9a1dc16b78770) | `` automatic update `` |
| [`f3550dc7`](https://github.com/nix-community/NUR/commit/f3550dc776b9af2f2dbd03477c4f67be599232c5) | `` automatic update `` |
| [`3a6222ba`](https://github.com/nix-community/NUR/commit/3a6222ba50170f00911b20e14d0893be19502464) | `` automatic update `` |
| [`3a28ece6`](https://github.com/nix-community/NUR/commit/3a28ece61e8065df10b761f9f9cc0a2a5dc08fec) | `` automatic update `` |
| [`0ee220eb`](https://github.com/nix-community/NUR/commit/0ee220eb9acd37aaee74edbf9c926734d0ec4c9d) | `` automatic update `` |
| [`d981a698`](https://github.com/nix-community/NUR/commit/d981a6989b399a63bb04b8b1f2e54c3a4f9dcf1b) | `` automatic update `` |
| [`82470813`](https://github.com/nix-community/NUR/commit/82470813b5394c2b4e51b3eb5b1142c65089e9c6) | `` automatic update `` |
| [`13deb9d2`](https://github.com/nix-community/NUR/commit/13deb9d23daa58856053b7e2aaed25eb5e94bb7c) | `` automatic update `` |
| [`2a6b7948`](https://github.com/nix-community/NUR/commit/2a6b79487f1477b619f8f0386d46f94de529849a) | `` automatic update `` |
| [`c821971e`](https://github.com/nix-community/NUR/commit/c821971ede20008661d5ded3e49750accc5b0f71) | `` automatic update `` |
| [`d324bcae`](https://github.com/nix-community/NUR/commit/d324bcae8ed3737f634ebd3423e51e6ad7659b0c) | `` automatic update `` |
| [`c18524ff`](https://github.com/nix-community/NUR/commit/c18524ffa61618ae889f2718045f6a01585325b0) | `` automatic update `` |
| [`0fbffd39`](https://github.com/nix-community/NUR/commit/0fbffd3931d6838b120505965fb576bfb6f13b35) | `` automatic update `` |
| [`2daf8298`](https://github.com/nix-community/NUR/commit/2daf8298d05ccbf40ba2333ec6ae899b55b598b3) | `` automatic update `` |
| [`99ed99c1`](https://github.com/nix-community/NUR/commit/99ed99c1edefe9896322e6b00c9fcbe4c4e579ce) | `` automatic update `` |
| [`dea3d5a1`](https://github.com/nix-community/NUR/commit/dea3d5a1c975e95dcaea4feb331e6beeaee325e7) | `` automatic update `` |
| [`55ff7c9e`](https://github.com/nix-community/NUR/commit/55ff7c9e06b3dd19be193158fb39df1a4623ea70) | `` automatic update `` |
| [`f1089799`](https://github.com/nix-community/NUR/commit/f10897998cc2c92bafb252b5450bc7af6a9fe006) | `` automatic update `` |
| [`3dd5078c`](https://github.com/nix-community/NUR/commit/3dd5078cfc2cd74b83561fb67669acf05944c982) | `` automatic update `` |
| [`82d6c288`](https://github.com/nix-community/NUR/commit/82d6c2887abbcc767962134c212b2b766390f7c7) | `` automatic update `` |
| [`b826d6c5`](https://github.com/nix-community/NUR/commit/b826d6c5443660754ffee97885affc1256309985) | `` automatic update `` |
| [`4c2346f4`](https://github.com/nix-community/NUR/commit/4c2346f45fd7a97ff67a2e8f7d92ae1945b2a541) | `` automatic update `` |
| [`ab573e6f`](https://github.com/nix-community/NUR/commit/ab573e6fe0b6de427749a0dd0a3ca1c955314c7d) | `` automatic update `` |
| [`57f42201`](https://github.com/nix-community/NUR/commit/57f42201f76e03ab61399e5be14e7e4189a31ae5) | `` automatic update `` |
| [`4364c134`](https://github.com/nix-community/NUR/commit/4364c134309c00c0d6bec9613809e8795262970d) | `` automatic update `` |
| [`ba1f83ae`](https://github.com/nix-community/NUR/commit/ba1f83ae768a4156108087078792da671b5cff61) | `` automatic update `` |
| [`fe80556d`](https://github.com/nix-community/NUR/commit/fe80556dc7c777833d0ade8c47638acd6570db44) | `` automatic update `` |
| [`0a351b87`](https://github.com/nix-community/NUR/commit/0a351b87ccbd0aaf0e33e735d50d338293f63853) | `` automatic update `` |
| [`afac0dcd`](https://github.com/nix-community/NUR/commit/afac0dcdeb4bcfd484dee11afa7c9ab0b354d251) | `` automatic update `` |
| [`042bfa44`](https://github.com/nix-community/NUR/commit/042bfa44446558552faf967b8c69e98aa489eac3) | `` automatic update `` |
| [`9bf14f1a`](https://github.com/nix-community/NUR/commit/9bf14f1a4c465c703efd08ece4592db2b2e9125f) | `` automatic update `` |
| [`4b5a199d`](https://github.com/nix-community/NUR/commit/4b5a199daa8bc45a03dace5b7e16fe96b6a3c95a) | `` automatic update `` |
| [`e2172b7d`](https://github.com/nix-community/NUR/commit/e2172b7d7c678c67bd55951e9e1ff637348d1e42) | `` automatic update `` |
| [`1f0b3515`](https://github.com/nix-community/NUR/commit/1f0b35155592748d8fe4fc31eaf36942b97120b4) | `` automatic update `` |
| [`ba17dae4`](https://github.com/nix-community/NUR/commit/ba17dae4a1dc1c378d2e69c6970a24f236833709) | `` automatic update `` |
| [`a9277f1a`](https://github.com/nix-community/NUR/commit/a9277f1a00c6c16b86677dc88ca3b092a719423a) | `` automatic update `` |
| [`06e9177f`](https://github.com/nix-community/NUR/commit/06e9177f0af7d209181112a686616f33f161322c) | `` automatic update `` |
| [`28e619c1`](https://github.com/nix-community/NUR/commit/28e619c145f4c5599cf1e8dad65198a2f1144ff7) | `` automatic update `` |
| [`278041d5`](https://github.com/nix-community/NUR/commit/278041d55cfe6430a9070b6289ebf5dadf07fbf4) | `` automatic update `` |
| [`4dcb65d5`](https://github.com/nix-community/NUR/commit/4dcb65d572d80be05fb9155a2fc38d069b10ce20) | `` automatic update `` |
| [`b64714e4`](https://github.com/nix-community/NUR/commit/b64714e488fec373dfddb508641b9f75cad57b97) | `` automatic update `` |
| [`6a0aec47`](https://github.com/nix-community/NUR/commit/6a0aec47bb3c199b7977fced23d01a3be517e3ab) | `` automatic update `` |
| [`4bc62b9e`](https://github.com/nix-community/NUR/commit/4bc62b9e18645c92fd4454b8ec018e49da3fec13) | `` automatic update `` |
| [`f2b0400d`](https://github.com/nix-community/NUR/commit/f2b0400d6357299486512768cc968562880be5b1) | `` automatic update `` |
| [`08e5015a`](https://github.com/nix-community/NUR/commit/08e5015a6fed13ed80a52dd770c0f34174b29a33) | `` automatic update `` |
| [`a74ab283`](https://github.com/nix-community/NUR/commit/a74ab283c88537f02e64833ace0f37f95c9cf169) | `` automatic update `` |