### PR TITLE
chore(flake/hyprland): `d9b74ff9` -> `79f3888b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -271,11 +271,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1702986956,
-        "narHash": "sha256-HSXyJxXKqDqaAVoJhvbA+u8iDLS/TuCD6+w4eDqMIeI=",
+        "lastModified": 1703112892,
+        "narHash": "sha256-jCE0cUG/knifhUnkdEffuBRQ/KfPkuDVT4EYvjB2D/0=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "d9b74ff96b3e3f0341a386451b9a3375b6f05503",
+        "rev": "79f3888b4bd9796850189ed3e151a6c831e6faae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                           |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------- |
| [`79f3888b`](https://github.com/hyprwm/Hyprland/commit/79f3888b4bd9796850189ed3e151a6c831e6faae) | `` signal: fix invalid pointer access (#4207) ``                  |
| [`4eb42fab`](https://github.com/hyprwm/Hyprland/commit/4eb42fab7bb1b1d6c8fec4682c8c1de6dca7049b) | `` windowrules: add onworkspace ``                                |
| [`48ecb13b`](https://github.com/hyprwm/Hyprland/commit/48ecb13b14d99241725a65582edf42cd51843e94) | `` renderer: improve cursor hiding infra ``                       |
| [`a197fe3c`](https://github.com/hyprwm/Hyprland/commit/a197fe3c11d5ac095bf8e2f491edf28bde9f9b49) | `` renderer: don't set surfaces on cursor timeout ``              |
| [`53c78ab9`](https://github.com/hyprwm/Hyprland/commit/53c78ab90676ebd8034950a7573137921f875177) | `` idle: notify idle on tablet inputs (#4201) ``                  |
| [`b4f4bd38`](https://github.com/hyprwm/Hyprland/commit/b4f4bd38e8a0d9afd30231cf999e73548bef5760) | `` configmanager: set a limit to config variable substitutions `` |
| [`d1b8a63a`](https://github.com/hyprwm/Hyprland/commit/d1b8a63a8ef1d7258d49854d2256fa9b99fd99bc) | `` input: allow setting cursor even if it's hidden ``             |
| [`3771c49a`](https://github.com/hyprwm/Hyprland/commit/3771c49a94806b317fe4de470e96ae589b660a1b) | `` filesystem: Set the sticky bit on `/tmp/hypr` (#4199) ``       |