### PR TITLE
chore(flake/chaotic): `ea53eaf3` -> `5425e55c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1702575705,
-        "narHash": "sha256-j8jaOtke/iwZgXe+o4uE7dnwv8GoBrG2mpoxQoRe0SE=",
+        "lastModified": 1702671006,
+        "narHash": "sha256-f9FLcuWlww5cwjR6T7p54aNDWsNP7tJo5zREQUporcU=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "ea53eaf36957528b6ec099d317b7a20430227d27",
+        "rev": "5425e55c64a1739ebe35cb3f431868c1a5f1ad1c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                            |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`5425e55c`](https://github.com/chaotic-cx/nyx/commit/5425e55c64a1739ebe35cb3f431868c1a5f1ad1c) | `` qtile_git: init with qtile-extras_git (#487) `` |
| [`d2491a98`](https://github.com/chaotic-cx/nyx/commit/d2491a98eb35fe3501388b87436a2956437f783c) | `` Bump 20231215-1 (#486) ``                       |