### PR TITLE
chore(flake/nur): `a986d4b1` -> `d63d8a56`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -548,11 +548,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1702945779,
-        "narHash": "sha256-r56B8tUppjKOdA+r2NEk5Q3/Kef7U3SeGWTC0wWVttw=",
+        "lastModified": 1703028230,
+        "narHash": "sha256-7i04yJU/xbexLKJ0BggD1Xjx1qKApgdaVRp72RQ0qQg=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "a986d4b19eb2436c3bebb7d05a755b5786ee9993",
+        "rev": "d63d8a56df30124ebbf1b746a68fa1fe232e1a3c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`d63d8a56`](https://github.com/nix-community/NUR/commit/d63d8a56df30124ebbf1b746a68fa1fe232e1a3c) | `` automatic update `` |
| [`708a3cce`](https://github.com/nix-community/NUR/commit/708a3ccec178943b779b86e9f483fdc4fd75fee7) | `` automatic update `` |
| [`613dcbe6`](https://github.com/nix-community/NUR/commit/613dcbe6a9fb7b24910b28a866e6f8d340106a84) | `` automatic update `` |
| [`b495f967`](https://github.com/nix-community/NUR/commit/b495f96757696e896c541c7a3a69ca03d44ddae7) | `` automatic update `` |
| [`0b435607`](https://github.com/nix-community/NUR/commit/0b435607a86979ec23cbc6db39a1f7be5aad2276) | `` automatic update `` |
| [`3df75c48`](https://github.com/nix-community/NUR/commit/3df75c4890e142d2e4a25ea714eb364e3f770be7) | `` automatic update `` |
| [`a2439029`](https://github.com/nix-community/NUR/commit/a24390291a1e7ee106efc45fb84ab9aa00dbbd6e) | `` automatic update `` |
| [`5d091c37`](https://github.com/nix-community/NUR/commit/5d091c377eec89a596767b44cecf0813ace9e49a) | `` automatic update `` |
| [`b71756cd`](https://github.com/nix-community/NUR/commit/b71756cd7af7ae3b552d78fc42f1a9b7e8e5b917) | `` automatic update `` |
| [`a04eea76`](https://github.com/nix-community/NUR/commit/a04eea76ecdc42258fc3ed8391ba838145d0b96a) | `` automatic update `` |
| [`323e61a2`](https://github.com/nix-community/NUR/commit/323e61a2ca46ff0214f7b9aca70c28ad5ab20d3e) | `` automatic update `` |
| [`4b24bd5f`](https://github.com/nix-community/NUR/commit/4b24bd5f1f5fed16415f1031e3416a5e3342f19f) | `` automatic update `` |
| [`8f526594`](https://github.com/nix-community/NUR/commit/8f5265940d1c9f28cb55db6e1152e5dc2cc1a684) | `` automatic update `` |
| [`3ed287ae`](https://github.com/nix-community/NUR/commit/3ed287ae9ed76f5fae0f779b945561752951e272) | `` automatic update `` |
| [`ca61de8f`](https://github.com/nix-community/NUR/commit/ca61de8f2817c3e0ec1b7fabedb0617af3c05cf9) | `` automatic update `` |
| [`5d9b8f02`](https://github.com/nix-community/NUR/commit/5d9b8f0252da52ba5036af80fdecd0b72da38ef1) | `` automatic update `` |
| [`dea8ad34`](https://github.com/nix-community/NUR/commit/dea8ad34457611766f67dadd7c3db93297b15c1b) | `` automatic update `` |
| [`7d882745`](https://github.com/nix-community/NUR/commit/7d882745d7037597c0f44f3675d7ef5d459ddd24) | `` automatic update `` |
| [`0202de1e`](https://github.com/nix-community/NUR/commit/0202de1e4f429b6595dcc62b08cff04acd53fe17) | `` automatic update `` |
| [`06f325fc`](https://github.com/nix-community/NUR/commit/06f325fc281e404efda68baa45246ebc8a9e961b) | `` automatic update `` |
| [`0e217c8e`](https://github.com/nix-community/NUR/commit/0e217c8e4c1ab0af232aac3c82c35c2aef6570e8) | `` automatic update `` |
| [`e83fd566`](https://github.com/nix-community/NUR/commit/e83fd566c5a7683d3e0dfcb34b9a178ff4e6ea2b) | `` automatic update `` |
| [`a91d9315`](https://github.com/nix-community/NUR/commit/a91d931519972df2ebb143ea0d6d08d2e34548b3) | `` automatic update `` |
| [`ca0d61f1`](https://github.com/nix-community/NUR/commit/ca0d61f10724f603723d6feb303c64a585b618b1) | `` automatic update `` |