### PR TITLE
chore(flake/nur): `784c8293` -> `a986d4b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -536,11 +536,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702888842,
-        "narHash": "sha256-QNmsOTMLHJYY03zf7GpnMo5idHFqZyi2rZxgGx+800c=",
+        "lastModified": 1702945779,
+        "narHash": "sha256-r56B8tUppjKOdA+r2NEk5Q3/Kef7U3SeGWTC0wWVttw=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "784c8293dc4f19f89a812f6d745aff28d47d24d9",
+        "rev": "a986d4b19eb2436c3bebb7d05a755b5786ee9993",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                    |
| -------------------------------------------------------------------------------------------------- | -------------------------- |
| [`a986d4b1`](https://github.com/nix-community/NUR/commit/a986d4b19eb2436c3bebb7d05a755b5786ee9993) | `` automatic update ``     |
| [`e3f15013`](https://github.com/nix-community/NUR/commit/e3f15013fb1597e3cf88325f93035bfc7c4dc129) | `` automatic update ``     |
| [`12386cbc`](https://github.com/nix-community/NUR/commit/12386cbc26ffc94b73ace5f47e6b640674862544) | `` automatic update ``     |
| [`d8d0a4bd`](https://github.com/nix-community/NUR/commit/d8d0a4bdc7b0eb5562df998a7c95ead6780afb00) | `` automatic update ``     |
| [`47bcf66a`](https://github.com/nix-community/NUR/commit/47bcf66a01c7ec97477f10bbc247c54856f4fc5b) | `` add endle repository `` |
| [`36b62d63`](https://github.com/nix-community/NUR/commit/36b62d6324a6aa28487cc45e369e3789e25a0df6) | `` automatic update ``     |
| [`a29569e0`](https://github.com/nix-community/NUR/commit/a29569e000b9f81ade1dc408a20bfaf26fa7bedb) | `` automatic update ``     |
| [`f1427666`](https://github.com/nix-community/NUR/commit/f1427666b27e98e3852748dacbdc41f2586aa194) | `` automatic update ``     |
| [`b8868a0b`](https://github.com/nix-community/NUR/commit/b8868a0bd4b1c4e86111ecaafbef8c5695138e8f) | `` automatic update ``     |
| [`5d62db85`](https://github.com/nix-community/NUR/commit/5d62db8546cf2cade0992be6d7a3878f3a88a4b2) | `` automatic update ``     |
| [`4561fa27`](https://github.com/nix-community/NUR/commit/4561fa27240f2b30aeb1bfdc27162a32b77b0b8d) | `` automatic update ``     |
| [`e0a66087`](https://github.com/nix-community/NUR/commit/e0a6608756107b312ca46eb0920639c6a78a8fd1) | `` automatic update ``     |
| [`5eb36fd2`](https://github.com/nix-community/NUR/commit/5eb36fd2d32f43177896e8dd5a7ba134d3d5e949) | `` automatic update ``     |