### PR TITLE
chore(flake/nur): `8cf518b0` -> `1d374446`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -557,11 +557,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702599384,
-        "narHash": "sha256-W39mE6STcvX6k30xzk4/DGLajrYVEtp6SIOgzN4fDHo=",
+        "lastModified": 1702770334,
+        "narHash": "sha256-MVILxIF9ZVIk0f9w3yYZpy8auwxgey0MFzdoIFFvQNU=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "8cf518b0011e34505344cc78732a977d1d4ea453",
+        "rev": "1d37444620523278aa163bb9e30104f5d1152061",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                     |
| -------------------------------------------------------------------------------------------------- | --------------------------- |
| [`1d374446`](https://github.com/nix-community/NUR/commit/1d37444620523278aa163bb9e30104f5d1152061) | `` automatic update ``      |
| [`be5bda3f`](https://github.com/nix-community/NUR/commit/be5bda3f758c794fb3b56578b628a1f219d8aa2f) | `` automatic update ``      |
| [`7228b6c8`](https://github.com/nix-community/NUR/commit/7228b6c8a670781c9a0fbc9ec99211e672e99554) | `` automatic update ``      |
| [`9297adf9`](https://github.com/nix-community/NUR/commit/9297adf98ec59a92f1867bfc695f350373968e38) | `` automatic update ``      |
| [`c2110f8c`](https://github.com/nix-community/NUR/commit/c2110f8c85f9253d5d792af36a94ff4880355c22) | `` automatic update ``      |
| [`c522b3db`](https://github.com/nix-community/NUR/commit/c522b3db8799f9887b11dc5c50221db8e14ab7b2) | `` automatic update ``      |
| [`5507da3a`](https://github.com/nix-community/NUR/commit/5507da3a05bda4a1a53434418b318f35f282772d) | `` automatic update ``      |
| [`159a0d9c`](https://github.com/nix-community/NUR/commit/159a0d9ca13c0dcd3774d13b4e1b3bfab4d0faed) | `` automatic update ``      |
| [`42b64e39`](https://github.com/nix-community/NUR/commit/42b64e39b12fdb35d233af927c1e44449a78ca3c) | `` automatic update ``      |
| [`044531cd`](https://github.com/nix-community/NUR/commit/044531cd9b4882623ef8e0e9ddf1cf0cfff541a7) | `` automatic update ``      |
| [`d9beadda`](https://github.com/nix-community/NUR/commit/d9beaddaa7ab3d112394519c9fb84a4e7ba7cec7) | `` automatic update ``      |
| [`37468c28`](https://github.com/nix-community/NUR/commit/37468c2815fa4b1a3be56697d1921fcf27f84199) | `` automatic update ``      |
| [`00bbf94c`](https://github.com/nix-community/NUR/commit/00bbf94cccca4d8c4875c47fe79ed2c73321de88) | `` automatic update ``      |
| [`9cfdd1c8`](https://github.com/nix-community/NUR/commit/9cfdd1c87396b2bac372a6d8c2d3ce452b3401d1) | `` automatic update ``      |
| [`815ae533`](https://github.com/nix-community/NUR/commit/815ae533a5b7f38f5bf0c1449259668c82e685c8) | `` automatic update ``      |
| [`554a3376`](https://github.com/nix-community/NUR/commit/554a3376c9dfe9207477b252c9fe4e808b8accbf) | `` automatic update ``      |
| [`e344b8a6`](https://github.com/nix-community/NUR/commit/e344b8a64759fe2c5ada441a4baad6fde4fe56f5) | `` automatic update ``      |
| [`cdf58b69`](https://github.com/nix-community/NUR/commit/cdf58b69ab208e77fa1d6195983a151c9cd20e9e) | `` automatic update ``      |
| [`c17913c1`](https://github.com/nix-community/NUR/commit/c17913c1d4ccb0f5bbba4f7597698de1a8ac761e) | `` automatic update ``      |
| [`d74c5472`](https://github.com/nix-community/NUR/commit/d74c5472884bd57dd48b77e93e9a9ea971033522) | `` automatic update ``      |
| [`490fc283`](https://github.com/nix-community/NUR/commit/490fc283e431303fc90c26dadc0c69288f2e1c3d) | `` automatic update ``      |
| [`af946deb`](https://github.com/nix-community/NUR/commit/af946deb05cf232c2e8147b780383bea47b81e20) | `` automatic update ``      |
| [`e6fd729d`](https://github.com/nix-community/NUR/commit/e6fd729dc38b71be419d464b4b515d1270ba8d97) | `` automatic update ``      |
| [`476bb9ea`](https://github.com/nix-community/NUR/commit/476bb9eacb33dace8b614bf35bdc04129faeaae2) | `` automatic update ``      |
| [`aafce790`](https://github.com/nix-community/NUR/commit/aafce7906a49aef5bd7552b338cc59df4fa16e5e) | `` automatic update ``      |
| [`737bae45`](https://github.com/nix-community/NUR/commit/737bae458e329b06bdca56eb2fbbbbf328d4a97c) | `` add cherrypiejam repo `` |
| [`81f4c786`](https://github.com/nix-community/NUR/commit/81f4c7864a0ce0c1b91cee4278044e747c421f0a) | `` Update repos.json ``     |
| [`fb46a85c`](https://github.com/nix-community/NUR/commit/fb46a85c803d2260bf573c214e176cdc768782cf) | `` automatic update ``      |
| [`da202906`](https://github.com/nix-community/NUR/commit/da202906673e666a728d7db1fff88aa3cecda0f3) | `` automatic update ``      |
| [`76f22ae9`](https://github.com/nix-community/NUR/commit/76f22ae9407459965d1e6617d85bec0b8c7c93f3) | `` automatic update ``      |
| [`a476ab8b`](https://github.com/nix-community/NUR/commit/a476ab8b1871639b8ac3759df28267b8485a46df) | `` automatic update ``      |
| [`6d81d66b`](https://github.com/nix-community/NUR/commit/6d81d66b49920470cd7fedf7a352a42dae6b8dc2) | `` automatic update ``      |
| [`00d8221e`](https://github.com/nix-community/NUR/commit/00d8221e814d82ce862733c061f816a3cfa9f04f) | `` automatic update ``      |
| [`d55abfbc`](https://github.com/nix-community/NUR/commit/d55abfbcea31ff18935d56ac2882cdad26870f36) | `` automatic update ``      |
| [`b7decf2d`](https://github.com/nix-community/NUR/commit/b7decf2d362ef891a2085944808b51ed344f3dfc) | `` automatic update ``      |
| [`73a781ff`](https://github.com/nix-community/NUR/commit/73a781ff9db70a8558861583ec68649af6c08625) | `` automatic update ``      |
| [`36ddbacb`](https://github.com/nix-community/NUR/commit/36ddbacb4442366161d569f5bbe2f6310e22bb1d) | `` automatic update ``      |
| [`a179a5f3`](https://github.com/nix-community/NUR/commit/a179a5f334698fdb207ca1ec5187687bbb766ac0) | `` automatic update ``      |