### PR TITLE
chore(flake/nixpkgs): `120a26f8` -> `224b3a5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -492,11 +492,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702310776,
-        "narHash": "sha256-T2KJpsNjAytMsP6+xrhXfAb2KTG6Yt2D4hTTugpsJFo=",
+        "lastModified": 1702483393,
+        "narHash": "sha256-xdZ+69I2z5ywVtJHW3+BQ99rKFDPkyaPNznstw+gfS8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "120a26f8ce32ac2bdc0e49a9fed830b7446416b4",
+        "rev": "224b3a5ad9a960e4a6e3cd59233c1616164c5ef5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                 |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| [`224b3a5a`](https://github.com/NixOS/nixpkgs/commit/224b3a5ad9a960e4a6e3cd59233c1616164c5ef5) | `` jextract: 2023-04-14 -> 2023-11-27 (JDK 21) (#271127) ``                                             |
| [`8c2e8010`](https://github.com/NixOS/nixpkgs/commit/8c2e8010a01f71292980cdf233de932adac3012a) | `` grpc: add jaxlib in passthru.tests ``                                                                |
| [`8042d5e6`](https://github.com/NixOS/nixpkgs/commit/8042d5e6ada29353932056e92e1c8d561571dbbd) | `` cargo-pgrx: 0.11.0 -> 0.11.2 ``                                                                      |
| [`88b307e7`](https://github.com/NixOS/nixpkgs/commit/88b307e7f9cfd1c438c913191512a7a28c3300c1) | `` cargo-zigbuild: 0.18.0 -> 0.18.1 ``                                                                  |
| [`da2c7589`](https://github.com/NixOS/nixpkgs/commit/da2c7589a808cfa3cdf3bbb81f7d9c08591b2856) | `` path-of-building.data: 2.36.1 -> 2.37.0 ``                                                           |
| [`f9484cfa`](https://github.com/NixOS/nixpkgs/commit/f9484cfa2f7abf7f02dc10c116accd2b0d9b1a9e) | `` wasm-tools: 1.0.52 -> 1.0.54 ``                                                                      |
| [`e27d9bdf`](https://github.com/NixOS/nixpkgs/commit/e27d9bdf593b0a8b69612e8b8c6431f6bf2d8577) | `` vimPlugins.nvim-treesitter: update grammars ``                                                       |
| [`093660ab`](https://github.com/NixOS/nixpkgs/commit/093660aba2e61c62310754a1b6e63e97e3f0736d) | `` vimPlugins: update on 2023-12-13 ``                                                                  |
| [`cd4b3793`](https://github.com/NixOS/nixpkgs/commit/cd4b379338f313a8f79ff9408a513c99998ad698) | `` vimPlugins.startup-nvim: init at 2023-11-02 ``                                                       |
| [`70808d02`](https://github.com/NixOS/nixpkgs/commit/70808d0217b2860d3f5bf2d662fff8667433ba91) | `` nixos/jenkins: set StateDirectory if home is /var/lib/jenkins ``                                     |
| [`eb60ca8e`](https://github.com/NixOS/nixpkgs/commit/eb60ca8e5295e5a71feb12906d690bc0cc4b8fa0) | `` python3Packages.debianbts: Remove unused inputs ``                                                   |
| [`86e2b649`](https://github.com/NixOS/nixpkgs/commit/86e2b649ab4f7394faf934d030173f6d0119776c) | `` mpvScripts.chapterskip: Add missing metadata ``                                                      |
| [`37fc4514`](https://github.com/NixOS/nixpkgs/commit/37fc451476bdbf52970fbd3906354aab7b031b2a) | `` bun: 1.0.16 -> 1.0.17 ``                                                                             |
| [`1cf853b9`](https://github.com/NixOS/nixpkgs/commit/1cf853b9dee78197b0451a06d44a58aa7857c75f) | `` nixos/tinyproxy: fix services.tinyproxy.package ``                                                   |
| [`7a0fffdf`](https://github.com/NixOS/nixpkgs/commit/7a0fffdfe9589ff60c5b3dfed154a7ae552ada70) | `` tinyproxy: add meta.mainProgram ``                                                                   |
| [`3ae150e0`](https://github.com/NixOS/nixpkgs/commit/3ae150e098cbaf928a8e843f51e2a77675d5396c) | `` rio: v0.0.31 -> v0.0.32 ``                                                                           |
| [`77417f2c`](https://github.com/NixOS/nixpkgs/commit/77417f2c76586f6f6f43da8cf3b62f4e788bac09) | `` irrd: 4.3.0.post1 -> 4.4.2 ``                                                                        |
| [`013f3808`](https://github.com/NixOS/nixpkgs/commit/013f3808ed7b276b8b83b30027f1036cefe09e49) | `` python3.pkgs.smtpdfix: init at 0.5.1 ``                                                              |
| [`988d5294`](https://github.com/NixOS/nixpkgs/commit/988d52941d5c3860c8b34e83c07b27b41d3463b0) | `` python3.pkgs.asgi-logger: init at 0.1.0 ``                                                           |
| [`38579995`](https://github.com/NixOS/nixpkgs/commit/38579995830f16f8b63dae9dc4bd3cdf35c602ee) | `` pythonPackages.starlette-wtf: init at 0.4.3 ``                                                       |
| [`d54e65f5`](https://github.com/NixOS/nixpkgs/commit/d54e65f5193f15e07751ffb77d1e88c73f6c1972) | `` pythonPackages.imia: init at 0.5.3 ``                                                                |
| [`f265b267`](https://github.com/NixOS/nixpkgs/commit/f265b267ca837f87194dfa60f4e9e03e211d6b93) | `` pythonPackages.wtforms-bootstrap5: init at 0.3.0 ``                                                  |
| [`dacf818a`](https://github.com/NixOS/nixpkgs/commit/dacf818a19e68a81f19395e1d19d740218e4b904) | `` bilibili: 1.12.3-1 -> 1.12.5-2 ``                                                                    |
| [`f267f220`](https://github.com/NixOS/nixpkgs/commit/f267f220eca2dd0ae9c1f851fdac903ad003666c) | `` vimPlugins.yanky-nvim: init at 2023-11-27 ``                                                         |
| [`df70ab86`](https://github.com/NixOS/nixpkgs/commit/df70ab86b3371fb55250f65eb10b8de3c55d6376) | `` ocaml-ng.ocamlPackages_5_1.ocaml: 5.1.0 → 5.1.1 ``                                                   |
| [`125c3968`](https://github.com/NixOS/nixpkgs/commit/125c39688b2b25838d732593367c0c0f344d6a9e) | `` bosh-cli: 7.5.0 -> 7.5.1 ``                                                                          |
| [`16d97f57`](https://github.com/NixOS/nixpkgs/commit/16d97f57df84b2a6432a90256375175a1c5f8621) | `` bomber-go: 0.4.5 -> 0.4.7 ``                                                                         |
| [`b12769d7`](https://github.com/NixOS/nixpkgs/commit/b12769d76d140c805c2519c7cec4d0c4ac97805c) | `` knot-dns: 3.3.2 -> 3.3.3 ``                                                                          |
| [`354184a8`](https://github.com/NixOS/nixpkgs/commit/354184a83e7360c7c5a6fd76d9f6d28508ac3461) | `` apfel: 3.1.0 -> 3.1.1 ``                                                                             |
| [`2a8d453a`](https://github.com/NixOS/nixpkgs/commit/2a8d453a2567184a07f3e7639c94d4e4b5eaae97) | `` signal-desktop-beta: fix missing `callPackage` ``                                                    |
| [`ad88d38f`](https://github.com/NixOS/nixpkgs/commit/ad88d38f8e7c289d232697c078928999892d638b) | `` signal-desktop: fix `jq` not present in nix-shell ``                                                 |
| [`da353681`](https://github.com/NixOS/nixpkgs/commit/da353681bd185c6293db383a833d402b496537e3) | `` telegraf: 1.28.5 -> 1.29.0 ``                                                                        |
| [`4436b851`](https://github.com/NixOS/nixpkgs/commit/4436b851bc2cee507eb409b91d87866e8be28ab2) | `` mindustry: match gradle and package JDK ``                                                           |
| [`2e3bbf45`](https://github.com/NixOS/nixpkgs/commit/2e3bbf451bef5aad0817d98e1c595e0ad51ec9a3) | `` gradle: use SRI hashes ``                                                                            |
| [`b3ff745b`](https://github.com/NixOS/nixpkgs/commit/b3ff745b7bfa5cc2cb07573cb2420636175f443a) | `` gradle: 8.4 -> 8.5 ``                                                                                |
| [`c64ebc8a`](https://github.com/NixOS/nixpkgs/commit/c64ebc8adf8b7ac846afbd18335bd51663c70fb1) | `` minetest: 5.7.0 -> 5.8.0, cleanup ``                                                                 |
| [`46da2077`](https://github.com/NixOS/nixpkgs/commit/46da2077152d49640ba75f096b8b93821a052c37) | `` irrlichtmt: 1.9.0mt10 -> 1.9.0mt13 ``                                                                |
| [`f43a0a2e`](https://github.com/NixOS/nixpkgs/commit/f43a0a2e4f8edbfa848ad8ece1a8fee87cb7a7ec) | `` azure-storage-azcopy: 10.21.1 -> 10.22.0 ``                                                          |
| [`c76f5258`](https://github.com/NixOS/nixpkgs/commit/c76f5258162696766e78a01c8430837b4508cf7c) | `` aws-iam-authenticator: 0.6.13 -> 0.6.14 ``                                                           |
| [`ed8eec0f`](https://github.com/NixOS/nixpkgs/commit/ed8eec0f1481b58e8a99120440728046ed7d349b) | `` avalanchego: 1.10.15 -> 1.10.17 ``                                                                   |
| [`bccc6afc`](https://github.com/NixOS/nixpkgs/commit/bccc6afcce6a3ad01732c4082526e1c2bc3d48c6) | `` automatic-timezoned: 1.0.131 -> 1.0.137 ``                                                           |
| [`9a32ae4c`](https://github.com/NixOS/nixpkgs/commit/9a32ae4cb4de83a03366ca02692b8718d2ccaea7) | `` ocamlPackages.batteries: 3.7.1 → 3.7.2 ``                                                            |
| [`0e98a613`](https://github.com/NixOS/nixpkgs/commit/0e98a613ff0b754256880307473feee7cede09e0) | `` ocamlPackages.gsl: 1.24.3 → 1.25.0 ``                                                                |
| [`0c38aa9c`](https://github.com/NixOS/nixpkgs/commit/0c38aa9ce82a6b2f17b61201bb21252c5a9f39c6) | `` coqPackages.QuickChick: 1.6.5 → 2.0.1 ``                                                             |
| [`a2b78690`](https://github.com/NixOS/nixpkgs/commit/a2b78690c34c2d1d1e3bd175f3f7e572b225d930) | `` framac: 27.1 (Cobalt) → 28.0 (Nickel) ``                                                             |
| [`60b23fa8`](https://github.com/NixOS/nixpkgs/commit/60b23fa8c57aaaffc301c786df9c34029398217a) | `` ark-pixel-font: 2023.08.15 -> 2023.11.26 ``                                                          |
| [`762d26ae`](https://github.com/NixOS/nixpkgs/commit/762d26ae89057d717331f30f73a959eeb65d1806) | `` corkscrew: fix build ``                                                                              |
| [`7af05007`](https://github.com/NixOS/nixpkgs/commit/7af05007fcfa6bd47b06691d91e3ed2407961855) | `` api-linter: 1.59.1 -> 1.59.2 ``                                                                      |
| [`0f14ad07`](https://github.com/NixOS/nixpkgs/commit/0f14ad073152bd6ae3c2db935223e2e89d9e9c0e) | `` android-file-transfer: 4.2 -> 4.3 ``                                                                 |
| [`81c97f00`](https://github.com/NixOS/nixpkgs/commit/81c97f004c89d26ab2de997180cab9b12419f3fc) | `` android-udev-rules: 20231124 -> 20231207 ``                                                          |
| [`f83bb17b`](https://github.com/NixOS/nixpkgs/commit/f83bb17bb65c21a8f3c198aee0ee871d65c3cc4f) | `` allure: 2.24.1 -> 2.25.0 ``                                                                          |
| [`5fd6ebdb`](https://github.com/NixOS/nixpkgs/commit/5fd6ebdbef4b0f88831e3ca5f9c6411cba0dff3b) | `` nixos/nebula: wait for start notification to prevent startup race ``                                 |
| [`987845b7`](https://github.com/NixOS/nixpkgs/commit/987845b73e265113c1368efe4a5825fc7eed61bb) | `` cudaPackages.cudnn: 8.9.6.50 -> 8.9.7.29 ``                                                          |
| [`b4fe267b`](https://github.com/NixOS/nixpkgs/commit/b4fe267be58386f2f5a977997d69ba7760f63ca3) | `` cudaPackages.cudnn: correct hash for CUDA 10.2, v7.6.5.32 release ``                                 |
| [`d2241ab5`](https://github.com/NixOS/nixpkgs/commit/d2241ab5276b3334e373b97e1521f49a62ff2862) | `` aliyun-cli: 3.0.186 -> 3.0.189 ``                                                                    |
| [`9dd61c88`](https://github.com/NixOS/nixpkgs/commit/9dd61c8843bdb3908b859abf9579aa1b242108fe) | `` algolia-cli: 1.4.2 -> 1.4.3 ``                                                                       |
| [`33207dd7`](https://github.com/NixOS/nixpkgs/commit/33207dd7fcb3f8ddc2af95f5f6bed80b04859c0d) | `` jetbrains.rider: fix dotnet linking ``                                                               |
| [`96104948`](https://github.com/NixOS/nixpkgs/commit/96104948188dc79a7d0c0870bb3802af96ab69c7) | `` jetbrains: add libraries needed for patchelf ``                                                      |
| [`aa6240d5`](https://github.com/NixOS/nixpkgs/commit/aa6240d51daa3ef4cbca2fd55a59298e89577fed) | `` python3Packages.dataclasses-json: 0.6.1 -> 0.6.3 ``                                                  |
| [`4eb501c9`](https://github.com/NixOS/nixpkgs/commit/4eb501c977591c17db6697e5c8fed4c8520809ed) | `` vector: add SystemConfiguration for darwin, fixes ld ``                                              |
| [`6b83dc8f`](https://github.com/NixOS/nixpkgs/commit/6b83dc8ff8e9c23039f045567038e13e19699211) | `` neovim-qt: Add `meta.mainProgram` ``                                                                 |
| [`62480480`](https://github.com/NixOS/nixpkgs/commit/62480480791b21ac4fe37f4c467c204bca27eb62) | `` nushellPlugins: update to nushell 0.88.0 ``                                                          |
| [`3be75886`](https://github.com/NixOS/nixpkgs/commit/3be758860c96b3c0e94f97fdb72f0387ca033736) | `` nushell: 0.87.1 -> 0.88.0 ``                                                                         |
| [`6b6b12c2`](https://github.com/NixOS/nixpkgs/commit/6b6b12c27cb9e21d6530b8139591c7696b2dca2f) | `` doc/manpage-urls.json: Add *all* systemd manpages ``                                                 |
| [`6012fe8f`](https://github.com/NixOS/nixpkgs/commit/6012fe8f2d052a13c72c65eb91c445011b9739d9) | `` nixos/doc/manual: Rework `nixos-state.section.md` ``                                                 |
| [`22cb8a17`](https://github.com/NixOS/nixpkgs/commit/22cb8a17128b471fca2d5aba67e8d1184abfed83) | `` nixos/doc/manual: Add `/var/lib/nixos` under “Necessary system state” ``                             |
| [`735481ef`](https://github.com/NixOS/nixpkgs/commit/735481ef6b8be1ef884a6c4b0a4b80264216a379) | `` nixos/doc: Add chapter “necessary system state” ``                                                   |
| [`539081a9`](https://github.com/NixOS/nixpkgs/commit/539081a985a8e3f31016cb9c4125d27bed0622fa) | `` python311Packages.yte: 1.5.1 -> 1.5.4 ``                                                             |
| [`1ceeb7c5`](https://github.com/NixOS/nixpkgs/commit/1ceeb7c5b57a7ba2988af416e08f814e956abd43) | `` checkov: 3.1.33 -> 3.1.34 ``                                                                         |
| [`9a039b04`](https://github.com/NixOS/nixpkgs/commit/9a039b0401f648900da58ab40e6e6c669480a7d0) | `` cnspec: 9.10.0 -> 9.11.0 ``                                                                          |
| [`710cf8a9`](https://github.com/NixOS/nixpkgs/commit/710cf8a99964ae29838a675f866ad5a787ef2924) | `` warp-terminal: v0.2023.11.07.08.02.stable_00 -> v0.2023.12.05.08.02.stable_00 ``                     |
| [`5138116f`](https://github.com/NixOS/nixpkgs/commit/5138116fa7f0e7bfd62e17434499fe5686866828) | `` pscale: 0.172.0 -> 0.174.0 ``                                                                        |
| [`90d83cc0`](https://github.com/NixOS/nixpkgs/commit/90d83cc035c67491370e97320e3d3ae4957a2bd0) | `` phpExtensions.relay: Fix dylib in Darwin ``                                                          |
| [`1a5412e1`](https://github.com/NixOS/nixpkgs/commit/1a5412e14030d2a00281021d5f8ef05b31027912) | `` toil: 5.7.1 -> 5.12.0 (#273274) ``                                                                   |
| [`ea9e108a`](https://github.com/NixOS/nixpkgs/commit/ea9e108a0bafe81df7e0461f7286400e1db6c694) | `` lhapdf: 6.5.3 -> 6.5.4 (#273276) ``                                                                  |
| [`1f06e081`](https://github.com/NixOS/nixpkgs/commit/1f06e081c92baffb0e159819fee1f1d6db3352da) | `` restic: set meta.mainProgram ``                                                                      |
| [`e8d403b6`](https://github.com/NixOS/nixpkgs/commit/e8d403b6974c41201a82cb8e2ea84095088c2f19) | `` htmlq: set meta.mainProgram ``                                                                       |
| [`f13c7978`](https://github.com/NixOS/nixpkgs/commit/f13c79788c8022bb5ad01ae7875cbb2b51edf8bb) | `` cudaPackages: prefix libPath with lib in manifest builder ``                                         |
| [`52488862`](https://github.com/NixOS/nixpkgs/commit/524888629f8ab7a3e84967e9636c0781061880df) | `` chickenPackages_5.chickenEggs: fix license ``                                                        |
| [`78fcfa8b`](https://github.com/NixOS/nixpkgs/commit/78fcfa8b6c4da966bf261e04a58a6abb3b681786) | `` rio: v0.0.30 -> v0.0.31 ``                                                                           |
| [`93d72b92`](https://github.com/NixOS/nixpkgs/commit/93d72b9294a000782fa0450c8cb4e5b8709b1bf0) | `` forgejo: 1.21.2-0 -> 1.21.2-1 ``                                                                     |
| [`bc21d73d`](https://github.com/NixOS/nixpkgs/commit/bc21d73d6dee769295569f5dcf70a8a99860f5f1) | `` gum: 0.12.0 -> 0.13.0 ``                                                                             |
| [`52af4c8c`](https://github.com/NixOS/nixpkgs/commit/52af4c8c0f41daf6701eed2472bf377755920b7b) | `` gnome-extension-manager: unbreak on aarch64-linux ``                                                 |
| [`6de3122f`](https://github.com/NixOS/nixpkgs/commit/6de3122f4316c74d8898fe6d1e888aa527db5bab) | `` asusctl: 4.7.2 -> 5.0.0 ``                                                                           |
| [`1ec772ee`](https://github.com/NixOS/nixpkgs/commit/1ec772ee91fec40766ca2d4e650a7029e7309227) | `` supergfxctl: 5.1.1 -> 5.1.2 ``                                                                       |
| [`eb2f1aa3`](https://github.com/NixOS/nixpkgs/commit/eb2f1aa391fd59f8013a83ad552bcc136f19630d) | `` remmina: Add `meta.mainProgram` ``                                                                   |
| [`5c640240`](https://github.com/NixOS/nixpkgs/commit/5c640240561a332b97eb20121d098fb0146efe18) | `` matrix-synapse: 1.97.0 -> 1.98.0 ``                                                                  |
| [`002861bb`](https://github.com/NixOS/nixpkgs/commit/002861bb572de737edab426a456163268afe1e7e) | `` release-python.nix: remove dreamed-up config option ``                                               |
| [`ea93ca9c`](https://github.com/NixOS/nixpkgs/commit/ea93ca9c3a05f2f0d44aacce136a56762d9f0053) | `` opentofu: 1.6.0-beta3 -> 1.6.0-beta4 ``                                                              |
| [`076fc3ad`](https://github.com/NixOS/nixpkgs/commit/076fc3ad3158bdf0b04374570dfaa30fd0aaf9a9) | `` cudaPackages.autoAddCudaCompatRunpathHook: dummy libcudaPath when broken ``                          |
| [`6256391a`](https://github.com/NixOS/nixpkgs/commit/6256391a3571679d876ddd58652bdfdc2f5b3ad6) | `` cudaPackages.autoAddCudaCompatRunpathHook: broken on non-jetsons ``                                  |
| [`fa2d2bbe`](https://github.com/NixOS/nixpkgs/commit/fa2d2bbe6d6a61d01412e3c15acacde772522846) | `` nixos/iproute2: add release note for the backward compatibility caused by stateless configuration `` |
| [`b21e84ea`](https://github.com/NixOS/nixpkgs/commit/b21e84ea8d1db73e3cc7e9f0ec999ed79257e62e) | `` nixos/iproute2: use rt_tables.d to avoid IFD ``                                                      |
| [`e6364478`](https://github.com/NixOS/nixpkgs/commit/e6364478be7fd717b418363a374b511ee64d439d) | `` gerbil: fix soname of libgerbil on darwin ``                                                         |
| [`26dd9754`](https://github.com/NixOS/nixpkgs/commit/26dd975482dc86a0fe115c999edc82427c0d43d2) | `` Add basic documentation on cuda_compat ``                                                            |
| [`d6c198a5`](https://github.com/NixOS/nixpkgs/commit/d6c198a5d95f39fbd54042f1b7b874461c8e8951) | `` Enable cuda_compat by default on Jetson devices ``                                                   |
| [`0cdbeb74`](https://github.com/NixOS/nixpkgs/commit/0cdbeb740940453520856bb4e991e9337c01e4c0) | `` sing-box: 1.7.4 -> 1.7.5 ``                                                                          |
| [`0ed60bbc`](https://github.com/NixOS/nixpkgs/commit/0ed60bbcd1b043431958f004c29cb0f01ebd9004) | `` chromium: fix increased build time for non-cross-compilation builds ``                               |
| [`0eb389be`](https://github.com/NixOS/nixpkgs/commit/0eb389be6e718b4d668d433a3fe4dea1fa4099de) | `` chromium: move stray patches into `./patches` directory ``                                           |
| [`b8927e20`](https://github.com/NixOS/nixpkgs/commit/b8927e2047689d7636c32a5a6f0f46b7b316d349) | `` ungoogled-chromium: add `ungoogled-` prefix to `chromium-unwrapped` ``                               |
| [`c979d0ef`](https://github.com/NixOS/nixpkgs/commit/c979d0efb4babbb00f8c52a27298804adc28355a) | `` plasma5Packages.polonium: init at 0.6.0 ``                                                           |
| [`6fe8ff23`](https://github.com/NixOS/nixpkgs/commit/6fe8ff23d27566b92c14766b739c5ad4367176cd) | `` pylyzer: 0.0.50 -> 0.0.51 ``                                                                         |
| [`a3ac436c`](https://github.com/NixOS/nixpkgs/commit/a3ac436cfb2d494729ad40d75e4762dc3c4de83b) | `` Add ignore dependency for cuda_compat ``                                                             |
| [`11a5040a`](https://github.com/NixOS/nixpkgs/commit/11a5040a483ef9e5db62ba5b13985aa79d2ad48e) | `` lshw: fix static build ``                                                                            |
| [`d92daec2`](https://github.com/NixOS/nixpkgs/commit/d92daec27ee4662c8a4a10206d9bfc3d7e557f90) | `` ratman: migrate to prefetch-yarn-deps (#269285) ``                                                   |
| [`a39043f1`](https://github.com/NixOS/nixpkgs/commit/a39043f124bed049574388cbe21bfdea7b22fb4a) | `` Apply markdown lints to CUDA READMEs ``                                                              |
| [`e5a30535`](https://github.com/NixOS/nixpkgs/commit/e5a305357c398401f64981db221284a91de9b1ac) | `` php82Extensions.blackfire: block php zts builds ``                                                   |
| [`19c4cb1d`](https://github.com/NixOS/nixpkgs/commit/19c4cb1dd735aced526033902c8f5cd49b4c2d97) | `` athens: 0.12.1 -> 0.13.0 ``                                                                          |
| [`324c7bbd`](https://github.com/NixOS/nixpkgs/commit/324c7bbda1f320e5a9bb64cfcde2882a3c5c75af) | `` yq-go: 4.40.4 -> 4.40.5 ``                                                                           |
| [`a59c7364`](https://github.com/NixOS/nixpkgs/commit/a59c7364955e5f32798d0314fbb6aae347ff064d) | `` warzone2100: fix fetch url ``                                                                        |
| [`f908761f`](https://github.com/NixOS/nixpkgs/commit/f908761f4f40b51a71f325ede4859fb2edc0b8f1) | `` python311Packages.awscrt: 0.19.18 -> 0.19.19 ``                                                      |
| [`7167c7ce`](https://github.com/NixOS/nixpkgs/commit/7167c7ce4c3dbf4e0cd7a0f225d6ef4d05d00da3) | `` python311Packages.dvc-data: 2.22.6 -> 2.23.1 ``                                                      |
| [`59b11ff3`](https://github.com/NixOS/nixpkgs/commit/59b11ff3322e69c660ada4271aae317955ef0810) | `` exploitdb: 2023-12-07 -> 2023-12-12 ``                                                               |
| [`73a4603d`](https://github.com/NixOS/nixpkgs/commit/73a4603df849e21ec7a792e99dd12868c3bbded3) | `` clickhouse: 23.10.3.5 -> 23.11.1.2711 ``                                                             |
| [`e490b9f9`](https://github.com/NixOS/nixpkgs/commit/e490b9f91777f50a30dc9185042deef1f3e8ae62) | `` terragrunt: 0.54.0 -> 0.54.1 ``                                                                      |
| [`5d43a876`](https://github.com/NixOS/nixpkgs/commit/5d43a8764fa6b933eb01b8bb0f4bd253226bf261) | `` coqPackages.metacoq: update for coq 8.17 and 8.18 (#273541) ``                                       |
| [`3089e32d`](https://github.com/NixOS/nixpkgs/commit/3089e32da2e6eb3ed2289d99e8eb3748b1765bc6) | `` python311Packages.caldav: 1.3.6 -> 1.3.8 ``                                                          |
| [`48fd74cc`](https://github.com/NixOS/nixpkgs/commit/48fd74ccdf9e83eca9e8e40d26b6726cd5323731) | `` imagemagick: 7.1.1-21 -> 7.1.1-23 ``                                                                 |
| [`18523ded`](https://github.com/NixOS/nixpkgs/commit/18523dedab7742c80abf1cef31c49f8f2884625a) | `` release-python.nix: allow evaluation with openssl_1_1 ``                                             |
| [`52836538`](https://github.com/NixOS/nixpkgs/commit/528365383f85194ac9b330534cc2aaf9b7969f8f) | `` gasket: 1.0-18 -> 1.0-18-unstable-2023-09-05 ``                                                      |
| [`b576bc26`](https://github.com/NixOS/nixpkgs/commit/b576bc2681ccc45a341f8dafa3361fe4e6bbfd1f) | `` apfel: 3.0.6 -> 3.1.0 (#273073) ``                                                                   |