### PR TITLE
chore(flake/nixpkgs): `7d692982` -> `3a16c644`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -473,11 +473,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702723167,
-        "narHash": "sha256-cIxAF4Do+B7mQxzRDo/8B9QO0i2ap3i/i6Ujk8kx+Ws=",
+        "lastModified": 1702855317,
+        "narHash": "sha256-5EXeUkoWvrfbZQQLVRn7Ebb9LOt3DkVm6T0M31/VhtM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7d6929828a2d28eda9d37254ff6be3b6819506ca",
+        "rev": "3a16c6447466f4034c2d75fe7014477142c9513e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
| [`6946f33a`](https://github.com/NixOS/nixpkgs/commit/6946f33a2e0666ad09aaf8eb51c31c2028c3664a) | `` luaPackages.nlua: init at 0.1 ``                                                                    |
| [`8e9d4495`](https://github.com/NixOS/nixpkgs/commit/8e9d4495c78515277aa43d579610ef3750f59e2c) | `` luarocks-packages-updater: silence some warnings ``                                                 |
| [`743225f2`](https://github.com/NixOS/nixpkgs/commit/743225f29ca80595dd3e4bc2260cc8ec70ab34b6) | `` python311Packages.markdown-it-py: set mainProgram in meta ``                                        |
| [`efd788a5`](https://github.com/NixOS/nixpkgs/commit/efd788a5e91062c421025a60d131f882fa8aaea7) | `` creduce: port to LLVM 16 ``                                                                         |
| [`eaaa8996`](https://github.com/NixOS/nixpkgs/commit/eaaa899658df154c3970b04a72aad2ff3a8cca1d) | `` photoqt: 3.4 -> 4.0.1 ``                                                                            |
| [`aa17e198`](https://github.com/NixOS/nixpkgs/commit/aa17e1989ee8af6a3549e0fd9652798516342706) | `` lomiri.lomiri-action-api: init at 1.1.2 ``                                                          |
| [`5b16aafb`](https://github.com/NixOS/nixpkgs/commit/5b16aafb00d20bcfbfbbf0814d38c3408a2eef1d) | `` yazi: add mainProgram in meta ``                                                                    |
| [`344d4e77`](https://github.com/NixOS/nixpkgs/commit/344d4e77da0abbc482025bd2da7ac069d97aaad0) | `` xyce: 7.6.0 -> 7.7.0 ``                                                                             |
| [`efccae32`](https://github.com/NixOS/nixpkgs/commit/efccae3227b37a70308da4596cfbf96d10793128) | `` gallery-dl: 1.26.3 -> 1.26.4 ``                                                                     |
| [`6ae04cdf`](https://github.com/NixOS/nixpkgs/commit/6ae04cdf6e5f40ff5d66e5d918b907410eaf92d8) | `` scala-cli: 1.0.5 -> 1.1.0 ``                                                                        |
| [`1593b234`](https://github.com/NixOS/nixpkgs/commit/1593b2344f69309768cc0b2fdbb46b96e65537bd) | `` msmtp: add meta.mainProgram ``                                                                      |
| [`6e3af659`](https://github.com/NixOS/nixpkgs/commit/6e3af659471f22f3e6c919399ce37616941f9b0e) | `` luaPackages.nvim-client: remove ``                                                                  |
| [`cbed1154`](https://github.com/NixOS/nixpkgs/commit/cbed115407d0b7d9fe2dbaaf6bd756dba3298b9c) | `` nixos/tests/nixos-rebuild-specialisations: download even more RAM ``                                |
| [`60cb6ee9`](https://github.com/NixOS/nixpkgs/commit/60cb6ee94f9a943bcbc989dd0e1ce51c26542db7) | `` nixos/tuxclocker: init module ``                                                                    |
| [`98d49cc3`](https://github.com/NixOS/nixpkgs/commit/98d49cc3265b78e8a91f3d327d225b63d843a648) | `` signal-desktop (aarch64) : 6.40.0 -> 6.42.0, signal-desktop-beta: 6.40.0-beta.2 -> 6.43.0-beta.1 `` |
| [`e778c475`](https://github.com/NixOS/nixpkgs/commit/e778c47517a9914e2f1cdfddead91bb6719e09f6) | `` xen-guest-agent: init at 0.3.0 ``                                                                   |
| [`9296ff2b`](https://github.com/NixOS/nixpkgs/commit/9296ff2b58d656a0a829a474ce895dac83e6ebff) | `` maintainers: add matdibu ``                                                                         |
| [`03eb7592`](https://github.com/NixOS/nixpkgs/commit/03eb759230f457275e3f305d3e9f9a4db2fc99b0) | `` pgmoneta: 0.7.1 -> 0.7.2 ``                                                                         |
| [`1272bba1`](https://github.com/NixOS/nixpkgs/commit/1272bba1877a9f7cfe1d4d2b62fb36b0e85bd91b) | `` kaufkauflist: 3.0.0 -> 3.1.0 ``                                                                     |
| [`61b335c4`](https://github.com/NixOS/nixpkgs/commit/61b335c4cc70e93ddb3d2f584e32d4ade2b0b0c5) | `` msolve: 0.6.1 -> 0.6.3 ``                                                                           |
| [`62f7117e`](https://github.com/NixOS/nixpkgs/commit/62f7117e7ad1634a24f8b6b755b725c43b3152dc) | `` peazip: 9.4.0 -> 9.6.0 ``                                                                           |
| [`2a3d4f9a`](https://github.com/NixOS/nixpkgs/commit/2a3d4f9afe8f49e8c29bfe38f03a8ae64f112aea) | `` alt-ergo: fix build on darwin ``                                                                    |
| [`232b3c6f`](https://github.com/NixOS/nixpkgs/commit/232b3c6fb6d1334adbc731e9fa9bfc3bc36b4e2d) | `` jmol: 16.1.45 -> 16.1.47 ``                                                                         |
| [`80e7226b`](https://github.com/NixOS/nixpkgs/commit/80e7226bdf9f1ba828bfb41e6c9909d5ec764c03) | `` mlkit: 4.7.5 -> 4.7.7 ``                                                                            |
| [`b8278523`](https://github.com/NixOS/nixpkgs/commit/b82785239528c1c874418849be63e0f98fc956ca) | `` neocmakelsp: 0.6.11 -> 0.6.17 ``                                                                    |
| [`8c605365`](https://github.com/NixOS/nixpkgs/commit/8c605365792171aad6018962f9071a9666166e4d) | `` lidarr: 1.4.5 -> 2.0.7 ``                                                                           |
| [`27ec5c33`](https://github.com/NixOS/nixpkgs/commit/27ec5c33b285661b20971e392f2aa902ceca906f) | `` lidarr: fix bug in update script ``                                                                 |
| [`91dc95c9`](https://github.com/NixOS/nixpkgs/commit/91dc95c9f9d53a7a637e845e71f3b16e6ea17e7e) | `` passes: 0.8 -> 0.9 ``                                                                               |
| [`c0bc142a`](https://github.com/NixOS/nixpkgs/commit/c0bc142aeddd878d230f05ccf959a0fbd39894cd) | `` oxigraph: 0.3.21 -> 0.3.22 ``                                                                       |
| [`468a6bab`](https://github.com/NixOS/nixpkgs/commit/468a6bab44bf370e9b55de1fd08ba9f10b396503) | `` opentofu: 1.6.0-beta4 -> 1.6.0-beta5 ``                                                             |
| [`944acd83`](https://github.com/NixOS/nixpkgs/commit/944acd831592e2eeb9f20ee893061372283ad2a6) | `` otpclient: 3.2.0 -> 3.2.1 ``                                                                        |
| [`54cf2b9d`](https://github.com/NixOS/nixpkgs/commit/54cf2b9dbef23f5b62dbfc3adf3179e6eafd974b) | `` orchard: 0.14.3 -> 0.15.0 ``                                                                        |
| [`d7b06e3b`](https://github.com/NixOS/nixpkgs/commit/d7b06e3b8226c1142d0096328d480fbdffe129fe) | `` orbiton: 2.65.6 -> 2.65.8 ``                                                                        |
| [`6582c473`](https://github.com/NixOS/nixpkgs/commit/6582c473f1908342d92159b47153c72c40bc94da) | `` zbus-xmlgen: init at 3.1.1 ``                                                                       |
| [`ff951740`](https://github.com/NixOS/nixpkgs/commit/ff95174013ca918973f54426b7f8befcd626c25a) | `` telegraf: 1.29.0 -> 1.29.1 ``                                                                       |
| [`5c22e192`](https://github.com/NixOS/nixpkgs/commit/5c22e192d9fb191e9378260851f32efe29bb0836) | `` nix-ld: restore 32-bit support ``                                                                   |
| [`0d840e3a`](https://github.com/NixOS/nixpkgs/commit/0d840e3a1496333e0e94fc89a6686dfd403f0cea) | `` nix-ld: 1.2.2 -> 1.2.3 ``                                                                           |
| [`4c501306`](https://github.com/NixOS/nixpkgs/commit/4c501306af1ab6c19491fdafebb30fd097eb42c5) | `` asn1editor: init at 0.8.0 ``                                                                        |
| [`819924bb`](https://github.com/NixOS/nixpkgs/commit/819924bbf8ee07f1e709d1d6486ff365f774dcfc) | `` soco-cli: 0.4.55 -> 0.4.73 ``                                                                       |
| [`8ba76f8d`](https://github.com/NixOS/nixpkgs/commit/8ba76f8dd46043c2928f39da7491da8b3b335f24) | `` nixos/pipewire: add pipewire config ``                                                              |
| [`a4f5ccfb`](https://github.com/NixOS/nixpkgs/commit/a4f5ccfba449c39fbc8fd0f83cf0120fc897c96c) | `` op-geth: 1.101304.0 -> 1.101304.2 ``                                                                |
| [`63437b22`](https://github.com/NixOS/nixpkgs/commit/63437b222b6162c14b7381d0a5a536f546cb11e1) | `` python311Packages.types-aiobotocore-*: 2.8.0 -> 2.9.0 ``                                            |
| [`d2458900`](https://github.com/NixOS/nixpkgs/commit/d2458900870aae0f7df6cace865ba9ca4fb9aad2) | `` root: 6.28.10 -> 6.30.02 (#274348) ``                                                               |
| [`811e7967`](https://github.com/NixOS/nixpkgs/commit/811e796739505f065dad66c9c4502eb65826ee14) | `` Initial helper to update types-aiobotocore-* ``                                                     |
| [`e85489ea`](https://github.com/NixOS/nixpkgs/commit/e85489ea5351d25e4d8d1c7121a235ad8889655b) | `` okteta: 0.26.13 -> 0.26.14 ``                                                                       |
| [`348b70d8`](https://github.com/NixOS/nixpkgs/commit/348b70d881b62973ec61ace4b2191d2403987de8) | `` mainsail: 2.8.0 -> 2.9.0 ``                                                                         |
| [`33ac45a1`](https://github.com/NixOS/nixpkgs/commit/33ac45a1e480db0092f8bf45fd09f6e25f649512) | `` ncspot: 0.13.4 -> 1.0.0 ``                                                                          |
| [`da57484f`](https://github.com/NixOS/nixpkgs/commit/da57484f2426f297d858c6b5e64c1ab1eff1450d) | `` swayfx: wrap like sway ``                                                                           |
| [`6bed76a2`](https://github.com/NixOS/nixpkgs/commit/6bed76a2a9316c288e4ac468c2ff90e5ebcc43b8) | `` sway: set version and pname attribute ``                                                            |
| [`83267ae4`](https://github.com/NixOS/nixpkgs/commit/83267ae441a5698afa0622d9e04cf45cf3582bb6) | `` sway*: move to pkgs/by-name ``                                                                      |
| [`27260c6b`](https://github.com/NixOS/nixpkgs/commit/27260c6b8aaa12727e346b770769df314df78983) | `` evcxr: 0.16.0 -> 0.17.0 ``                                                                          |
| [`2d9c3878`](https://github.com/NixOS/nixpkgs/commit/2d9c3878c95878fbc1775cf70b69c391fe81ba21) | `` clightning: 23.11 -> 23.11.1 ``                                                                     |
| [`a96dfb45`](https://github.com/NixOS/nixpkgs/commit/a96dfb45810f41a6e0f6db5a6bae8039a5927093) | `` terraform: 1.6.5 -> 1.6.6 (#274877) ``                                                              |
| [`45f63047`](https://github.com/NixOS/nixpkgs/commit/45f630473d7003402e29751f95740a4d3df21973) | `` engelsystem: 3.4.0 -> 3.4.1 ``                                                                      |
| [`71dff6fb`](https://github.com/NixOS/nixpkgs/commit/71dff6fbc606b7d37ba730c9653e82818b2f1d0c) | `` mautrix-whatsapp: 0.10.4 -> 0.10.5 ``                                                               |
| [`6a08cc6e`](https://github.com/NixOS/nixpkgs/commit/6a08cc6e1ac6fc474b5de5220dbc3ff2d9fd9360) | `` unzip: change license to info-zip ``                                                                |
| [`bf123a7e`](https://github.com/NixOS/nixpkgs/commit/bf123a7e48ed95930891c25c9d6da269e06fdcf9) | `` xdg-utils: change license to mit ``                                                                 |
| [`c6519028`](https://github.com/NixOS/nixpkgs/commit/c6519028fb91878683f305b227cb208d40a8a326) | `` zsync: change license to artistic2 ``                                                               |
| [`a70060d2`](https://github.com/NixOS/nixpkgs/commit/a70060d2e48c2583c3bbd7792f0e98ebca0186b2) | `` tribler: move license elsewhere to avoid conflict ``                                                |
| [`22ffa7b3`](https://github.com/NixOS/nixpkgs/commit/22ffa7b32e38303229659445711ca1596ef9afbb) | `` liquidsoap: 2.2.2 -> 2.2.3 ``                                                                       |
| [`df40868e`](https://github.com/NixOS/nixpkgs/commit/df40868ed63d759a3388d9123906f5a08499a3aa) | `` ockam: 0.105.0 -> 0.111.0 ``                                                                        |
| [`d5a2a642`](https://github.com/NixOS/nixpkgs/commit/d5a2a64222965f7cf9bb1df47abef3e803cddf83) | `` obs-studio-plugins.obs-vertical-canvas: 1.3.0 -> 1.3.1 ``                                           |
| [`613b6a54`](https://github.com/NixOS/nixpkgs/commit/613b6a54da63f44a0e4e8529ef93ab9689e28c78) | `` nwg-bar: 0.1.4 -> 0.1.5 ``                                                                          |
| [`4af519af`](https://github.com/NixOS/nixpkgs/commit/4af519af8431c2eb16539835e2e4e5c75fbb157d) | `` nvc: 1.11.0 -> 1.11.1 ``                                                                            |
| [`e9959bb9`](https://github.com/NixOS/nixpkgs/commit/e9959bb985be6a5e3e8f0a066389a767d7bc868d) | `` numix-icon-theme-square: 23.11.11 -> 23.12.10 ``                                                    |
| [`c728c403`](https://github.com/NixOS/nixpkgs/commit/c728c4031126b74163cd581c8c8809c31b9f0d12) | `` numix-icon-theme-circle: 23.11.11 -> 23.12.10 ``                                                    |
| [`cbf2438b`](https://github.com/NixOS/nixpkgs/commit/cbf2438b632394dca791b77f3ab9dac0792f8afa) | `` numix-icon-theme: 23.11.20 -> 23.12.02 ``                                                           |
| [`84b8d14c`](https://github.com/NixOS/nixpkgs/commit/84b8d14cd81c1f47c5e437a4003fc399be08564b) | `` noto-fonts: 23.11.1 -> 23.12.1 ``                                                                   |
| [`18c3e729`](https://github.com/NixOS/nixpkgs/commit/18c3e729ba8913ae1e2688d1ab51df6cf516b341) | `` saleae-logic-2: 2.4.12 -> 2.4.13 ``                                                                 |
| [`5496f871`](https://github.com/NixOS/nixpkgs/commit/5496f871e063a30420ff0e67cd913b930aeabed4) | `` noson: 5.6.0 -> 5.6.3 ``                                                                            |
| [`5d0dc445`](https://github.com/NixOS/nixpkgs/commit/5d0dc445db7eeda2700bb992b3b35924240d57ac) | `` nixdoc: 2.6.0 -> 2.7.0 ``                                                                           |
| [`866ddf0a`](https://github.com/NixOS/nixpkgs/commit/866ddf0a4f2edd683614c3412ea0f2e35ad6f8aa) | `` nmap-formatter: 2.1.4 -> 2.1.6 ``                                                                   |
| [`93ba9d88`](https://github.com/NixOS/nixpkgs/commit/93ba9d88222116e6d036f17506faf605ba67075d) | `` nixpacks: 1.19.0 -> 1.20.0 ``                                                                       |
| [`416c1c65`](https://github.com/NixOS/nixpkgs/commit/416c1c65aa0186c7b3590db550c8ffafdf029dae) | `` nerdctl: 1.7.1 -> 1.7.2 ``                                                                          |
| [`e65fa789`](https://github.com/NixOS/nixpkgs/commit/e65fa789bb9341776d5ad2cd476a9a40fda9c6a2) | `` neosay: 1.0.0 -> 1.0.1 ``                                                                           |
| [`3386144e`](https://github.com/NixOS/nixpkgs/commit/3386144e61d4ea13f061ee2e4cfe3e12cde24a2e) | `` navidrome: 0.50.1 -> 0.50.2 ``                                                                      |
| [`95a91f5a`](https://github.com/NixOS/nixpkgs/commit/95a91f5afc84d419b62726b4425b00fd2ffdb49e) | `` gotosocial: 0.12.2 -> 0.13.0 ``                                                                     |
| [`8888d281`](https://github.com/NixOS/nixpkgs/commit/8888d281ccb3cbec0c79f42f808ae7f7091c4ac3) | `` navi: 2.22.1 -> 2.23.0 ``                                                                           |
| [`35d45083`](https://github.com/NixOS/nixpkgs/commit/35d45083f790d4b01a6bfac9d38358737bd8ecd4) | `` libzim: 9.0.0 -> 9.1.0 ``                                                                           |
| [`2e5f9637`](https://github.com/NixOS/nixpkgs/commit/2e5f96375e553bbc897ff45a19bbb3489ec771a3) | `` nanoflann: 1.5.1 -> 1.5.3 ``                                                                        |
| [`e75f4bbb`](https://github.com/NixOS/nixpkgs/commit/e75f4bbbde5ccdaf416c1209aba2b1d0e470a356) | `` cargo-hack: 0.6.14 -> 0.6.15 ``                                                                     |
| [`3db4657b`](https://github.com/NixOS/nixpkgs/commit/3db4657ba98b1d2c60f897e78df720bb99489c06) | `` mystmd: 1.1.31 -> 1.1.36 ``                                                                         |
| [`df1b6009`](https://github.com/NixOS/nixpkgs/commit/df1b60093799f1886ffa9e000dbd14768a949396) | `` mympd: 13.0.0 -> 13.0.5 ``                                                                          |
| [`54ad786e`](https://github.com/NixOS/nixpkgs/commit/54ad786ee2d3d4faf60ad83132d7fef9551cf69f) | `` nautilus-open-in-blackbox: init at 0.1.1 ``                                                         |
| [`42c48874`](https://github.com/NixOS/nixpkgs/commit/42c488743173f766e6ec2c9b2420c7979fca12d1) | `` rqbit: 4.0.1 -> 5.4.0 ``                                                                            |
| [`f2fb73b3`](https://github.com/NixOS/nixpkgs/commit/f2fb73b39973c28ccd06189287230b1cafbee71d) | `` python310Packages.pglast: 5.5 -> 5.6 ``                                                             |
| [`77657ea7`](https://github.com/NixOS/nixpkgs/commit/77657ea73e6085b2a28ae85127e0b15997c7a203) | `` millet: 0.14.0 -> 0.14.2 ``                                                                         |
| [`f155248b`](https://github.com/NixOS/nixpkgs/commit/f155248b7bf1b3ac383dff40a9eed8de951ab545) | `` mutagen-compose: 0.17.2 -> 0.17.4 ``                                                                |
| [`30ff1b62`](https://github.com/NixOS/nixpkgs/commit/30ff1b625d8631884a901ec0d2a8bc25a7bbaa0d) | `` murex: 5.2.7610 -> 5.3.4000 ``                                                                      |
| [`f88c003d`](https://github.com/NixOS/nixpkgs/commit/f88c003dce3390d55c56f6f6ea07233ef7eb1795) | `` mimir: 2.10.4 -> 2.10.5 ``                                                                          |
| [`835c1ca5`](https://github.com/NixOS/nixpkgs/commit/835c1ca50ac6e979079bc90dc449cdada4cb4a74) | `` zpaq: enable darwin build ``                                                                        |
| [`8a9698b0`](https://github.com/NixOS/nixpkgs/commit/8a9698b0914775be8a426fe94b83d512571eb06a) | `` mullvad-vpn: 2023.5 -> 2023.6 ``                                                                    |
| [`bda2181c`](https://github.com/NixOS/nixpkgs/commit/bda2181c288a1c0d1c38ec90c8d91f88129afd81) | `` mount-zip: 1.0.11 -> 1.0.12 ``                                                                      |
| [`bc799672`](https://github.com/NixOS/nixpkgs/commit/bc799672810c25dd41ca69531d455ed856815c72) | `` geant4: 11.1.3 -> 11.2.0 (#274661) ``                                                               |
| [`b5e5520a`](https://github.com/NixOS/nixpkgs/commit/b5e5520a6b35287434e0ea632ab43feda98f5af0) | `` monkeysAudio: 10.28 -> 10.30 ``                                                                     |
| [`03978164`](https://github.com/NixOS/nixpkgs/commit/0397816476b11816dcfebcda57d8278bf9133efc) | `` mommy: 1.2.4 -> 1.2.6 ``                                                                            |
| [`48391483`](https://github.com/NixOS/nixpkgs/commit/483914836cfe4f1f5902a95967cfb7bc0cf65fb2) | `` mod: 0.7.0 -> 0.7.1 ``                                                                              |
| [`c4be56b2`](https://github.com/NixOS/nixpkgs/commit/c4be56b2fe0435c70956aa67a3449f9191a65c82) | `` llvmPackages_latest: 16.0.6 -> 17.0.6 ``                                                            |
| [`63c7c3b7`](https://github.com/NixOS/nixpkgs/commit/63c7c3b74ceab9d29bf11f7f3bf5b83dc8c0eba0) | `` patool: fix build on darwin ``                                                                      |
| [`15be6a54`](https://github.com/NixOS/nixpkgs/commit/15be6a54ec029b09b280884a95bed7db380e7d86) | `` zpaq: add darwin support ``                                                                         |
| [`434c8b89`](https://github.com/NixOS/nixpkgs/commit/434c8b89d4952f79c9ea6f1c2d6e66e00bb14bef) | `` espanso: fix build on darwin ``                                                                     |
| [`36182fca`](https://github.com/NixOS/nixpkgs/commit/36182fcaa526300d2cd6729f538212f0d05cbf75) | `` miniaudio: 0.11.20 -> 0.11.21 ``                                                                    |
| [`983f9e0b`](https://github.com/NixOS/nixpkgs/commit/983f9e0b4bff87bb36957937c9dbf9b7c4d8bc93) | `` vinegar: add segrevert patch for wine 9.0-rc1-staging ``                                            |
| [`99bebfa4`](https://github.com/NixOS/nixpkgs/commit/99bebfa4348126072093baf07727fbf0ee855dc0) | `` kdiff3: 1.10.6 -> 1.10.7 ``                                                                         |