### PR TITLE
chore(flake/nixpkgs): `224b3a5a` -> `02357add`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702483393,
-        "narHash": "sha256-xdZ+69I2z5ywVtJHW3+BQ99rKFDPkyaPNznstw+gfS8=",
+        "lastModified": 1702635820,
+        "narHash": "sha256-rClms9NTmSL/WIN5VmEccVhUExMkjCrRNswxU9QGNNo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "224b3a5ad9a960e4a6e3cd59233c1616164c5ef5",
+        "rev": "02357adddd0889782362d999628de9d309d202dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                             |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| [`db1680d1`](https://github.com/NixOS/nixpkgs/commit/db1680d1d644c71972fb110833f7f96096c61d7f) | `` gh: 2.40.0 -> 2.40.1 ``                                                                          |
| [`cb37959f`](https://github.com/NixOS/nixpkgs/commit/cb37959f992f27388f16c8aae30d573446ab57d4) | `` miller: copy manpage to $man ``                                                                  |
| [`1950eec4`](https://github.com/NixOS/nixpkgs/commit/1950eec4aa7bbae7097b7da5b72a04268b9a596b) | `` nixos/ldso: remove string context from linker soname ``                                          |
| [`7e3d3351`](https://github.com/NixOS/nixpkgs/commit/7e3d3351522e0510917e52dd3657d663bf5efe71) | `` nixos/tests/containers-imperative: download more RAM ``                                          |
| [`80b93fa3`](https://github.com/NixOS/nixpkgs/commit/80b93fa3e8650079b6d3fb375fa18d751ae1e435) | `` gotools: 0.7.0 -> 0.16.1 ``                                                                      |
| [`715d39b1`](https://github.com/NixOS/nixpkgs/commit/715d39b1b1ee6f43e4d98f55986104e87bf0c76b) | `` cargo-generate: 0.18.5 -> 0.19.0 ``                                                              |
| [`9ed75988`](https://github.com/NixOS/nixpkgs/commit/9ed75988e2848ed09b23c56bf151b055e32a5ab4) | `` ocamlPackages.angstrom: 0.15.0 → 0.16.0 ``                                                       |
| [`64daf50f`](https://github.com/NixOS/nixpkgs/commit/64daf50ff3a7e5294ccd483a7bb44d1afa5a1e89) | `` ocamlPackages.httpaf: add missing dependency ``                                                  |
| [`968905ab`](https://github.com/NixOS/nixpkgs/commit/968905ab76aba874bc4818eb3a491b94241aca25) | `` nixos/caddy: also increase socket send buffer size as recommended by upstream ``                 |
| [`43935075`](https://github.com/NixOS/nixpkgs/commit/439350753ed2e27b0aa4fa1cfdf3ea80ea344644) | `` nixos/sysctl: use highest value on conflict for net.core.wmem_max ``                             |
| [`805cac89`](https://github.com/NixOS/nixpkgs/commit/805cac89ab33b11c5d5a0287db186568fabebfa4) | `` python311Packages.homeassistant-stubs: 2023.12.2 -> 2023.12.3 ``                                 |
| [`d5b02fef`](https://github.com/NixOS/nixpkgs/commit/d5b02fef5f6e7f59ad44220012ad8ebd686629fb) | `` python311Packages.pyatv: disable failing test ``                                                 |
| [`bf81cded`](https://github.com/NixOS/nixpkgs/commit/bf81cded7dfda6d27508cc4638befa87cde00838) | `` makeNugetSource: symlink files instead of copying them ``                                        |
| [`5ef86678`](https://github.com/NixOS/nixpkgs/commit/5ef866783f04770bb0cc088075eb090627a4f7d4) | `` makeNugetSource: fix meta.description being overwritten, misc cleanup ``                         |
| [`a33ae59e`](https://github.com/NixOS/nixpkgs/commit/a33ae59eeb935515194f8edabbabe0df767fa8ba) | `` nvidia-optical-flow-sdk: refactor: propagation via setupCudaHook ``                              |
| [`adf2347f`](https://github.com/NixOS/nixpkgs/commit/adf2347f8b49860d7c82e98f17b4a4b7a72709fd) | `` erlang_26: 26.1.2 -> 26.2 ``                                                                     |
| [`5a1e8c90`](https://github.com/NixOS/nixpkgs/commit/5a1e8c90ab7e7bf88d40c79fc535419363e8869e) | `` home-assistant: 2023.12.2 -> 2023.12.3 ``                                                        |
| [`c90d5cc9`](https://github.com/NixOS/nixpkgs/commit/c90d5cc985570d8306c82a9ca5d096f1fa683f96) | `` python311Packages.zeroconf: 0.128.4 -> 0.129.0 ``                                                |
| [`e5ede120`](https://github.com/NixOS/nixpkgs/commit/e5ede120d292e7b0f2ecba37ced002eec0e35518) | `` python311Packages.renault-api: 0.2.0 -> 0.2.1 ``                                                 |
| [`ea7e4bae`](https://github.com/NixOS/nixpkgs/commit/ea7e4baea03c8fd6142189567de1225177e37231) | `` fg-virgil: 0.16.1 -> 0.17.0 ``                                                                   |
| [`a47d6e0f`](https://github.com/NixOS/nixpkgs/commit/a47d6e0fd6edf862d53ea8554a181f810acb21b5) | `` hare: unstable-2023-10-23 -> unstable-2023-11-27 ``                                              |
| [`22bbd183`](https://github.com/NixOS/nixpkgs/commit/22bbd1834e2aed9c917c67d2181fe7cf225cd7a5) | `` nixos/node-red: fix `cfg.package` default value ``                                               |
| [`3f31bfcd`](https://github.com/NixOS/nixpkgs/commit/3f31bfcd6501288c4606991026388ef985d80d36) | `` setzer: 63 -> 65 ``                                                                              |
| [`96c1f0e7`](https://github.com/NixOS/nixpkgs/commit/96c1f0e798320e57f887006a5d01ccff9866a661) | `` python3.pkgs.reuse: make a python library ``                                                     |
| [`9ec60b1f`](https://github.com/NixOS/nixpkgs/commit/9ec60b1f5ff68dd15916b1f3f325aadadd8e57af) | `` slurm: 23.02.6.1 -> 23.02.7.1 ``                                                                 |
| [`d3843eed`](https://github.com/NixOS/nixpkgs/commit/d3843eed57b689504fa9c045932b9eed554d9596) | `` sudo: 1.9.15p2 -> 1.9.15p3 ``                                                                    |
| [`df7672c3`](https://github.com/NixOS/nixpkgs/commit/df7672c36c8e1998c2f57b56ecc33285c79286e7) | `` aws-gate: init at 0.11.3 ``                                                                      |
| [`3644340b`](https://github.com/NixOS/nixpkgs/commit/3644340b6e470140386de27e5789354e0ea0fbf1) | `` ungoogled-chromium: 120.0.6099.71-1 -> 120.0.6099.109-1 ``                                       |
| [`c29d53ba`](https://github.com/NixOS/nixpkgs/commit/c29d53ba0fe8ed1f43abc7baca5ad7a60b0ea699) | `` chromium: 120.0.6099.71 -> 120.0.6099.109 ``                                                     |
| [`5f8f3c12`](https://github.com/NixOS/nixpkgs/commit/5f8f3c1250888834410e034c6b5c03ec45821caf) | `` signald: build with jdk17 ``                                                                     |
| [`aa19ae19`](https://github.com/NixOS/nixpkgs/commit/aa19ae19c9ba88ab3255ca6556b33f602aa85433) | `` nixos/tests/kernel-generic: test hardened 6.6 ``                                                 |
| [`5f6dbf8d`](https://github.com/NixOS/nixpkgs/commit/5f6dbf8d6fe8a6a6f81487869ae52540b63bdf34) | `` hardened kernel: remove obsolete 4.14 section ``                                                 |
| [`d832b119`](https://github.com/NixOS/nixpkgs/commit/d832b1197bb0327edc0d972d527a8c73deb3cb62) | `` nixos/doc: include section for 24.05 ``                                                          |
| [`24b57708`](https://github.com/NixOS/nixpkgs/commit/24b57708c68bc5b0e8e1af47bff71abab6bd8a91) | `` dino: support cross compilation ``                                                               |
| [`e6751379`](https://github.com/NixOS/nixpkgs/commit/e6751379bcaa6f425fa30b77faf6ffac8f615f64) | `` nextcloud28Packages.bookmarks: 13.1.1 -> 13.1.2 ``                                               |
| [`6fe98c3c`](https://github.com/NixOS/nixpkgs/commit/6fe98c3cc8617d43008dec60aa3b7cc921459688) | `` nixos/tests/zammad: set memory limit to 2048 MB ``                                               |
| [`bec9edfd`](https://github.com/NixOS/nixpkgs/commit/bec9edfd20fcd84243a8dffbe86b892574ee8314) | `` nixos/doc: mention nc28 ``                                                                       |
| [`f718012d`](https://github.com/NixOS/nixpkgs/commit/f718012d9226547766f6d4fc45712d89fe06de8a) | `` nixos/nextcloud: updates for nc28 ``                                                             |
| [`dc2b6d2a`](https://github.com/NixOS/nixpkgs/commit/dc2b6d2af401041dfb6351f72582ad4a078a0b6f) | `` zammad: 6.1.0 -> 6.2.0 ``                                                                        |
| [`0cb577ff`](https://github.com/NixOS/nixpkgs/commit/0cb577ff62d62e6e8d3dd5721cf112805b087e89) | `` nextcloud27: 27.1.4 -> 27.1.5 ``                                                                 |
| [`43c07d02`](https://github.com/NixOS/nixpkgs/commit/43c07d029122e760b6a9fccb10e89fd96ac18d2d) | `` nextcloud26: 26.0.9 -> 26.0.10 ``                                                                |
| [`cb0fb74a`](https://github.com/NixOS/nixpkgs/commit/cb0fb74a2b58eda5d263f6cb424cfaaee7700940) | `` nixos/udev: update description for services.udev.path ``                                         |
| [`82fcf258`](https://github.com/NixOS/nixpkgs/commit/82fcf2589b7ac8430eb2de4fe91db6b502aad889) | `` vbam: 2.1.7 -> 2.1.8 ``                                                                          |
| [`6d499a26`](https://github.com/NixOS/nixpkgs/commit/6d499a262d2a26db1dab7d9c77fa135566e2b18b) | `` framework-laptop-kmod: init at unstable-2023-12-03 ``                                            |
| [`c5e85c45`](https://github.com/NixOS/nixpkgs/commit/c5e85c459830b30d1e54ca4ae0d4d37fc23adbe2) | `` warzone2100: 4.4.1 -> 4.4.2 ``                                                                   |
| [`99c14aab`](https://github.com/NixOS/nixpkgs/commit/99c14aab26339a8ae94da9da197d54a1508a0af2) | `` gitea: 1.21.1 -> 1.21.2 ``                                                                       |
| [`d59e3dee`](https://github.com/NixOS/nixpkgs/commit/d59e3dee72a53fc595a432211be91a046bf3f2c5) | `` eksctl: 0.164.0 -> 0.165.0 ``                                                                    |
| [`a365120b`](https://github.com/NixOS/nixpkgs/commit/a365120b26188f55d8c4cf10b3f3343ffe2ae592) | `` eigenmath: unstable-2023-12-11 -> unstable-2023-12-12 ``                                         |
| [`3174629e`](https://github.com/NixOS/nixpkgs/commit/3174629e7c976b456218bf20d06b5ecdd589e7ba) | `` droidcam: 2.1.0 -> 2.1.1 ``                                                                      |
| [`f9227b9d`](https://github.com/NixOS/nixpkgs/commit/f9227b9de9e8155238e52178407ca811e2f22d04) | `` duckscript: 0.9.1 -> 0.9.2 ``                                                                    |
| [`a70abc68`](https://github.com/NixOS/nixpkgs/commit/a70abc68407355a4f7acef92320ddf8c150e32ed) | `` libnvme: apply ns scan payload alignment patch ``                                                |
| [`f37be825`](https://github.com/NixOS/nixpkgs/commit/f37be82593a90a414e879253e8624588b51153e7) | `` include-what-you-use: 0.19 -> 0.21 ``                                                            |
| [`c78ba618`](https://github.com/NixOS/nixpkgs/commit/c78ba61863c1bca19e2413f84b5b95a4e0bae01c) | `` diswall: 0.4.2 -> 0.4.3 ``                                                                       |
| [`2bb19345`](https://github.com/NixOS/nixpkgs/commit/2bb1934579ff8489f3ff1dcd158746f358852982) | `` discordo: unstable-2023-12-11 -> unstable-2023-12-12 ``                                          |
| [`6f6435de`](https://github.com/NixOS/nixpkgs/commit/6f6435de1c363377ea1032eb8608bdef5dc2a498) | `` camunda-modeler: 5.17.0 -> 5.18.0 (#273963) ``                                                   |
| [`0f382f30`](https://github.com/NixOS/nixpkgs/commit/0f382f309295d3025133c4a073faf5742057bdf9) | `` pdfcpu: 0.5.0 -> 0.6.0 ``                                                                        |
| [`a62019e4`](https://github.com/NixOS/nixpkgs/commit/a62019e4c2f6f0863a065aa604008f42531909e7) | `` godot_4: 4.2.0 -> 4.2.1 ``                                                                       |
| [`4f02038c`](https://github.com/NixOS/nixpkgs/commit/4f02038c7fcdaf8b1369c11aa71174cffa7cfd75) | `` backblaze-b2: 3.9.0 -> 3.15.0 ``                                                                 |
| [`23879b92`](https://github.com/NixOS/nixpkgs/commit/23879b924170fd80e3fbc5da1e365617574c4d6c) | `` pythonPackages.b2sdk: 1.24.1 -> 1.29.0 ``                                                        |
| [`65202f80`](https://github.com/NixOS/nixpkgs/commit/65202f809c5c49c61e77bcf095cd162a94e44a69) | `` utm: 4.4.4 -> 4.4.5 ``                                                                           |
| [`4fc44b7d`](https://github.com/NixOS/nixpkgs/commit/4fc44b7ddf8456f7b4163f328e6be2525807866d) | `` nixos/qmk: ensure plugdev groups exists ``                                                       |
| [`4e393f96`](https://github.com/NixOS/nixpkgs/commit/4e393f96727f23df4d136778b9d4c6dfd40de8cb) | `` mailpit: 1.10.4 -> 1.11.0 ``                                                                     |
| [`27a9a1ca`](https://github.com/NixOS/nixpkgs/commit/27a9a1ca3f7c2d078ed64a55cfd1daa42d98efd4) | `` clasp-common-lisp: use ninjaFlags instead of explicitly setting buildPhase and installPhase ``   |
| [`cee76210`](https://github.com/NixOS/nixpkgs/commit/cee762101c7240812e8d638e16ba60be4dabc364) | `` clasp-common-lisp: fix build warning ``                                                          |
| [`c6234da6`](https://github.com/NixOS/nixpkgs/commit/c6234da6986ff31c58c7dd86d7741a1cf2fa44d3) | `` clasp-common-lisp: fetch dependencies in Nix ``                                                  |
| [`3023b2d0`](https://github.com/NixOS/nixpkgs/commit/3023b2d0bafcb115e3794543fdf321af7a3f184a) | `` clasp-common-lisp: use callPackage style instead of `with pkgs;` ``                              |
| [`13d8ffa2`](https://github.com/NixOS/nixpkgs/commit/13d8ffa26f0f8ba2429b88a4cda7a247a8557934) | `` koodousfinder: init at 0.1.0 ``                                                                  |
| [`aa9d4729`](https://github.com/NixOS/nixpkgs/commit/aa9d4729cbc99dabacb50e3994dcefb3ea0f7447) | `` steam: unset GIO_EXTRA_MODULES to supress errors ``                                              |
| [`c3a429fe`](https://github.com/NixOS/nixpkgs/commit/c3a429feac44321b8e3f98b64bb08c90e6bbada8) | `` steam: add glibc.bin to FHS for ldconfig ``                                                      |
| [`195248b6`](https://github.com/NixOS/nixpkgs/commit/195248b6c101f3d58002d5c7e15be38231780786) | `` buildFHSEnv, steam: isolate steam's /tmp from host ``                                            |
| [`452b8162`](https://github.com/NixOS/nixpkgs/commit/452b8162ecc995793d906cde424b652fa3dd1314) | `` buildFHSEnv: use symlinks instead of bind mounts for files from host /etc ``                     |
| [`a9d183cf`](https://github.com/NixOS/nixpkgs/commit/a9d183cff49c24ccc55a71a74be9b43f8078a7e0) | `` terrascan: 1.18.5 -> 1.18.7 ``                                                                   |
| [`eb4a64eb`](https://github.com/NixOS/nixpkgs/commit/eb4a64ebbd418b9e94b77e9c84b2302976cea758) | `` ocamlPackages.functoria: 4.3.6 → 4.4.1 ``                                                        |
| [`45ede5b9`](https://github.com/NixOS/nixpkgs/commit/45ede5b9f07b3357287d4ffe41d1acf83c0f4495) | `` copilot-cli: 1.32.0 -> 1.32.1 ``                                                                 |
| [`b0fdc32d`](https://github.com/NixOS/nixpkgs/commit/b0fdc32dd4bc96f9109ddcc1b61ef4176064ee1f) | `` python311Packages.jupyter-server: 2.11.1 -> 2.12.1 ``                                            |
| [`775de9fe`](https://github.com/NixOS/nixpkgs/commit/775de9fe27c258188b38e747061890ec88c15e05) | `` python3Packages.jupyter-server: 2.10.1 -> 2.11.1 ``                                              |
| [`309e6be7`](https://github.com/NixOS/nixpkgs/commit/309e6be7d43d4a8477bab57eb6d206fe29dcde7a) | `` ocamlPackages.lambda-term: 3.3.1 → 3.3.2 ``                                                      |
| [`be7d6c2a`](https://github.com/NixOS/nixpkgs/commit/be7d6c2a7acdf7942f1c8faf5bf69141f2ae307f) | `` cargo-about: 0.5.7 -> 0.6.0 ``                                                                   |
| [`c2827afc`](https://github.com/NixOS/nixpkgs/commit/c2827afc157df706292f9f068b721ab89d83f169) | `` cyclonedx-gomod: 1.4.1 -> 1.5.0 ``                                                               |
| [`14a5c976`](https://github.com/NixOS/nixpkgs/commit/14a5c9768102581ae0ae9b0196031c68b70d9a79) | `` credhub-cli: 2.9.22 -> 2.9.24 ``                                                                 |
| [`3e3c00a2`](https://github.com/NixOS/nixpkgs/commit/3e3c00a28e1be18517a4a02766dd2bd1e47c4a6c) | `` crd2pulumi: 1.2.5 -> 1.3.0 ``                                                                    |
| [`102500d2`](https://github.com/NixOS/nixpkgs/commit/102500d2bae0b6a7af1affa8a42d8fb12d5b3702) | `` tailscale: 1.54.1 -> 1.56.0 ``                                                                   |
| [`b35e94bd`](https://github.com/NixOS/nixpkgs/commit/b35e94bd9914690b52a504081b888ca9eeb24d6c) | `` qtcreator: 12.0.0 -> 12.0.1 ``                                                                   |
| [`cfe3e686`](https://github.com/NixOS/nixpkgs/commit/cfe3e686d0d573d374522f6c8a42ab2a3e038de7) | `` vesktop: add missing libnotify ``                                                                |
| [`5bc6ddb8`](https://github.com/NixOS/nixpkgs/commit/5bc6ddb8715c5c78892ebdc9280b3e94007cd6f7) | `` python311Packages.homeassistant-stubs: 2023.12.1 -> 2023.12.2 ``                                 |
| [`0b7e4691`](https://github.com/NixOS/nixpkgs/commit/0b7e4691c98956403917264924746da30c5cfde8) | `` cpp-utilities: 5.24.2 -> 5.24.4 ``                                                               |
| [`6fa23b90`](https://github.com/NixOS/nixpkgs/commit/6fa23b90c25a116668cc8af162eec05a02a701cf) | `` cpm-cmake: 0.38.6 -> 0.38.7 ``                                                                   |
| [`b501ab6f`](https://github.com/NixOS/nixpkgs/commit/b501ab6faadc30c431493da98d3be6a3068d7cdc) | `` coreth: 0.12.6 -> 0.12.7 ``                                                                      |
| [`59dc10b5`](https://github.com/NixOS/nixpkgs/commit/59dc10b5a6f2a592af36375c68fda41246794b86) | `` nixos/users-groups: fix confusing error message ``                                               |
| [`ebc9339c`](https://github.com/NixOS/nixpkgs/commit/ebc9339cc515d763157de0757c150109634a7207) | `` container2wasm: 0.5.1 -> 0.5.2 ``                                                                |
| [`c5d0c3da`](https://github.com/NixOS/nixpkgs/commit/c5d0c3da497f379648d66b4f57a39444af3a1cca) | `` pantheon.elementary-files: 6.5.2 -> 6.5.3 ``                                                     |
| [`82b3151d`](https://github.com/NixOS/nixpkgs/commit/82b3151def372ceabdc762c7006c6720da1d2ce2) | `` bpftools: add homepage ``                                                                        |
| [`5cff955d`](https://github.com/NixOS/nixpkgs/commit/5cff955d591ef02dc4b3c9a91c261feabe9b21a8) | `` nali: 0.8.0 -> 0.8.1 ``                                                                          |
| [`f6ea3f91`](https://github.com/NixOS/nixpkgs/commit/f6ea3f91b577921d9fbc48fb683b81445f9f150b) | `` nextcloud28: init at 28.0.0 ``                                                                   |
| [`e9444f1b`](https://github.com/NixOS/nixpkgs/commit/e9444f1b2df67250ee171e4a7692025e8933a00c) | `` abracadabra: 2.3.1 -> 2.3.4 ``                                                                   |
| [`197a0984`](https://github.com/NixOS/nixpkgs/commit/197a0984c749105aa02fc17c5233c54ef8baa467) | `` python311Packages.weasel: remove dev and lint depedencies ``                                     |
| [`d6c3275f`](https://github.com/NixOS/nixpkgs/commit/d6c3275fe0ef2a2b90516d0e823567a2f845e6ba) | `` conftest: 0.46.0 -> 0.47.0 ``                                                                    |
| [`d665488d`](https://github.com/NixOS/nixpkgs/commit/d665488d40e9aaa062326ba6c0aa5778de1ca8d4) | `` commit-mono: 1.141 -> 1.142 ``                                                                   |
| [`18a19d8d`](https://github.com/NixOS/nixpkgs/commit/18a19d8dd2f92d2220296023f11246d16aa4ad8c) | `` cargo-mobile2: 0.7.0 -> 0.9.0 ``                                                                 |
| [`ee4176d3`](https://github.com/NixOS/nixpkgs/commit/ee4176d3253108b764b76d42c9dd046cec503fde) | `` nixos/matrix-synapse: update broken link to redis related docs ``                                |
| [`0102fd19`](https://github.com/NixOS/nixpkgs/commit/0102fd19b5ecfc5b327eecc31cfd429756752e5e) | `` python311Packages.dvc: 3.33.3 -> 3.33.4 ``                                                       |
| [`60689bff`](https://github.com/NixOS/nixpkgs/commit/60689bffab4b4cc11d31b54f3ce0aacf862898c3) | `` matrix-synapse: update license to agpl3Plus ``                                                   |
| [`3d7e5f4f`](https://github.com/NixOS/nixpkgs/commit/3d7e5f4f26a2103b09958fa66274bdd9dc0d58c1) | `` nixos/matrix-synapse: replace references to matrix-org/synapse with element-hq/synapse ``        |
| [`49ebc387`](https://github.com/NixOS/nixpkgs/commit/49ebc3878e9ec7848d77d75450f8c78233aa898a) | `` nixos/nebula: tests: revert wait_for_unit ``                                                     |
| [`7f7ab041`](https://github.com/NixOS/nixpkgs/commit/7f7ab041399663de5cad1cf0e88b9e0ea34c1353) | `` matrix-synapse.tools.synadm: replace references to matrix-org/synapse with element-hq/synapse `` |
| [`51edd222`](https://github.com/NixOS/nixpkgs/commit/51edd222c2dddcf2c0f58a589cdfa4c59a98a532) | `` matrix-synapse: replace references to matrix-org/synapse with element-hq/synapse ``              |
| [`1d50215d`](https://github.com/NixOS/nixpkgs/commit/1d50215dfd686e25ccb50af3c89e6acc099f8bd7) | `` python311Packages.dvc-data: 2.23.1 -> 2.24.0 ``                                                  |
| [`7f075f16`](https://github.com/NixOS/nixpkgs/commit/7f075f16ad0238b7a2ea126503d0ce23d2e31d67) | `` python311Packages.dvc-objects: 1.4.9 -> 2.0.1 ``                                                 |
| [`9efe1ff2`](https://github.com/NixOS/nixpkgs/commit/9efe1ff25e5b65cd9d06104c2ad4c6b8a65b0504) | `` terragrunt: 0.54.1 -> 0.54.3 ``                                                                  |
| [`c005c106`](https://github.com/NixOS/nixpkgs/commit/c005c106cc54949af27fde77ac7e78f15714d7eb) | `` linux/hardened/patches/6.6: 6.6.6-hardened1 -> 6.6.7-hardened1 ``                                |
| [`b9d37f2d`](https://github.com/NixOS/nixpkgs/commit/b9d37f2d15c067d16bf73366804d274c27e4be78) | `` linux/hardened/patches/6.1: 6.1.67-hardened1 -> 6.1.68-hardened1 ``                              |
| [`73a860b0`](https://github.com/NixOS/nixpkgs/commit/73a860b056a608dfb1a21ff63120b04a90ae7267) | `` linux/hardened/patches/5.4: 5.4.263-hardened1 -> 5.4.264-hardened1 ``                            |
| [`5b5eb633`](https://github.com/NixOS/nixpkgs/commit/5b5eb633b351f55222120529664c0f3e67067022) | `` linux/hardened/patches/5.15: 5.15.142-hardened1 -> 5.15.143-hardened1 ``                         |
| [`56931ddc`](https://github.com/NixOS/nixpkgs/commit/56931ddc416b3d365f5bd6bd5c9bc894fe0480f5) | `` linux/hardened/patches/5.10: 5.10.203-hardened1 -> 5.10.204-hardened1 ``                         |
| [`1ee3fe27`](https://github.com/NixOS/nixpkgs/commit/1ee3fe27f20bf80311231b5f6e5df3cb2caa2e49) | `` linux/hardened/patches/4.19: 4.19.301-hardened1 -> 4.19.302-hardened1 ``                         |