### PR TITLE
chore(flake/home-manager): `e9b9ecef` -> `efc177c1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -247,11 +247,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702735279,
-        "narHash": "sha256-SztEzDOE/6bDNnWWvnRbSHPVrgewLwdSei1sxoZFejM=",
+        "lastModified": 1703026685,
+        "narHash": "sha256-AkualfMbc40HkDR2AZc6u71pcap50wDQOXFCY1ULDUA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "e9b9ecef4295a835ab073814f100498716b05a96",
+        "rev": "efc177c15f2a8bb063aeb250fe3c7c21e1de265e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`efc177c1`](https://github.com/nix-community/home-manager/commit/efc177c15f2a8bb063aeb250fe3c7c21e1de265e) | `` sapling: add module ``                                |
| [`ebeeef94`](https://github.com/nix-community/home-manager/commit/ebeeef94ab0cba72ca3b3a89b98658dcc1296c11) | `` docs: fix typo in nix-flakes.md ``                    |
| [`e8aaced7`](https://github.com/nix-community/home-manager/commit/e8aaced73ebaf6bfa8e3c6ab0a19cb184bc4d798) | `` home-manager: sort list packages output ``            |
| [`e4dba0bd`](https://github.com/nix-community/home-manager/commit/e4dba0bd01956170667458be7b45f68170a63651) | `` docs: set the manual version to "24.05 (unstable)" `` |
| [`a2e592cc`](https://github.com/nix-community/home-manager/commit/a2e592cc49850f32b59d0ab2a66ae0871f525c65) | `` home-manager: improve nix profile detection ``        |
| [`c22b41f0`](https://github.com/nix-community/home-manager/commit/c22b41f006d4c66d183d1e8baaca4b8f48062979) | `` docs: fix broken link text ``                         |
| [`59c15ebe`](https://github.com/nix-community/home-manager/commit/59c15ebe3df602432cff8454a4918465dd05c9d9) | `` docs: fix link texts in release notes ``              |