### PR TITLE
chore(flake/treefmt-nix): `5ff2cdbe` -> `d06b70e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -732,11 +732,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702281974,
-        "narHash": "sha256-OX6umqmLlRKKX0yEfQBmMx8pDNHtxp+sGTLyFh8kLG8=",
+        "lastModified": 1702461037,
+        "narHash": "sha256-ssyGxfGHRuuLHuMex+vV6RMOt7nAo07nwufg9L5GkLg=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "5ff2cdbe0db6a6f3445f7d878cb87d121d914d83",
+        "rev": "d06b70e5163a903f19009c3f97770014787a080f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                         |
| ---------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`d06b70e5`](https://github.com/numtide/treefmt-nix/commit/d06b70e5163a903f19009c3f97770014787a080f) | `` nickel: remove wrapper ``    |
| [`3b3a58ea`](https://github.com/numtide/treefmt-nix/commit/3b3a58ea5e21f749c3c98f1513ae96849a83f76d) | `` yamlfmt: fix examples ``     |
| [`8af5563a`](https://github.com/numtide/treefmt-nix/commit/8af5563aa9971a96af7fbbf8830be602869278f3) | `` yamlfmt also *.yml (#140) `` |
| [`390018a9`](https://github.com/numtide/treefmt-nix/commit/390018a9398f9763bfc05ffe6443ce0622cb9ba6) | `` Add fprettify (#138) ``      |