### PR TITLE
chore(flake/nur): `d63d8a56` -> `cc008520`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -548,11 +548,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703028230,
-        "narHash": "sha256-7i04yJU/xbexLKJ0BggD1Xjx1qKApgdaVRp72RQ0qQg=",
+        "lastModified": 1703045478,
+        "narHash": "sha256-oBRcJulvYtXoAGXR/9E/SI8pMUiYRjuh6ahwGW0I2KY=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "d63d8a56df30124ebbf1b746a68fa1fe232e1a3c",
+        "rev": "cc0085209a3d80939926f623ce03491e175126ea",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cc008520`](https://github.com/nix-community/NUR/commit/cc0085209a3d80939926f623ce03491e175126ea) | `` automatic update `` |
| [`048e584a`](https://github.com/nix-community/NUR/commit/048e584a141528a23afd6f766f4eba3e1b86c4c3) | `` automatic update `` |
| [`e6c1cb82`](https://github.com/nix-community/NUR/commit/e6c1cb825ecb0e9b22d1fd1e7951283d4bb11bb3) | `` automatic update `` |
| [`bd0d1ee7`](https://github.com/nix-community/NUR/commit/bd0d1ee76ad572396fa2f24472cb2912f2172703) | `` automatic update `` |
| [`3878f144`](https://github.com/nix-community/NUR/commit/3878f144cfd520006706955f8c34cae696dbda31) | `` automatic update `` |
| [`eb093e7b`](https://github.com/nix-community/NUR/commit/eb093e7bd7df6824eadeb7b54a71da08574b834a) | `` automatic update `` |
| [`7d10cd42`](https://github.com/nix-community/NUR/commit/7d10cd423b547844845673cd2325ff6a1b095e9f) | `` automatic update `` |
| [`94757c76`](https://github.com/nix-community/NUR/commit/94757c76440dfe1590ca912e1729c52445b2d94e) | `` automatic update `` |
| [`6b4cc234`](https://github.com/nix-community/NUR/commit/6b4cc234fe24b71b22b2f1509f80d9e8e45426c6) | `` automatic update `` |