### PR TITLE
chore(flake/nur): `cc008520` -> `eef232c5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -548,11 +548,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703045478,
-        "narHash": "sha256-oBRcJulvYtXoAGXR/9E/SI8pMUiYRjuh6ahwGW0I2KY=",
+        "lastModified": 1703115921,
+        "narHash": "sha256-IdnOa1vkH9i0pG7JIHMTyXqATRihHwPJFZ3jm180SOU=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "cc0085209a3d80939926f623ce03491e175126ea",
+        "rev": "eef232c53c6ebf77ff116a330047f541b6a941b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eef232c5`](https://github.com/nix-community/NUR/commit/eef232c53c6ebf77ff116a330047f541b6a941b6) | `` automatic update `` |
| [`5e5fc963`](https://github.com/nix-community/NUR/commit/5e5fc9633fb8157b82a0ceab57d2077ce1c8a454) | `` automatic update `` |
| [`c44685fc`](https://github.com/nix-community/NUR/commit/c44685fcc602f336fc88e8e136db39f3a1e9f51c) | `` automatic update `` |
| [`bbf1ea20`](https://github.com/nix-community/NUR/commit/bbf1ea20193bd5f8a643f3cd1dceda72be110e75) | `` automatic update `` |
| [`f133fc54`](https://github.com/nix-community/NUR/commit/f133fc54e2a2495d19f6020120717240068ce0f3) | `` automatic update `` |
| [`d19b0ed1`](https://github.com/nix-community/NUR/commit/d19b0ed13ad371fe975f20872d7d198d50ecf763) | `` automatic update `` |
| [`ab71702f`](https://github.com/nix-community/NUR/commit/ab71702fafee4be31d7b6f08e7f023c528eb7572) | `` automatic update `` |
| [`1367f14e`](https://github.com/nix-community/NUR/commit/1367f14eadcb8a4fa6d15f773ff05f9dbd6065eb) | `` automatic update `` |
| [`075964f8`](https://github.com/nix-community/NUR/commit/075964f8e9a623bb8df3e414a682b2715b9c4b6e) | `` automatic update `` |
| [`a2bc1582`](https://github.com/nix-community/NUR/commit/a2bc1582b5fc1b6f52d6fd5c517dd5c08f3b4bf2) | `` automatic update `` |
| [`471263c9`](https://github.com/nix-community/NUR/commit/471263c9a9e14f635761af844e048c6fae27e44d) | `` automatic update `` |
| [`c3e9ef4a`](https://github.com/nix-community/NUR/commit/c3e9ef4a5fd38e7ab6ec75bdf66b9cc52decdc48) | `` automatic update `` |
| [`f1f4985e`](https://github.com/nix-community/NUR/commit/f1f4985e27c2a52c5d6d1758401d01207804c460) | `` automatic update `` |
| [`5553baf4`](https://github.com/nix-community/NUR/commit/5553baf4adcbbd2ff21acb81627799a33be3d05e) | `` automatic update `` |
| [`a404a219`](https://github.com/nix-community/NUR/commit/a404a21923e210932e60b3d6da030f7e19b627a2) | `` automatic update `` |
| [`be3e24a6`](https://github.com/nix-community/NUR/commit/be3e24a6a4823b573bcb32086f254551f8fe75c8) | `` automatic update `` |
| [`bbb4c54c`](https://github.com/nix-community/NUR/commit/bbb4c54c0af005c9d919148259169ee8865dc933) | `` automatic update `` |
| [`73ddd465`](https://github.com/nix-community/NUR/commit/73ddd465ba3fa1757e9f72be6420aabd78b5a764) | `` automatic update `` |
| [`7af72fd9`](https://github.com/nix-community/NUR/commit/7af72fd93b596b5bb3f89815d0cbf6a055e6af72) | `` automatic update `` |