### PR TITLE
chore(flake/chaotic): `3662460d` -> `d496c55f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1702931339,
-        "narHash": "sha256-3vm4Iw2acyjfG9hNYQGioZ52w1Si2oFig4m6TlWU1sc=",
+        "lastModified": 1703014225,
+        "narHash": "sha256-xoRLzXQ1v2ct9hX8leq+r+2z48SjcFiw99V/byA29Sw=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "3662460dde402c02a6ca2ea3a073af01e9e85a0b",
+        "rev": "d496c55f7c6a3b7e00ba7e3c3a426799f11748db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                               |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`d496c55f`](https://github.com/chaotic-cx/nyx/commit/d496c55f7c6a3b7e00ba7e3c3a426799f11748db) | `` Bump 20231219-2 (#495) ``                          |
| [`5c29c53b`](https://github.com/chaotic-cx/nyx/commit/5c29c53b19400faa54ca1ee319e754a54dfe4e87) | `` ci/full-bump: allow skipping building sometimes `` |
| [`6930a843`](https://github.com/chaotic-cx/nyx/commit/6930a843c0407d316e7742a0ae3ab297682fde05) | `` Bump 20231219-1 (#494) ``                          |
| [`3391b144`](https://github.com/chaotic-cx/nyx/commit/3391b144d23845501a3b0bb415248e5efda4865f) | `` nixpkgs: bump to 20231219 ``                       |