### PR TITLE
chore(flake/home-manager): `0e2e443f` -> `e9b9ecef`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -270,11 +270,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702538064,
-        "narHash": "sha256-At5GwJPu2tzvS9dllhBoZmqK6lkkh/sOp2YefWRlaL8=",
+        "lastModified": 1702735279,
+        "narHash": "sha256-SztEzDOE/6bDNnWWvnRbSHPVrgewLwdSei1sxoZFejM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "0e2e443ff24f9d75925e91b89d1da44b863734af",
+        "rev": "e9b9ecef4295a835ab073814f100498716b05a96",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                         |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
| [`e9b9ecef`](https://github.com/nix-community/home-manager/commit/e9b9ecef4295a835ab073814f100498716b05a96) | `` gtk: fix GTK 4 theme being ignored ``        |
| [`5b339866`](https://github.com/nix-community/home-manager/commit/5b3398668b2b7f41607cf77fc9f1cb6402716882) | `` fish: Fix babelization of hm-session-vars `` |
| [`07754e93`](https://github.com/nix-community/home-manager/commit/07754e935a5e6f07f73e43c214f4f24f8ef82117) | `` docs: add considerate as maintainer ``       |
| [`6c82b1c9`](https://github.com/nix-community/home-manager/commit/6c82b1c9ce4dfb882cf53d1b9a09f01fbc9b0ba1) | `` docs: use .xhtml for appendices ``           |
| [`6fc71dc5`](https://github.com/nix-community/home-manager/commit/6fc71dc563c78f999386a55b1892c05039199e8f) | `` docs: add release-notes as appendix ``       |
| [`abdc82d9`](https://github.com/nix-community/home-manager/commit/abdc82d930521448e47574b8ca1a0a450e861cca) | `` yazi: pass additional args to ya alias ``    |