### PR TITLE
chore(flake/nixpkgs): `3a16c644` -> `fa5e0f2e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -532,11 +532,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1702855317,
-        "narHash": "sha256-5EXeUkoWvrfbZQQLVRn7Ebb9LOt3DkVm6T0M31/VhtM=",
+        "lastModified": 1702987609,
+        "narHash": "sha256-m2hErow1pxz2KcpCH0LGykgf/LVy9tOkXnNOnssDBmw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3a16c6447466f4034c2d75fe7014477142c9513e",
+        "rev": "fa5e0f2ed065dd00cfa0347c1421b67da6a5a10e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`33308800`](https://github.com/NixOS/nixpkgs/commit/333088006cc26591250fd1e2b8cc972855aa9c4b) | `` pkgsLLVM.llvmPackages.compiler-rt: fix for RISC-V ``                    |
| [`8b5ecc55`](https://github.com/NixOS/nixpkgs/commit/8b5ecc55e1801f3db13bde4d558c9a4a572530b0) | `` clang-tools: 14.0.6 -> 16.0.6 ``                                        |
| [`c4b3e4f5`](https://github.com/NixOS/nixpkgs/commit/c4b3e4f5f89b2d5a96a0280e81eaa880c91b075a) | `` dbus-broker: avoid errors when reloading when /tmp got remounted ``     |
| [`8cdf0312`](https://github.com/NixOS/nixpkgs/commit/8cdf03122ff68f0ea72b8f5f357b9ce627c1ad65) | `` nix-direnv: 3.0.0 -> 3.0.1 ``                                           |
| [`18e9441d`](https://github.com/NixOS/nixpkgs/commit/18e9441d06e3323c328220fb555c7949951a1b7f) | `` dbus-broker: 33 -> 34 ``                                                |
| [`f12cc4da`](https://github.com/NixOS/nixpkgs/commit/f12cc4da785c2c9952c013aff65f43ab18faa3cd) | `` kubedog: 0.9.12 -> 0.10.0 ``                                            |
| [`dce218f4`](https://github.com/NixOS/nixpkgs/commit/dce218f4f35440622d2056f93ddc335351763bb4) | `` python310Packages.enlighten: 1.12.2 -> 1.12.3 ``                        |
| [`12fc644d`](https://github.com/NixOS/nixpkgs/commit/12fc644daf90c7b5d96185ef328a4fdea0d5ccba) | `` plantuml: 1.2023.12 -> 1.2023.13 ``                                     |
| [`972626f1`](https://github.com/NixOS/nixpkgs/commit/972626f1422fbdfa9be799c97a83fd30c5de5d90) | `` mopidy: make service wait until system is online ``                     |
| [`5a57cde1`](https://github.com/NixOS/nixpkgs/commit/5a57cde1105ddfaa1f24d5661f74adbd8787ce6d) | `` nixos/systemd/initrd: add systemd-makefs unconditionally ``             |
| [`52b1e193`](https://github.com/NixOS/nixpkgs/commit/52b1e193034abec02eb3cf3c6e0e2bfeda8f1b8d) | `` path-of-building.data: 2.38.0 -> 2.38.2 ``                              |
| [`fa4741ec`](https://github.com/NixOS/nixpkgs/commit/fa4741ecb52244c36b8d237df5a692e4e2b6aa13) | `` python310Packages.fastembed: 0.1.1 -> 0.1.2 ``                          |
| [`49f9ceb4`](https://github.com/NixOS/nixpkgs/commit/49f9ceb4f71274bb25bfdd54f3974115d40d647c) | `` maintainer-list: drop gm6k ``                                           |
| [`cdbfd046`](https://github.com/NixOS/nixpkgs/commit/cdbfd046bffaf2a61ae1b9ef6aecb68fb6b312ec) | `` ollama: 0.1.11 -> 0.1.17 ``                                             |
| [`8b522701`](https://github.com/NixOS/nixpkgs/commit/8b52270180c947ed2d2cf5c1f3815f52670927a0) | `` python310Packages.farm-haystack: 1.22.1 -> 1.23.0 ``                    |
| [`e4a8fef4`](https://github.com/NixOS/nixpkgs/commit/e4a8fef4ab57588c36cb974a1b3717409bef2314) | `` python310Packages.edk2-pytool-library: 0.19.6 -> 0.19.8 ``              |
| [`24770ef3`](https://github.com/NixOS/nixpkgs/commit/24770ef35f74380a49938975a8f5410e7aea7ca8) | `` python310Packages.dvclive: 3.3.1 -> 3.4.1 ``                            |
| [`19a8f086`](https://github.com/NixOS/nixpkgs/commit/19a8f0868aa93ce18150bad16b3c6a482659695b) | `` python310Packages.dvc-studio-client: 0.17.0 -> 0.18.0 ``                |
| [`94e3fd7a`](https://github.com/NixOS/nixpkgs/commit/94e3fd7aac9080078868f99e0ce1a6abea5a0a5c) | `` python310Packages.dvc-data: 2.24.0 -> 3.0.1 ``                          |
| [`517916e9`](https://github.com/NixOS/nixpkgs/commit/517916e94f7d588929db327634a027fd9c99c851) | `` vsmtp: drop as upstream has gone ``                                     |
| [`cea1ae36`](https://github.com/NixOS/nixpkgs/commit/cea1ae3633c1cffba0a43e2ca057d03afff9ac0d) | `` argos: unstable-20230404 → unstable-2023-09-26 ``                       |
| [`b25b7d9e`](https://github.com/NixOS/nixpkgs/commit/b25b7d9e40d1cc24b7b79ad728d5fcb0a38fdf3e) | `` lomiri.lomiri-download-manager: init at 0.1.2 ``                        |
| [`09aa95a7`](https://github.com/NixOS/nixpkgs/commit/09aa95a74efc9b018307a3a5160a61121d0849fc) | `` python310Packages.djangoql: 0.17.1 -> 0.18.0 ``                         |
| [`dfb1eeb6`](https://github.com/NixOS/nixpkgs/commit/dfb1eeb6203f1f5717bad06cba0c5feed74f0b52) | `` python310Packages.botorch: 0.9.4 -> 0.9.5 ``                            |
| [`fc4e60a5`](https://github.com/NixOS/nixpkgs/commit/fc4e60a5214a22be6086c25cc601bfedf4da6cb8) | `` vulkan-tools-lunarg: add qt5 ``                                         |
| [`640831bf`](https://github.com/NixOS/nixpkgs/commit/640831bf79564a52b1b7108af1221621642a1dc9) | `` python310Packages.django-rq: 2.9.0 -> 2.10.1 ``                         |
| [`c597e026`](https://github.com/NixOS/nixpkgs/commit/c597e026873894d69e3661d4a335f7321c8841e7) | `` protoc-gen-rust-grpc: init at 0.8.3 ``                                  |
| [`c9df5dba`](https://github.com/NixOS/nixpkgs/commit/c9df5dbaec08a3167838321c596621f47f0dd564) | `` python310Packages.django-ipware: 6.0.1 -> 6.0.3 ``                      |
| [`ea960719`](https://github.com/NixOS/nixpkgs/commit/ea960719b48c581b2061de7e34cdf8646c2c9248) | `` signald: Add xargs and sed dependencies to wrapper ``                   |
| [`0bac154c`](https://github.com/NixOS/nixpkgs/commit/0bac154c969c7f65434e8106db513f1cc2a5a400) | `` sqlboiler: refactor ``                                                  |
| [`3e4e8411`](https://github.com/NixOS/nixpkgs/commit/3e4e8411244ca4e3969ab71deeff33330634b53a) | `` python311Packages.acquire: 3.10 -> 3.11 ``                              |
| [`994fc1f9`](https://github.com/NixOS/nixpkgs/commit/994fc1f931869d8c01096ee5099141c6f87c04ef) | `` python311Packages.dissect-target: 3.13 -> 3.14 ``                       |
| [`5ca627ad`](https://github.com/NixOS/nixpkgs/commit/5ca627ad2b43c104d6d9960106bf918fe93ae3ca) | `` python311Packages.dissect-util: 3.12 -> 3.13 ``                         |
| [`10380ec4`](https://github.com/NixOS/nixpkgs/commit/10380ec4b06a4c2ef179a78942d72ca3becd04b9) | `` osu-lazer: 2023.1026.0 -> 2023.1218.1 ``                                |
| [`39c3f5fe`](https://github.com/NixOS/nixpkgs/commit/39c3f5fe38844ff7521741967fcb5706084931b1) | `` osu-lazer-bin: 2023.1130.0 -> 2023.1218.1 ``                            |
| [`27582799`](https://github.com/NixOS/nixpkgs/commit/27582799515ded5ad7cf9255de32cae0ef452f24) | `` python310Packages.dissect-extfs: 3.6 -> 3.7 ``                          |
| [`e2a49d95`](https://github.com/NixOS/nixpkgs/commit/e2a49d958215321048bd0dac8efbae07417cb626) | `` python310Packages.dissect-esedb: 3.9 -> 3.10 ``                         |
| [`501585ea`](https://github.com/NixOS/nixpkgs/commit/501585eac1b1de29a2747490d722d02f0951c0f6) | `` obs-studio-plugins.wlrobs: remove self as maintainer ``                 |
| [`1eb75826`](https://github.com/NixOS/nixpkgs/commit/1eb75826beb297ffc9800c2673ae3f9a7b8555bb) | `` obs-studio: remove self as maintainer ``                                |
| [`a18f2d40`](https://github.com/NixOS/nixpkgs/commit/a18f2d4085e48ed84233aabe3c7ab54b0efd7a96) | `` python310Packages.dissect: 3.10 -> 3.11 ``                              |
| [`63c77c23`](https://github.com/NixOS/nixpkgs/commit/63c77c2361cd1cb27a8566b1dffa2a626fc79a08) | `` python311Packages.qingping-ble: 0.8.2 -> 0.9.0 ``                       |
| [`bdd67c91`](https://github.com/NixOS/nixpkgs/commit/bdd67c91f25dfa977152fd9c15dfe9c0b9a68aef) | `` python311Packages.aiodiscover: 1.5.1 -> 1.6.0 ``                        |
| [`2592a670`](https://github.com/NixOS/nixpkgs/commit/2592a6704ef820f60b2c7c41037e508a9d14a252) | `` python311Packages.cached-ipaddress: init at 0.3.0 ``                    |
| [`15a64317`](https://github.com/NixOS/nixpkgs/commit/15a643171de00bfcfba1d061e4ca62b1d2c4d15b) | `` xwayland-run: init at 0.0.2 ``                                          |
| [`8ea50098`](https://github.com/NixOS/nixpkgs/commit/8ea5009875e9901b56a2cfbb97ba0514c4a6c0d8) | `` gcfflasher: set platforms ``                                            |
| [`0ea45cd1`](https://github.com/NixOS/nixpkgs/commit/0ea45cd17b9454344e86473a1743d1239360d628) | `` gcfflasher: 4.0.3-beta -> 4.3.0-beta ``                                 |
| [`aaae1b52`](https://github.com/NixOS/nixpkgs/commit/aaae1b52a3c2f20e53025228a893f1303f81ced1) | `` ktls-utils: init at 0.10 ``                                             |
| [`40f39e81`](https://github.com/NixOS/nixpkgs/commit/40f39e8117c83dea7ebab68e121d4f31528bb293) | `` python311Packages.bluetooth-adapters: 0.16.1 -> 0.16.2 ``               |
| [`246e1de3`](https://github.com/NixOS/nixpkgs/commit/246e1de302454d98646285098ce044b1a4d1bf95) | `` python311Packages.bleak-esphome: 0.3.0 -> 0.4.0 ``                      |
| [`3128cd73`](https://github.com/NixOS/nixpkgs/commit/3128cd737c7f7558a90f6c1b622fa58bd7540ab2) | `` python311Packages.pyasuswrt: 0.1.20 -> 0.1.21 ``                        |
| [`b774d4b3`](https://github.com/NixOS/nixpkgs/commit/b774d4b3735965279d8a9f23ab6ab5ae90af1f92) | `` python311Packages.reolink-aio: 0.8.2 -> 0.8.4 ``                        |
| [`b2ea24e5`](https://github.com/NixOS/nixpkgs/commit/b2ea24e59c0007dd065b808e36d4fc1ae4ccfb8e) | `` python311Packages.blinkpy: 0.22.3 -> 0.22.4 ``                          |
| [`c7cb02a4`](https://github.com/NixOS/nixpkgs/commit/c7cb02a4359fb58dc03b66897b24b8fa8d11dc75) | `` python311Packages.motionblinds: 0.6.18 -> 0.6.19 ``                     |
| [`7a1b958d`](https://github.com/NixOS/nixpkgs/commit/7a1b958d069fb54ed017920578be599ee417520e) | `` python311Packages.opower: 0.0.41 -> 0.1.0 ``                            |
| [`432b9bd6`](https://github.com/NixOS/nixpkgs/commit/432b9bd6208071be5035efa7e275f906f252861c) | `` nixos/firmware: Omit removed rtl8723-bs package ``                      |
| [`57c4009c`](https://github.com/NixOS/nixpkgs/commit/57c4009cfdb03dd1fb426af4fa8046e2563a6469) | `` python310Packages.dataprep-ml: 0.0.20 -> 0.0.21 ``                      |
| [`51f5b7df`](https://github.com/NixOS/nixpkgs/commit/51f5b7df9723b09c1fbab48846bacb793a2a45c4) | `` syn2mas: init at 0.7.0 ``                                               |
| [`b69c7344`](https://github.com/NixOS/nixpkgs/commit/b69c73444956b5386a5b029f0cf6b5ff1112b9cf) | `` gitlab-runner: 16.6.0 -> 16.6.1 (#274415) ``                            |
| [`b9704019`](https://github.com/NixOS/nixpkgs/commit/b9704019c99bfa358712debe86d91d3fe58d442d) | `` cgal_4: 4.14.2 → 4.14.3 ``                                              |
| [`1791eeb7`](https://github.com/NixOS/nixpkgs/commit/1791eeb7bd782b49b33998fa9152710f4117ffc2) | `` cgal: default to version 5 ``                                           |
| [`59302f4a`](https://github.com/NixOS/nixpkgs/commit/59302f4a91eb5dc408587a911dac56fc3354fb41) | `` python311Packages.auth0-python: update disabled ``                      |
| [`442e1ea3`](https://github.com/NixOS/nixpkgs/commit/442e1ea3990c7371f256cfcab66d8039f5539e76) | `` python311Packages.aioconsole: refactor ``                               |
| [`3998c003`](https://github.com/NixOS/nixpkgs/commit/3998c00333767542639d3d9ca0586847d9181aea) | `` python310Packages.cryptoparser: 0.12.0 -> 0.12.1 ``                     |
| [`635bd604`](https://github.com/NixOS/nixpkgs/commit/635bd604b6cc51f7e1be8f864e0ae0a2b068da49) | `` python310Packages.cryptolyzer: 0.12.0 -> 0.12.1 ``                      |
| [`8de14f52`](https://github.com/NixOS/nixpkgs/commit/8de14f527765f885635e15524181dd2d97a620b4) | `` python310Packages.crc: 5.0.0 -> 6.0.0 ``                                |
| [`a0f94525`](https://github.com/NixOS/nixpkgs/commit/a0f94525b0c387c9e311031873b3d4d33ab5d204) | `` julia docs: one line per sentence ``                                    |
| [`f54152d2`](https://github.com/NixOS/nixpkgs/commit/f54152d2a509df6f6e4c9852baf25113f857c086) | `` python311Packages.censys: refactor ``                                   |
| [`8e0593cc`](https://github.com/NixOS/nixpkgs/commit/8e0593ccf348a835335ed644af69160e6c16ca90) | `` zsh-powerlevel10k: avoid importing `pkgs` ``                            |
| [`fd439a46`](https://github.com/NixOS/nixpkgs/commit/fd439a461855108ca3d6e4399732c88739f4d51c) | `` zsh-powerlevel10k: make imports more diff friendly ``                   |
| [`73f58904`](https://github.com/NixOS/nixpkgs/commit/73f58904034cecc77f429ee8aa0baa59f1d49466) | `` python310Packages.confight: 1.3.1 -> 2.0 ``                             |
| [`9bf1b596`](https://github.com/NixOS/nixpkgs/commit/9bf1b596d6ac72af6a4785fea8dff272eb7b7f50) | `` python310Packages.clickhouse-connect: 0.6.21 -> 0.6.23 ``               |
| [`8f0649c7`](https://github.com/NixOS/nixpkgs/commit/8f0649c7ae8c555b8034eed3e41889380d953f6d) | `` python310Packages.clarifai-grpc: 9.10.6 -> 9.11.2 ``                    |
| [`9e11ec57`](https://github.com/NixOS/nixpkgs/commit/9e11ec57b9957ba37a38a293ac34fc3891657f8e) | `` python310Packages.clarifai: 9.10.4 -> 9.11.0 ``                         |
| [`b9e4b87e`](https://github.com/NixOS/nixpkgs/commit/b9e4b87e32206c597e5043a9d8edd8ce1c7fec25) | `` cinnamon.xreader: 3.8.4 -> 4.0.0 ``                                     |
| [`ae8dc824`](https://github.com/NixOS/nixpkgs/commit/ae8dc8248110973e15a16fdf179f34b05889b5b7) | `` python311Packages.aioambient: refactor ``                               |
| [`6430b7a1`](https://github.com/NixOS/nixpkgs/commit/6430b7a181ddbe4774da00b30df9cf35d37ada30) | `` nixos/prometheus-sabnzbd-exporter: use LoadCredential for apiKeyFile `` |
| [`8a61def1`](https://github.com/NixOS/nixpkgs/commit/8a61def159502f5d5d0e351bbd43fc20010122ae) | `` indi-full: 2.0.3 -> 2.0.5 ``                                            |
| [`dfe67681`](https://github.com/NixOS/nixpkgs/commit/dfe67681d9299aca1174a5a4828cc446a02cfdda) | `` python310Packages.adafruit-platformdetect: refactor ``                  |
| [`5b31bfe1`](https://github.com/NixOS/nixpkgs/commit/5b31bfe1da7194266139c3da433f202b81e3ac9e) | `` indi-firmware: 2.0.3 -> 2.0.5 ``                                        |
| [`cdb27134`](https://github.com/NixOS/nixpkgs/commit/cdb271343f0c7443a5dd8aa8cbd2878f3aaae08b) | `` python310Packages.aiovodafone: refactor ``                              |
| [`bd1f27b9`](https://github.com/NixOS/nixpkgs/commit/bd1f27b9b3a614b1227ba444c81070aebf836c66) | `` indilib: 2.0.3 -> 2.0.5 ``                                              |
| [`c75a348b`](https://github.com/NixOS/nixpkgs/commit/c75a348b43f69dfb5f6d50597a672ee1f2b67734) | `` python310Packages.censys: 2.2.9 -> 2.2.10 ``                            |
| [`8372ba53`](https://github.com/NixOS/nixpkgs/commit/8372ba53e80eb4965e36dc3884d3cc30b2d64f51) | `` broot: 1.30.0 -> 1.30.1 ``                                              |
| [`f4ae825d`](https://github.com/NixOS/nixpkgs/commit/f4ae825dc2038af9892cca32a6bdc9473b2228d8) | `` lightdm-slick-greeter: 2.0.1 -> 2.0.2 ``                                |
| [`1d2d308e`](https://github.com/NixOS/nixpkgs/commit/1d2d308e2e25d5a5c38a2b44d4d2d4fe83416a0a) | `` avogadro2: 1.97.0 -> 1.98.1 ``                                          |
| [`817612c1`](https://github.com/NixOS/nixpkgs/commit/817612c13a0da4b3925a0d6776cb1dfb15ed4fdd) | `` avogadrolibs: 1.97.0 -> 1.98.1 ``                                       |
| [`da1f5eab`](https://github.com/NixOS/nixpkgs/commit/da1f5eab0f6014d30fcaf0ab8eaf6b2fe88a8b15) | `` molequeue: cmake fixes ``                                               |