### PR TITLE
chore(flake/nur): `cf183d15` -> `8cf518b0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -557,11 +557,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702575911,
-        "narHash": "sha256-n/N1jvuBSm+l3JOE+z6T1+gAwUGWwbBob7vS59QvRx0=",
+        "lastModified": 1702599384,
+        "narHash": "sha256-W39mE6STcvX6k30xzk4/DGLajrYVEtp6SIOgzN4fDHo=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "cf183d15196aa2bc1122e274149e99a78a98e1e0",
+        "rev": "8cf518b0011e34505344cc78732a977d1d4ea453",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8cf518b0`](https://github.com/nix-community/NUR/commit/8cf518b0011e34505344cc78732a977d1d4ea453) | `` automatic update `` |
| [`8eb5a04d`](https://github.com/nix-community/NUR/commit/8eb5a04d6ea6c65a0a58f2c8a994c92be0506b31) | `` automatic update `` |
| [`7f334741`](https://github.com/nix-community/NUR/commit/7f334741c3e99cbdeb76db62c81065138513d9e2) | `` automatic update `` |
| [`cd3d310a`](https://github.com/nix-community/NUR/commit/cd3d310adf9a6dfa381942e68665e29aae6c096e) | `` automatic update `` |
| [`e27861bd`](https://github.com/nix-community/NUR/commit/e27861bd55d4c36ba8ff9325ec6cafff008e16ec) | `` automatic update `` |
| [`7a3b52cf`](https://github.com/nix-community/NUR/commit/7a3b52cf4fa2d4fdfdc3a34ed66da80862506f73) | `` automatic update `` |