### PR TITLE
chore(flake/hyprland): `b1b8d732` -> `403fd7d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -273,11 +273,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1702675213,
-        "narHash": "sha256-Sl5gAPzCvYmXw7jo7ISzz/djhprOstFLRyznfxq2JIw=",
+        "lastModified": 1702858530,
+        "narHash": "sha256-54Udd5LVnk1ZFc0BayOLpf3DcOh3NKXutwF7JcY3bLQ=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "b1b8d732e64ecf527baef010ad2f28ed3b8c4ac1",
+        "rev": "403fd7d9f6b160dec71456c9fb195a4199134eff",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                 |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
| [`403fd7d9`](https://github.com/hyprwm/Hyprland/commit/403fd7d9f6b160dec71456c9fb195a4199134eff) | `` xwayland: move commit handler connect to associate ``                |
| [`763d5fa0`](https://github.com/hyprwm/Hyprland/commit/763d5fa05f7d0191182a1d6cd827415a65293f99) | `` xdgshell: set predicted tiled windows to monitor res size pre-map `` |
| [`9fd928e1`](https://github.com/hyprwm/Hyprland/commit/9fd928e114d7f57ac03aa7430d9cba41843347de) | `` internal: nuke CWindow::m_bMappedX11 ``                              |
| [`bf737401`](https://github.com/hyprwm/Hyprland/commit/bf7374011b17776137c6cadb016695ef05926c6c) | `` xwaylandmgr: allow resizes without a monitor ``                      |
| [`8c9f38e4`](https://github.com/hyprwm/Hyprland/commit/8c9f38e40500720d4de5881d62ec43625e9680ea) | `` events: improve wl_surface::commit event tracking ``                 |
| [`c0d9dcc5`](https://github.com/hyprwm/Hyprland/commit/c0d9dcc586ab17bf67c48c02a08bca28727f9237) | `` xwayland: set reported and pending size/pos on geometry sets ``      |
| [`2a777cb7`](https://github.com/hyprwm/Hyprland/commit/2a777cb71bc727836ca9c73ebb193773a99f8f1e) | `` hyprctl: add commit date to "hyprctl version" (#4171) ``             |
| [`9ca0c7d8`](https://github.com/hyprwm/Hyprland/commit/9ca0c7d814d6039450ff0341556faa1ce9b37e82) | `` input: Activate resize_on_border only when key is pressed (#4170) `` |