### PR TITLE
chore(flake/nixpkgs): `02357add` -> `7d692982`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -494,11 +494,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702635820,
-        "narHash": "sha256-rClms9NTmSL/WIN5VmEccVhUExMkjCrRNswxU9QGNNo=",
+        "lastModified": 1702723167,
+        "narHash": "sha256-cIxAF4Do+B7mQxzRDo/8B9QO0i2ap3i/i6Ujk8kx+Ws=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "02357adddd0889782362d999628de9d309d202dc",
+        "rev": "7d6929828a2d28eda9d37254ff6be3b6819506ca",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                    |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
| [`44f2f5ce`](https://github.com/NixOS/nixpkgs/commit/44f2f5ce5aaf6ae3ae0c82ffec74e2d235c68535) | `` klipper: unstable-2023-11-16 -> unstable-2023-12-13 (#274602) ``                                        |
| [`944cd0b0`](https://github.com/NixOS/nixpkgs/commit/944cd0b02acc79dc0c14252e116c637024d20525) | `` knot-dns: fixup build on darwin ``                                                                      |
| [`3dda6d5e`](https://github.com/NixOS/nixpkgs/commit/3dda6d5ed56af34534dd4cdcdd85627df25aec55) | `` signal-desktop: 6.40.0 -> 6.42.0 ``                                                                     |
| [`dbb72b23`](https://github.com/NixOS/nixpkgs/commit/dbb72b239e7615ef205567cd8ec92837ebbf9693) | `` esptool_3: drop ``                                                                                      |
| [`6000c3c9`](https://github.com/NixOS/nixpkgs/commit/6000c3c94cc92c1570f52fe61406a295fc11ef39) | `` esphome: use pep517 build, upgrade esptool to 4.x ``                                                    |
| [`6f2ef681`](https://github.com/NixOS/nixpkgs/commit/6f2ef6811e2d703dcb1b485e421d35ccbd3554fc) | `` platformio: 6.1.6 -> 6.1.11 ``                                                                          |
| [`5eb4128d`](https://github.com/NixOS/nixpkgs/commit/5eb4128d60a43b12f4daeabb645666b48fdab817) | `` buildFHSEnv: propagate host /etc if nested ``                                                           |
| [`3522b963`](https://github.com/NixOS/nixpkgs/commit/3522b963f5afe5d14adc08910e130f67d87af4ed) | `` home-assistant: pin aioesphomeapi at 19.2.1 ``                                                          |
| [`c048cfe4`](https://github.com/NixOS/nixpkgs/commit/c048cfe481a0d93ce6742346fe4a6db1588b05cc) | `` gasket: moved to linux-kernels.nix ``                                                                   |
| [`386647be`](https://github.com/NixOS/nixpkgs/commit/386647bebf6b1430c783790a513a51769f478252) | `` lsp-plugins: apply patch "Fix aarch64 msmatrix code" (#274504) ``                                       |
| [`2925a9ef`](https://github.com/NixOS/nixpkgs/commit/2925a9ef304ca42050efc7d0589b9cebd9e8173b) | `` hjson-go: 4.3.1 -> 4.4.0 ``                                                                             |
| [`d4fcb44d`](https://github.com/NixOS/nixpkgs/commit/d4fcb44dcc6153ef982bd7fa87dca97bd3142796) | `` nixos/kubo: fix potential panic on startup ``                                                           |
| [`271235e3`](https://github.com/NixOS/nixpkgs/commit/271235e3891e6825fd7dbe94d45e229e41283b3a) | `` signal-desktop: re-enable wayland ``                                                                    |
| [`c70ba88b`](https://github.com/NixOS/nixpkgs/commit/c70ba88ba86ceb9eda165ed1a6c1e40a37f3dfba) | `` nushell: 0.88.0 -> 0.88.1 ``                                                                            |
| [`c8b547ad`](https://github.com/NixOS/nixpkgs/commit/c8b547adfc5470d88c3ea925999ad7187dd8bd00) | `` intel-gmmlib: 22.3.14 -> 22.3.15 ``                                                                     |
| [`c71de1b2`](https://github.com/NixOS/nixpkgs/commit/c71de1b26252bbcabd49f736996cdcc64eeb386c) | `` cf-terraforming: 0.16.1 -> 0.17.0 (#274375) ``                                                          |
| [`e26a9c5f`](https://github.com/NixOS/nixpkgs/commit/e26a9c5f80a36b9e756c27b128a8357e6b3770c9) | `` infisical: 0.14.3 -> 0.16.3 ``                                                                          |
| [`bd5193e6`](https://github.com/NixOS/nixpkgs/commit/bd5193e6523b26ee6991369694e68097de7268e3) | `` ihp-new: 1.1.0 -> 1.2.0 ``                                                                              |
| [`770d67f2`](https://github.com/NixOS/nixpkgs/commit/770d67f25c276b42fc043851d11932277bb2ccad) | `` hyperrogue: 12.1y -> 12.1z ``                                                                           |
| [`eb9018d5`](https://github.com/NixOS/nixpkgs/commit/eb9018d59225a5c3044922946c0cd6f56e8e2c53) | `` httplib: 0.14.1 -> 0.14.2 ``                                                                            |
| [`700959c8`](https://github.com/NixOS/nixpkgs/commit/700959c8eea7f2c18a3adee5c40cfba81b69ea7c) | `` nixos/winbox: init ``                                                                                   |
| [`919401f9`](https://github.com/NixOS/nixpkgs/commit/919401f9635b3dd6fb0a76d8d43d75a3fd63dae7) | `` bozohttpd: Update source URL ``                                                                         |
| [`e4129a6c`](https://github.com/NixOS/nixpkgs/commit/e4129a6cad6e0e599e4c81522f513d2c06d195b5) | `` winbox: switch to wineWowPackages.stable ``                                                             |
| [`dbb599f2`](https://github.com/NixOS/nixpkgs/commit/dbb599f2e4337aa80cf71462f04bd32216d8bb90) | `` workflows/check-by-name: Cancel on merge conflicts ``                                                   |
| [`c9320682`](https://github.com/NixOS/nixpkgs/commit/c93206822b0d8c1aab591b83936ec971f12cfe4d) | `` haruna: 0.12.2 -> 0.12.3 ``                                                                             |
| [`0e4f9ff6`](https://github.com/NixOS/nixpkgs/commit/0e4f9ff6ec9e31a559d9a544b1e71b8f7ac973c4) | `` clippy: use unwrapped rustc when adding rpath for darwin ``                                             |
| [`2c10cef2`](https://github.com/NixOS/nixpkgs/commit/2c10cef2b38af301d50603c6fb8851677854a98f) | `` rustfmt: use unwrapped rustc when adding rpath for darwin ``                                            |
| [`fc2d2693`](https://github.com/NixOS/nixpkgs/commit/fc2d26939d2839d65553e8ca605f2440a45fc387) | `` tests.nixpkgs-check-by-name: Improve check clarity ``                                                   |
| [`4ede2b35`](https://github.com/NixOS/nixpkgs/commit/4ede2b3572225336f9800c5ab31753ae669e9d4b) | `` vimPlugins.sniprun: 1.3.8 -> 1.3.9 ``                                                                   |
| [`9aaba1f0`](https://github.com/NixOS/nixpkgs/commit/9aaba1f0f309f13f67c6f9978d66f3528369d0ec) | `` vimPlugins.nvim-treesitter: update grammars ``                                                          |
| [`931e7dc1`](https://github.com/NixOS/nixpkgs/commit/931e7dc1712253707f9650e46826ef799355a38d) | `` vimPlugins: resolve github repository redirects ``                                                      |
| [`e5eb61ea`](https://github.com/NixOS/nixpkgs/commit/e5eb61ea2576197f2f5bce9725e7c7486d507454) | `` vimPlugins: update on 2023-12-15 ``                                                                     |
| [`dbbbf247`](https://github.com/NixOS/nixpkgs/commit/dbbbf2470e021dc723f42ee91e87dac3b0c8fcd9) | `` grpc-gateway: 2.18.0 -> 2.18.1 ``                                                                       |
| [`d0b8914d`](https://github.com/NixOS/nixpkgs/commit/d0b8914d4a10c43c9e2041457c2928c5c9e3a90a) | `` python311Packages.jax: 0.4.21 -> 0.4.23 ``                                                              |
| [`1137e416`](https://github.com/NixOS/nixpkgs/commit/1137e416f863310c005200dfbaa50eebd0a1889e) | `` asterisk_18: 18.17.1 -> 18.20.1, asterisk_20: 20.2.1 -> 20.5.1 ``                                       |
| [`601e70ee`](https://github.com/NixOS/nixpkgs/commit/601e70eed8b7efa6ae74ef07c6aeec27b41ec6be) | `` python311Packages.jaxlib: 0.4.21 -> 0.4.23 ``                                                           |
| [`27d0568f`](https://github.com/NixOS/nixpkgs/commit/27d0568f4201cd356ed3009b5fa60b83298f8b54) | `` keycloak: 23.0.1 -> 23.0.3 ``                                                                           |
| [`bf4dd1e7`](https://github.com/NixOS/nixpkgs/commit/bf4dd1e756cf457f81d6c149fb72c9fa6e701f9a) | `` python311Packages.jaxlib-bin: 0.4.21 -> 0.4.23 ``                                                       |
| [`2191b766`](https://github.com/NixOS/nixpkgs/commit/2191b7662d6db6db1336034f83c0546e5d2636b8) | `` lua.lib: support arbitrary settings in generateLuarocksConfig ``                                        |
| [`4ea6c0c5`](https://github.com/NixOS/nixpkgs/commit/4ea6c0c58bea95f22fbca81ae5edddc93b342b5e) | `` lib.generators: made toLua accept derivations too ``                                                    |
| [`b98bbbd4`](https://github.com/NixOS/nixpkgs/commit/b98bbbd49ad4ea3810d907828125368fe61597f5) | `` CODEOWNERS: unsubscribe fricklerhandwerk ``                                                             |
| [`e54d2567`](https://github.com/NixOS/nixpkgs/commit/e54d256759d92b4188838b42a48b8e2a2d1f3a27) | `` goimports-reviser: 3.5.6 -> 3.6.0 ``                                                                    |
| [`db3d0e06`](https://github.com/NixOS/nixpkgs/commit/db3d0e06da922c473a67b134348011ba19e809d1) | `` gogui: 1.5.3 -> 1.5.4a ``                                                                               |
| [`809ff646`](https://github.com/NixOS/nixpkgs/commit/809ff646c9dc269c10b745f040a2ba2fcb874696) | `` goconst: 1.6.0 -> 1.7.0 ``                                                                              |
| [`d4af6e42`](https://github.com/NixOS/nixpkgs/commit/d4af6e420f92351da65e6726fe7246adc9e1d498) | `` root: build with root7 and webgui (#272723) ``                                                          |
| [`0d7a228f`](https://github.com/NixOS/nixpkgs/commit/0d7a228f8e3d2796beb1f33011918930c021b5cc) | `` fastjet: 3.4.1 -> 3.4.2 ``                                                                              |
| [`d412d72d`](https://github.com/NixOS/nixpkgs/commit/d412d72d693d6387ee0935ad43822fa17664b266) | `` pkgs/top-level/release-outpaths.nix: omit attrnames which fail with "unsupported" ``                    |
| [`8f34a10d`](https://github.com/NixOS/nixpkgs/commit/8f34a10d6a74ede31014d5f19e03253feb43edf1) | `` lib/tests/release.nix: temporary reference to pkgs/test/release ``                                      |
| [`2d036511`](https://github.com/NixOS/nixpkgs/commit/2d036511f65a267604a27d4758de1eb952315b15) | `` pkgs/test/release/default.nix: init ``                                                                  |
| [`77d3093c`](https://github.com/NixOS/nixpkgs/commit/77d3093caa6777dd5861d6f497fee2a61480bdf9) | `` AAAAAASomeThingsFailToEvaluate: provide a message which is actually helpful ``                          |
| [`eda44b74`](https://github.com/NixOS/nixpkgs/commit/eda44b741587f1612df32fc194266e3e06a9feff) | `` pkgs/top-level/release-attrpaths-superset.nix: init ``                                                  |
| [`80472e37`](https://github.com/NixOS/nixpkgs/commit/80472e375406bb8f130b7d1e360fe89d042f7661) | `` treewide: add __attrsFailEvaluation and __recurseIntoDerivationForReleaseJobs ``                        |
| [`2960f536`](https://github.com/NixOS/nixpkgs/commit/2960f5366bba81a9a00e3b5892c1956639c9207d) | `` endless-sky: 0.9.16.1 -> 0.10.4 (#273995) ``                                                            |
| [`11da3298`](https://github.com/NixOS/nixpkgs/commit/11da3298d1194e268a92ef319265812957b346f0) | `` go-toml: 2.1.0 -> 2.1.1 ``                                                                              |
| [`f5fbd161`](https://github.com/NixOS/nixpkgs/commit/f5fbd1619d38f4553b878ecf5c327c9c37ced12d) | `` python311Packages.google-cloud-automl: 2.11.4 -> 2.12.0 ``                                              |
| [`cd991092`](https://github.com/NixOS/nixpkgs/commit/cd99109202945cf00116dc70af2f31eb66e10695) | `` pkgs/top-level/release-outpaths.nix: never attempt to build unfree packages, most of them are broken `` |
| [`6e25b3f3`](https://github.com/NixOS/nixpkgs/commit/6e25b3f37c7c410236bacf122d55cf870b98c707) | `` pkgs/top-level/release-outpaths.nix: add includeBroken parameter ``                                     |
| [`e5df6570`](https://github.com/NixOS/nixpkgs/commit/e5df65704e52afafe7be717060579b07d476d30d) | `` pkgs/top-level/release-outpaths.nix: make systems parameter optional ``                                 |
| [`5d3cf4e5`](https://github.com/NixOS/nixpkgs/commit/5d3cf4e5157ac5f16555af1de1d1f47fafdc3b01) | `` pkgs/top-level/release-outpaths.nix: simplify invocation ``                                             |
| [`36b5bfc2`](https://github.com/NixOS/nixpkgs/commit/36b5bfc296dc2ede7f6a6dfdb7ae102529ff3c22) | `` pkgs/top-level/release-outpaths.nix: add attrNamesOnly option ``                                        |
| [`8d888a5c`](https://github.com/NixOS/nixpkgs/commit/8d888a5caa8cdecb7448542ef92209b2e616490f) | `` pkgs/top-level/release-outpaths.nix: adjust default path value ``                                       |
| [`5c9ec859`](https://github.com/NixOS/nixpkgs/commit/5c9ec8597b9d2dc586c64b1897d1440d6284c968) | `` pkgs/top-level/release-outpaths.nix: vendor from ofborg ``                                              |
| [`02a2822d`](https://github.com/NixOS/nixpkgs/commit/02a2822def0f4779f026d93080e0b7852c47fb22) | `` pkgs/top-level/release.nix: add attrNamesOnly option ``                                                 |
| [`f44a638e`](https://github.com/NixOS/nixpkgs/commit/f44a638e223b2ffc7b445fcf062acddd409b4e33) | `` python311Packages.google-cloud-asset: refactor ``                                                       |
| [`0fb2d134`](https://github.com/NixOS/nixpkgs/commit/0fb2d1343cbb5720e1f7f31d16dc4de287fd857d) | `` python311Packages.google-cloud-asset: 3.20.1 -> 3.22.0 ``                                               |
| [`9bf4d139`](https://github.com/NixOS/nixpkgs/commit/9bf4d139933ed19995fefbd000f0c1482b0fab5c) | `` python311Packages.google-cloud-appengine-logging: 1.3.2 -> 1.4.0 ``                                     |
| [`1f769aac`](https://github.com/NixOS/nixpkgs/commit/1f769aac00c0e64c498e79fe83edadfab13e8501) | `` python311Packages.google-auth-httplib2: 0.1.1 -> 0.2.0 ``                                               |
| [`95e79a93`](https://github.com/NixOS/nixpkgs/commit/95e79a93ce929774866df8fa8b31651b33407c41) | `` python311Packages.google-cloud-bigtable: 2.21.0 -> 2.22.0 ``                                            |
| [`d6265f32`](https://github.com/NixOS/nixpkgs/commit/d6265f327ae4c519ced6748f6bed0fa3a69289ff) | `` python311Packages.google-cloud-container: 2.35.0 -> 2.36.0 ``                                           |
| [`5e12d668`](https://github.com/NixOS/nixpkgs/commit/5e12d668a99f63c476bd5e405649a6267b3eafe8) | `` python311Packages.google-cloud-dataproc: refactor ``                                                    |
| [`17d6467e`](https://github.com/NixOS/nixpkgs/commit/17d6467e71df09c1ad82e92f2868bd00408c90d1) | `` python311Packages.google-cloud-dataproc: 5.7.0 -> 5.8.0 ``                                              |
| [`43e225ce`](https://github.com/NixOS/nixpkgs/commit/43e225cec92e027222ecf6424fb50956b6640925) | `` python311Packages.google-cloud-logging: 3.8.0 -> 3.9.0 ``                                               |
| [`ced43a67`](https://github.com/NixOS/nixpkgs/commit/ced43a67f2697e9e68170b06d8871aa5e9ab718e) | `` python311Packages.google-cloud-os-config: 1.15.3 -> 1.16.0 ``                                           |
| [`5c24b72c`](https://github.com/NixOS/nixpkgs/commit/5c24b72c60c591976b4609de45d7221ed0ec8b53) | `` python311Packages.google-cloud-redis: 2.13.2 -> 2.14.0 ``                                               |
| [`67e70b85`](https://github.com/NixOS/nixpkgs/commit/67e70b85aefbfd0d7a84f4c30d52b19ba01df09d) | `` python311Packages.google-cloud-speech: 2.22.0 -> 2.23.0 ``                                              |
| [`3c7a3116`](https://github.com/NixOS/nixpkgs/commit/3c7a3116e359fc015eeb8c316f45be05a968176a) | `` python311Packages.google-cloud-vision: 3.4.5 -> 3.5.0 ``                                                |
| [`a633fd17`](https://github.com/NixOS/nixpkgs/commit/a633fd177a6795dda083f2e80924a9c0e3daa4e2) | `` go-containerregistry: 0.16.1 -> 0.17.0 ``                                                               |
| [`ee1148c3`](https://github.com/NixOS/nixpkgs/commit/ee1148c372368108eead87063b2a43bf014e03dd) | `` mission-center: 0.4.1 -> 0.4.3 ``                                                                       |
| [`6e2493e7`](https://github.com/NixOS/nixpkgs/commit/6e2493e7f8f8761fe557d0ad911e7db10b8cf44b) | `` nextcloudPackages.apps.phonetrack: init at 0.7.6 (for nc26) & 0.7.7 (for nc27, nc28) ``                 |
| [`b06aad8b`](https://github.com/NixOS/nixpkgs/commit/b06aad8b1313b9f69dee05cdc535fab6ff44ae43) | `` nextcloudPackages.apps: update ``                                                                       |
| [`1cf35039`](https://github.com/NixOS/nixpkgs/commit/1cf35039f5c110d794039e6d715aeb8997c6cfc5) | `` cloud-hypervisor: 36.0 -> 37.0 ``                                                                       |
| [`577d1920`](https://github.com/NixOS/nixpkgs/commit/577d1920586122ece348cdbd22e99bd6b61f0ae8) | `` geos: fix package test script name ``                                                                   |
| [`8d8e2141`](https://github.com/NixOS/nixpkgs/commit/8d8e2141f5a7bcba1192948c8128963659c7f53d) | `` gpu-burn: unstabe-2021-04-29 -> unstable-2023-11-10 ``                                                  |
| [`93f97470`](https://github.com/NixOS/nixpkgs/commit/93f9747043df6af53a9dc954ae7af76a45d66bad) | `` glooctl: 1.15.16 -> 1.15.17 ``                                                                          |
| [`7ac8a22e`](https://github.com/NixOS/nixpkgs/commit/7ac8a22e971ee850111ddc48ab926640200755e3) | `` treecat: init at 1.0.2-unstable-2023-11-28 ``                                                           |
| [`521b9c3d`](https://github.com/NixOS/nixpkgs/commit/521b9c3d3607a20c2c4f18cab01924802397d15c) | `` hareThirdParty.hare-json: unstable-2023-09-21 -> unstable-2023-03-13 ``                                 |
| [`494bd425`](https://github.com/NixOS/nixpkgs/commit/494bd4255cfb73592329aece20d678260f93e5fc) | `` hareThirdParty.hare-json: move to `pkgs/development/hare-third-party` ``                                |
| [`d3910f75`](https://github.com/NixOS/nixpkgs/commit/d3910f75c348875470d292ab33f41ebb50903336) | `` metasploit: 6.3.46 -> 6.3.47 ``                                                                         |
| [`6ac8b7b4`](https://github.com/NixOS/nixpkgs/commit/6ac8b7b4d4c9644a095242e2a5eddb2042c455fc) | `` python311Packages.fakeredis: 2.20.0 -> 2.20.1 ``                                                        |
| [`05580d6f`](https://github.com/NixOS/nixpkgs/commit/05580d6f0a46da032013c05e63ada40a211628e4) | `` github-to-sqlite: 2.8.3 -> 2.9 ``                                                                       |
| [`ab74e429`](https://github.com/NixOS/nixpkgs/commit/ab74e429d0a63b93c0b9c515b950ffdbeea3ecff) | `` exploitdb: 2023-12-13 -> 2023-12-15 ``                                                                  |
| [`8b1c28b1`](https://github.com/NixOS/nixpkgs/commit/8b1c28b1d44a21bf105e0dda77c10ba2f0207549) | `` git-mit: 5.12.178 -> 5.12.180 ``                                                                        |
| [`9df0b1e5`](https://github.com/NixOS/nixpkgs/commit/9df0b1e53af4766d6bf06aa0dc65865624f12c8f) | `` git-lfs: 3.4.0 -> 3.4.1 ``                                                                              |
| [`8c93eb67`](https://github.com/NixOS/nixpkgs/commit/8c93eb670164ae36afcdbb61b9a67ca54141f2ed) | `` gci: 0.11.2 -> 0.12.0 ``                                                                                |
| [`0c08bb1d`](https://github.com/NixOS/nixpkgs/commit/0c08bb1d7db2752cbecf6c145bc5e4f2b908ac6d) | `` python311Packages.torchvision-bin: 0.16.1 -> 0.16.2 ``                                                  |
| [`3620b75b`](https://github.com/NixOS/nixpkgs/commit/3620b75b590a6cf05c1e8cb9c4b7c9e19b927eda) | `` python311Packages.torchvision: remove unused code in derivation ``                                      |
| [`fb35b194`](https://github.com/NixOS/nixpkgs/commit/fb35b19424d9360532a8ebc525a94337d77fb600) | `` python311Packages.torchvision: 0.16.1 -> 0.16.2 ``                                                      |
| [`8240efd0`](https://github.com/NixOS/nixpkgs/commit/8240efd0ccd9d4b3173a9e3cbae3d729cdfb3b74) | `` python311Packages.torchaudio-bin: 2.1.1 -> 2.1.2 ``                                                     |
| [`e5372c35`](https://github.com/NixOS/nixpkgs/commit/e5372c35105af60d84f3f298324457d2890a98f2) | `` python311Packages.torchaudio: 2.1.1 -> 2.1.2 ``                                                         |
| [`834f207e`](https://github.com/NixOS/nixpkgs/commit/834f207e3f37b180f4c47593fa11da8a142471c0) | `` python311Packages.torch-bin: 2.1.1 -> 2.1.2 ``                                                          |
| [`9b0e05e1`](https://github.com/NixOS/nixpkgs/commit/9b0e05e15e90be28e84a6db35df382afb0292a30) | `` python311Packages.torch: 2.1.1 -> 2.1.2 ``                                                              |
| [`5cb7e650`](https://github.com/NixOS/nixpkgs/commit/5cb7e6505c881f10ac36e17cf7f6e0366392b4e8) | `` conmon: 2.1.8 -> 2.1.9 ``                                                                               |
| [`e4afde8b`](https://github.com/NixOS/nixpkgs/commit/e4afde8b64c591a7750be89f4a764e58221c3f52) | `` codux: 15.14.0 -> 15.16.1 ``                                                                            |
| [`e8fb9eb3`](https://github.com/NixOS/nixpkgs/commit/e8fb9eb31a3b0c06eae7a1407bf5372771f0cff4) | `` cloudfoundry-cli: 8.7.5 -> 8.7.6 ``                                                                     |
| [`1de65585`](https://github.com/NixOS/nixpkgs/commit/1de65585be43e2194cff652727183bc371d66d8b) | `` chrony: 4.4 -> 4.5 ``                                                                                   |
| [`4221b485`](https://github.com/NixOS/nixpkgs/commit/4221b4857dceedfec459c8452c7ba7100182049d) | `` chamber: 2.13.5 -> 2.13.6 ``                                                                            |
| [`919d687e`](https://github.com/NixOS/nixpkgs/commit/919d687e2e331a1a3a5a8dc12d19b3e968d14813) | `` cargo-nextest: 0.9.64 -> 0.9.66 ``                                                                      |
| [`a1e9171c`](https://github.com/NixOS/nixpkgs/commit/a1e9171ca3c1a3224fad8dba8fe75a7be3fef745) | `` cadical: 1.9.0 -> 1.9.1 ``                                                                              |
| [`065b96aa`](https://github.com/NixOS/nixpkgs/commit/065b96aafe63d7723ebf122e8d022c7bf011410b) | `` buttercup-desktop: 2.21.0 -> 2.24.3 ``                                                                  |
| [`140f2db9`](https://github.com/NixOS/nixpkgs/commit/140f2db977a0c91d38d7c32b964a497f22c02b59) | `` jaxlib: use vendored grpc for XLA to fix build ``                                                       |
| [`7034e9bf`](https://github.com/NixOS/nixpkgs/commit/7034e9bfc6bad15052b2a20e8b6b4a149d9a8788) | `` fzf-make: 0.9.0 -> 0.11.0 ``                                                                            |
| [`4d666aa8`](https://github.com/NixOS/nixpkgs/commit/4d666aa84da691a1a17c879c61ce0830f4c26907) | `` fw: 2.19.0 -> 2.19.1 ``                                                                                 |
| [`b60af5f6`](https://github.com/NixOS/nixpkgs/commit/b60af5f605fb7555acf9da8dc6556092cb4c356c) | `` function-runner: 4.0.0 -> 4.1.0 ``                                                                      |
| [`b1479188`](https://github.com/NixOS/nixpkgs/commit/b14791881a6ce97e231e67b19b3d3303ead73382) | `` flyctl: 0.1.131 -> 0.1.134 ``                                                                           |
| [`30f8135b`](https://github.com/NixOS/nixpkgs/commit/30f8135bb6c8e9f1a0a8cc1289acc5e32f67aaec) | `` openvswitch: 3.1.1 -> 3.2.1 ``                                                                          |
| [`45714749`](https://github.com/NixOS/nixpkgs/commit/4571474946a17c356e6ab8b325294b164e2e5f05) | `` clipcat: 0.13.0 -> 0.14.0 ``                                                                            |
| [`e317292b`](https://github.com/NixOS/nixpkgs/commit/e317292b6808a50af81f881c1a59e820be27e7b0) | `` openvswitch-lts: 2.17.6 -> 2.17.8 ``                                                                    |
| [`ed923dc0`](https://github.com/NixOS/nixpkgs/commit/ed923dc0774e7a4bffeb3d63146d604dd147730e) | `` openvswitch: add updateScript ``                                                                        |
| [`74e8b38d`](https://github.com/NixOS/nixpkgs/commit/74e8b38dbe809022d096b11b87ba33a68ba0d374) | `` tests.nixpkgs-check-by-name: Move interface description into code ``                                    |
| [`72e9ddf1`](https://github.com/NixOS/nixpkgs/commit/72e9ddf1b773855be2dba63052d786fa20b1e3f0) | `` flex-ncat: 0.2-20230126.0 -> 0.4-20231210.1 ``                                                          |
| [`79618ff8`](https://github.com/NixOS/nixpkgs/commit/79618ff8cbfb69b6eb70dbc591b42cee2fed974e) | `` tests.nixpkgs-check-by-name: Improve docs, introduce "ratchet" term ``                                  |
| [`1d0612e3`](https://github.com/NixOS/nixpkgs/commit/1d0612e3c7adab30cf7c9adbcaafb9943b8f4dd3) | `` flarectl: 0.82.0 -> 0.83.0 ``                                                                           |
| [`3a159b86`](https://github.com/NixOS/nixpkgs/commit/3a159b86e9bed2421132365df5d7d06447ddd993) | `` hexyl: 0.13.1 -> 0.14.0 ``                                                                              |
| [`46212980`](https://github.com/NixOS/nixpkgs/commit/46212980d7e7ee695d3f9b02361ad8f5f9137392) | `` fits-cloudctl: 0.12.6 -> 0.12.11 ``                                                                     |
| [`413dd9c0`](https://github.com/NixOS/nixpkgs/commit/413dd9c03e37562c61cd89799e5eb8a88c7bb42a) | `` tests.nixpkgs-check-by-name: Minor improvements from review ``                                          |
| [`53b43ce0`](https://github.com/NixOS/nixpkgs/commit/53b43ce0e322eb4fc8daaad8a5a597155d42379a) | `` tests.nixpkgs-check-by-name: Fix and document behavior without --base ``                                |
| [`0d899bc7`](https://github.com/NixOS/nixpkgs/commit/0d899bc7b8c4140fbd6de134ea4cfd39ee7d623b) | `` fingerprintx: 1.1.10 -> 1.1.12 ``                                                                       |
| [`77172b88`](https://github.com/NixOS/nixpkgs/commit/77172b88f64c8f2da1985e7854e2b036ddd79cfe) | `` fh: 0.1.8 -> 0.1.9 ``                                                                                   |
| [`16a8b378`](https://github.com/NixOS/nixpkgs/commit/16a8b378b7e69e44cac785116cef061463b7f070) | `` kubo: 0.24.0 -> 0.25.0 ``                                                                               |
| [`05b4972d`](https://github.com/NixOS/nixpkgs/commit/05b4972db0bf91462b1e01b0c1ad234ff29c37d7) | `` kubo: migrate to by-name ``                                                                             |