### PR TITLE
chore(flake/nixpkgs): `fa5e0f2e` -> `64121103`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -532,11 +532,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1702987609,
-        "narHash": "sha256-m2hErow1pxz2KcpCH0LGykgf/LVy9tOkXnNOnssDBmw=",
+        "lastModified": 1703032144,
+        "narHash": "sha256-diY4uEfU/7JkTfzs7tKHt7K4MX/trzkVhqpN3rjemE4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fa5e0f2ed065dd00cfa0347c1421b67da6a5a10e",
+        "rev": "64121103ec8253dce1c285ffd2b1e35f0351fe30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`64121103`](https://github.com/NixOS/nixpkgs/commit/64121103ec8253dce1c285ffd2b1e35f0351fe30) | `` hareThirdParty.hare-ev: init at unstable-2023-10-31 ``                        |
| [`38cf6ff0`](https://github.com/NixOS/nixpkgs/commit/38cf6ff099856e19f83649fcdbc98b5bde58eaca) | `` Remove --simulate-pure-eval ``                                                |
| [`4a70c1e4`](https://github.com/NixOS/nixpkgs/commit/4a70c1e4da8bd66fe27885d1fba54ffee775e3da) | `` lib.fileset.gitTracked: Support out-of-tree builds ``                         |
| [`e9bfe646`](https://github.com/NixOS/nixpkgs/commit/e9bfe6460709099004be063c32824cb844a11efe) | `` python3Packages.asyncssh: 2.14.1 -> 2.14.2 ``                                 |
| [`4dd61b6e`](https://github.com/NixOS/nixpkgs/commit/4dd61b6e68ad858006afcad21558930f597cbc5c) | `` nixos/mastodon: properly escape arguments to psql in init-db script ``        |
| [`b34be5a1`](https://github.com/NixOS/nixpkgs/commit/b34be5a15e2e117d8241e4b2e32df1b5821ff209) | `` path-of-building.data: 2.38.2 -> 2.38.3 ``                                    |
| [`54aac082`](https://github.com/NixOS/nixpkgs/commit/54aac082a4d9bb5bbc5c4e899603abfb76a3f6d6) | `` prometheus-collectd-exporter: 0.5.0 -> 0.6.0 (#275097) ``                     |
| [`fc219f85`](https://github.com/NixOS/nixpkgs/commit/fc219f85fac1fae8979f6e921ec932ae5591fc0c) | `` prometheus-mysqld-exporter: 0.15.0 -> 0.15.1 (#275110) ``                     |
| [`090b929b`](https://github.com/NixOS/nixpkgs/commit/090b929b8ab9b7df11825554828f0cb51e9eab9b) | `` lib.packagesFromDirectoryRecursive: init ``                                   |
| [`fa9727cf`](https://github.com/NixOS/nixpkgs/commit/fa9727cf1e4916d948529946b877eae7f0a61b0d) | `` lib: `modules.sh` should check JSON output for predictability ``              |
| [`8596226c`](https://github.com/NixOS/nixpkgs/commit/8596226c93614fc9032ec585deffd668c2f4be5a) | `` CODEOWNERS: Watch the maintainers lists ``                                    |
| [`da92887a`](https://github.com/NixOS/nixpkgs/commit/da92887a3d1384d8fb22d5dcd8eee628cbe18a65) | `` vimPlugins.nvim-treesitter: update grammars ``                                |
| [`c07e508e`](https://github.com/NixOS/nixpkgs/commit/c07e508ee3d02dace15f22f5d78ff40ec52775f1) | `` vimPlugins: update on 2023-12-19 ``                                           |
| [`e7009ef0`](https://github.com/NixOS/nixpkgs/commit/e7009ef00cab1bf68ebbf30a5adf390fd64d3a0c) | `` vimPlugins.ollama-nvim: init at 2023-12-03 ``                                 |
| [`552ffb31`](https://github.com/NixOS/nixpkgs/commit/552ffb31c20dd7d047c639cd82f10a37cb6ca206) | `` espanso: fix sandbox issue with /bin/echo ``                                  |
| [`0fc323ee`](https://github.com/NixOS/nixpkgs/commit/0fc323eeef556d9803aa74956a826318bb42ee5a) | `` moonraker: disable check_klipper_config if klipper is immutable ``            |
| [`321daa01`](https://github.com/NixOS/nixpkgs/commit/321daa018b9ee425d2cdfa8a6c50861507398668) | `` python310Packages.fschat: 0.2.33 -> 0.2.34 ``                                 |
| [`4ca8ae0d`](https://github.com/NixOS/nixpkgs/commit/4ca8ae0d1f4355e6938eb88da67d640dbd6dff98) | `` libbsd: mark unsupported on microblaze ``                                     |
| [`fcec8edc`](https://github.com/NixOS/nixpkgs/commit/fcec8edc3f69b67115f28623225f9e72c135fe66) | `` libseccomp: mark unsupported on microblaze and m68k ``                        |
| [`752e3add`](https://github.com/NixOS/nixpkgs/commit/752e3add0751e76914a25ea4a0efb81b929af834) | `` pcre2: fix build for s390x ``                                                 |
| [`2b76501a`](https://github.com/NixOS/nixpkgs/commit/2b76501a4b83976b59a44fbad445e39eb4cc0704) | `` systemd: disable bpf on powerpc64le ``                                        |
| [`385cb5a5`](https://github.com/NixOS/nixpkgs/commit/385cb5a5f85c922eb9a28f5646872aea1df5b547) | `` python3Packages.trimesh: 4.0.5 -> 4.0.6 ``                                    |
| [`5fff7f40`](https://github.com/NixOS/nixpkgs/commit/5fff7f40788a9fc09f7e8cf5ba54d100754d4ba0) | `` Update zerotierone.nix per input ``                                           |
| [`7b83a839`](https://github.com/NixOS/nixpkgs/commit/7b83a839dc9f2dd17e8b9b041f6c1b691df00ec8) | `` Fix bash prestart script syntax error ``                                      |
| [`996bbe5b`](https://github.com/NixOS/nixpkgs/commit/996bbe5bd96ee6e99004b7986a7a71adafa51738) | `` delete trailing whitespace at row 70 ``                                       |
| [`8af401d3`](https://github.com/NixOS/nixpkgs/commit/8af401d3cfc4322beb5c8786c48fc09d568c7785) | `` Update zerotierone.nix per input ``                                           |
| [`b233faab`](https://github.com/NixOS/nixpkgs/commit/b233faab8289d208a0398d19cc08fd53db5efec8) | `` Update zerotierone.nix ``                                                     |
| [`36791bab`](https://github.com/NixOS/nixpkgs/commit/36791bab6a507e440f433c6238318b612a4c8556) | `` Update zerotierone.nix ``                                                     |
| [`0b357293`](https://github.com/NixOS/nixpkgs/commit/0b357293e8b14db8cab16c6e8fd7612217248e57) | `` Update zerotierone.nix ``                                                     |
| [`097f2b67`](https://github.com/NixOS/nixpkgs/commit/097f2b673741570eaf0d475127b3f5c6edbd2f0f) | `` Update zerotierone.nix ``                                                     |
| [`9f3d0870`](https://github.com/NixOS/nixpkgs/commit/9f3d0870058fe9fe7623ae34ba9a44bd8b57646e) | `` nix-serve-ng: unbreak. ``                                                     |
| [`7a991545`](https://github.com/NixOS/nixpkgs/commit/7a9915455b632af6b8261716bb2aee2bafbb0c6e) | `` fd: 8.7.1 -> 9.0.0 ``                                                         |
| [`5a267192`](https://github.com/NixOS/nixpkgs/commit/5a26719285c0f45cd584d14c3b7691a23654e04b) | `` python310Packages.flask-jwt-extended: 4.5.3 -> 4.6.0 ``                       |
| [`4e8975a9`](https://github.com/NixOS/nixpkgs/commit/4e8975a97a26a61e00bd732c96a996adbd0030b2) | `` gleam: 0.32.4 -> 0.33.0 ``                                                    |
| [`08d11dc8`](https://github.com/NixOS/nixpkgs/commit/08d11dc8be02072f63a3dcb62932e092af630413) | `` python310Packages.flake8-bugbear: 23.11.28 -> 23.12.2 ``                      |
| [`003d43d0`](https://github.com/NixOS/nixpkgs/commit/003d43d091c37d6eb48dec2bb8c8a5a16b2b70cc) | `` platformio-core: install shell completion ``                                  |
| [`76bf1b26`](https://github.com/NixOS/nixpkgs/commit/76bf1b26a36916d8b23c9a16cb92a75f2572280b) | `` python310Packages.findpython: 0.4.0 -> 0.4.1 ``                               |
| [`4ae92838`](https://github.com/NixOS/nixpkgs/commit/4ae92838239e69c262d3a6388f45ac1b40af700e) | `` linux-rt_6_1: 6.1.65-rt18 -> 6.1.67-rt20 ``                                   |
| [`dd9b63a9`](https://github.com/NixOS/nixpkgs/commit/dd9b63a911646b87c49044f99f7cbd5842438108) | `` linux_testing: 6.7-rc5 -> 6.7-rc6 ``                                          |
| [`8bbbb228`](https://github.com/NixOS/nixpkgs/commit/8bbbb228b4f6c0ecbd746296a67be7723b0851b9) | `` nixos/nextcloud: serve flac and ogg files ``                                  |
| [`0dad0923`](https://github.com/NixOS/nixpkgs/commit/0dad09239dbf7accd00dcad4815b287dd0e1aa94) | `` rio: 0.0.32 -> 0.0.33 ``                                                      |
| [`a13a4a04`](https://github.com/NixOS/nixpkgs/commit/a13a4a04eaf0a3b8cc74c75de29496405ea83aef) | `` pluto: 5.18.6 -> 5.19.0 ``                                                    |
| [`eacc407e`](https://github.com/NixOS/nixpkgs/commit/eacc407e1f560988d29333f924e6e5bcfedbf46c) | `` nostr-rs-relay: 0.8.12 -> 0.8.13 ``                                           |
| [`848aeefe`](https://github.com/NixOS/nixpkgs/commit/848aeefeb46e92485489cbecd2850d2e80ecb374) | `` python311Packages.caldav: 1.3.8 -> 1.3.9 ``                                   |
| [`0d059066`](https://github.com/NixOS/nixpkgs/commit/0d059066e7cb3467b230de1471ee7851e855ef70) | `` sqlboiler: 4.14.2 -> 4.15.0 ``                                                |
| [`c3deab04`](https://github.com/NixOS/nixpkgs/commit/c3deab041fe5d6742e722c7dec93c8291cad2ad8) | `` python311Packages.python-didl-lite: refactor ``                               |
| [`cb861324`](https://github.com/NixOS/nixpkgs/commit/cb861324193cb78814ac7a6eb30533765c944f14) | `` clamtk: 6.16 -> 6.17 ``                                                       |
| [`3df514a5`](https://github.com/NixOS/nixpkgs/commit/3df514a5c588e20fdc0f5eae4b4450475ffa3680) | `` python311Packages.python-didl-lite: 1.3.2 -> 1.4.0 ``                         |
| [`0ecf097e`](https://github.com/NixOS/nixpkgs/commit/0ecf097e92351e206f5b0e3052f7c5400560da7c) | `` last: 1518 -> 1519 ``                                                         |
| [`d49844be`](https://github.com/NixOS/nixpkgs/commit/d49844be64550768e50ae0bcf979d60d8e549461) | `` k9s: format ``                                                                |
| [`8b3fd732`](https://github.com/NixOS/nixpkgs/commit/8b3fd7323d9df9793e6c8d608d8d6e148634e9ae) | `` k9s: fix vendorHash mismatch by using proxyVendor ``                          |
| [`3ed9b7f8`](https://github.com/NixOS/nixpkgs/commit/3ed9b7f8052900190b37ad0c5a28cdeb3acf989a) | `` pip-audit: 2.6.1 -> 2.6.2 ``                                                  |
| [`1bca50d8`](https://github.com/NixOS/nixpkgs/commit/1bca50d8fbd2459362913d1653b7babad3bd8d8a) | `` python310Packages.djangorestframework-simplejwt: update disabled ``           |
| [`791894c1`](https://github.com/NixOS/nixpkgs/commit/791894c10c6ce9252f36b92582eafb14e2c46896) | `` google-java-format: 1.18.1 -> 1.19.0 ``                                       |
| [`68a8f62a`](https://github.com/NixOS/nixpkgs/commit/68a8f62ad3f5fa8f9939d016f9d0153d7f67519c) | `` frankenphp: 1.0.0 -> 1.0.1 ``                                                 |
| [`df51ffbc`](https://github.com/NixOS/nixpkgs/commit/df51ffbcfc3beb5f523267a325fa137d35419a03) | `` ddns-go: 5.6.6 -> 5.6.7 ``                                                    |
| [`56507658`](https://github.com/NixOS/nixpkgs/commit/565076587a53f4b1ce1a8bc8033bfceae4466146) | `` python310Packages.anthropic: 0.7.4 -> 0.7.8 ``                                |
| [`a720e207`](https://github.com/NixOS/nixpkgs/commit/a720e20762e53eede21a53777ec4835e7b10fb09) | `` uiua: 0.7.0 -> 0.7.1 ``                                                       |
| [`432aa817`](https://github.com/NixOS/nixpkgs/commit/432aa817203416d969d18285114da356237aa6f8) | `` vscodium: 1.85.0.23343 -> 1.85.1.23348 ``                                     |
| [`3c553dbb`](https://github.com/NixOS/nixpkgs/commit/3c553dbb434bce2ecd7e418ecc07197f1b35c631) | `` python310Packages.elasticsearch8: 8.11.0 -> 8.11.1 ``                         |
| [`941397c1`](https://github.com/NixOS/nixpkgs/commit/941397c1b1414dd8c9ce3181df873281f771c16a) | `` mpvScripts.{blacklistExtensions, seekTo}: unstable-2022-10-02 → 2023-12-18 `` |
| [`21c14e70`](https://github.com/NixOS/nixpkgs/commit/21c14e7095229a27f8ac4d403350467542794aa9) | `` mpvScripts.{blacklistExtensions, seekTo}: Add (hacky) `updateScript` ``       |
| [`74f2e495`](https://github.com/NixOS/nixpkgs/commit/74f2e495436983b9b3d8c9a94a638bb411cfb245) | `` lib.fileset.fetchGit: Refactoring ``                                          |
| [`4b1ee3e6`](https://github.com/NixOS/nixpkgs/commit/4b1ee3e616190461004dbe50fd26014506eaf85e) | `` gnomeExtensions.system-monitor: Remove in favor of system-monitor-next ``     |
| [`dc58efc6`](https://github.com/NixOS/nixpkgs/commit/dc58efc69cc430dc5bf08cf5b69fdfdd763e343c) | `` gnomeExtensions.system-monitor-next: Patch to fix runtime errors ``           |
| [`16ddc355`](https://github.com/NixOS/nixpkgs/commit/16ddc355d39f5a2f67d4105e101154bdfb3fba5e) | `` python310Packages.djangorestframework-simplejwt: 5.3.0 -> 5.3.1 ``            |
| [`9ee8211c`](https://github.com/NixOS/nixpkgs/commit/9ee8211ce30ddd5b738bf6ef3bd1b05b6ebec209) | `` python310Packages.django-rest-registration: 0.8.2 -> 0.8.3 ``                 |
| [`4a49de9d`](https://github.com/NixOS/nixpkgs/commit/4a49de9da680ee8b826b679f6599dcc368f85aed) | `` python310Packages.django-import-export: 3.3.3 -> 3.3.4 ``                     |
| [`7d565226`](https://github.com/NixOS/nixpkgs/commit/7d565226df0b818af851c810ecf46f4dc39dd900) | `` openssh: 9.5p1 -> 9.6p1 ``                                                    |
| [`48c5f854`](https://github.com/NixOS/nixpkgs/commit/48c5f85442c450b5e7bffaa511c0f256ffe418c9) | `` python3Packages.brother-ql: apply patch for Pillow>=10.0 ``                   |
| [`c0268a7b`](https://github.com/NixOS/nixpkgs/commit/c0268a7b9aefc14ab28558d07741059c644f0866) | `` home-assistant-custom-components.waste_collection_schedule: init at 1.44.0 `` |
| [`969f3a45`](https://github.com/NixOS/nixpkgs/commit/969f3a45ab54efafa307ce9714f47e3e194cc3cf) | `` python311Packages.icalevents: init at 0.1.27 ``                               |
| [`551d7c03`](https://github.com/NixOS/nixpkgs/commit/551d7c03299f224e4cfe03babac2455b8dd9a95a) | `` home-assistant: update component packages ``                                  |
| [`7e6bc497`](https://github.com/NixOS/nixpkgs/commit/7e6bc49753eb0d24f23796e5fae4a424f1aec0fa) | `` python311Packages.anova-wifi: init at 0.10.3 ``                               |
| [`f12915c4`](https://github.com/NixOS/nixpkgs/commit/f12915c4e0c143774d3139d6accb7a66df252fb9) | `` waagent: fix re-execution ``                                                  |
| [`f0d3f016`](https://github.com/NixOS/nixpkgs/commit/f0d3f016970f1f3f4e41bf883222e11439c7f25f) | `` qt6Packages.qxlsx: 1.4.6 -> 1.4.7 ``                                          |
| [`f1c8d070`](https://github.com/NixOS/nixpkgs/commit/f1c8d0709be6c9d510d4cafcdb2ad481f398c461) | `` nixos/waagent: provide waagent udev rules in initrd ``                        |
| [`276939e0`](https://github.com/NixOS/nixpkgs/commit/276939e0a1a218a8541c6c36a675e166c7131845) | `` nixos/waagent: move runtime dependencies to systemd service ``                |
| [`f9991e9d`](https://github.com/NixOS/nixpkgs/commit/f9991e9de0014bc7e15394ef312fdf3d3112abd6) | `` waagent: fixes ``                                                             |
| [`76254a64`](https://github.com/NixOS/nixpkgs/commit/76254a64b941574e76c18d2e3d70090a023ec1af) | `` waagent: fix description in meta ``                                           |
| [`beff92b8`](https://github.com/NixOS/nixpkgs/commit/beff92b86faa946f1413e9fb419eacca51c76317) | `` waagent: use buildPythonApplication ``                                        |
| [`29d99b1a`](https://github.com/NixOS/nixpkgs/commit/29d99b1a6eef724d32ece21d56cb4adf2924d326) | `` waagent: nixpkgs-fmt ``                                                       |
| [`ffa6079c`](https://github.com/NixOS/nixpkgs/commit/ffa6079cb03df796478e4e7030d3af5368ae781f) | `` add libGL ``                                                                  |
| [`80a04171`](https://github.com/NixOS/nixpkgs/commit/80a04171d5f6011292f1eb83146716058ca1f1ad) | `` maintainers: add endle ``                                                     |
| [`44b90312`](https://github.com/NixOS/nixpkgs/commit/44b9031298a7f28541d2f00a00604011e0b2ae3a) | `` prometheus-gitlab-ci-pipelines-exporter: 0.5.5 -> 0.5.6 ``                    |
| [`362a2e61`](https://github.com/NixOS/nixpkgs/commit/362a2e618c143d139f1c0058f7b45b4c626ee493) | `` nixos/tests: add test api in angie package ``                                 |
| [`b79f1854`](https://github.com/NixOS/nixpkgs/commit/b79f1854093a172684321bf1ce8bf26781694362) | `` nixos/tests/nginx-http3: add angie package in testing ``                      |
| [`c580ebee`](https://github.com/NixOS/nixpkgs/commit/c580ebee409e5bfad058c4c39dad5535fcbbee5a) | `` angie-console-light: init at 1.1.1 ``                                         |
| [`86efccfa`](https://github.com/NixOS/nixpkgs/commit/86efccfa45b058d51c429105dc2108e2ad1da005) | `` angie: init at 1.4.0 ``                                                       |
| [`34ced515`](https://github.com/NixOS/nixpkgs/commit/34ced5157c2206daddfccb2d8662da0600214ca6) | `` shotcut: 23.11.29 -> 23.12.15 ``                                              |
| [`00cb53de`](https://github.com/NixOS/nixpkgs/commit/00cb53de4fa2ba9fcdb52f504943d6ec8ebe5ce5) | `` nginx: fix nginx binary pathname ``                                           |
| [`965254f8`](https://github.com/NixOS/nixpkgs/commit/965254f8d3b06dc42a2a6e88230286b44ff99b5b) | `` webcord: 4.5.2 -> 4.6.0 ``                                                    |
| [`cfc1c6e7`](https://github.com/NixOS/nixpkgs/commit/cfc1c6e7a940fe42598c3de343acab1e78793586) | `` ooniprobe-cli: 3.19.1 -> 3.20.0 ``                                            |
| [`1078b943`](https://github.com/NixOS/nixpkgs/commit/1078b943f04951bfb39f504f8c847f808397afdb) | `` trufflehog: 3.63.2 -> 3.63.4 ``                                               |
| [`bb1ab299`](https://github.com/NixOS/nixpkgs/commit/bb1ab2997f9cb8b0579833d2e0df7fb141cd0aec) | `` trufflehog: 3.63.1 -> 3.63.2 ``                                               |
| [`b4a9d7cd`](https://github.com/NixOS/nixpkgs/commit/b4a9d7cda615f8f856751c6aa55fd30e7c61722b) | `` moonraker: unstable-2023-08-03 -> unstable-2023-12-16 ``                      |
| [`70c8ee0c`](https://github.com/NixOS/nixpkgs/commit/70c8ee0c9292450cd7263f1fbdea63f6909073e9) | `` vscode: 1.84.2 -> 1.85.1 ``                                                   |
| [`418d39f8`](https://github.com/NixOS/nixpkgs/commit/418d39f81ae800512e52bce47e6d9d8ca46354b9) | `` exodus: 23.11.6 -> 23.12.7 ``                                                 |
| [`f4c3a1a8`](https://github.com/NixOS/nixpkgs/commit/f4c3a1a8b32aa97e71390ce56718c9fa9f63b120) | `` cilium-cli: 0.15.12 -> 0.15.17 ``                                             |
| [`a529d6f9`](https://github.com/NixOS/nixpkgs/commit/a529d6f911c3e73a88955a75bf683ebd9f0a5923) | `` vencord: 1.6.4 -> 1.6.5 ``                                                    |
| [`f1ea01f9`](https://github.com/NixOS/nixpkgs/commit/f1ea01f944d8c4c3533aa99f9b9884ee175385ab) | `` rPackages.tesseract: fix build ``                                             |
| [`0678d2ea`](https://github.com/NixOS/nixpkgs/commit/0678d2eaa0e9a9dd1fd4151ed019630ba273699f) | `` nixpkgs-hammering: unstable-2023-03-09 -> unstable-2023-11-06 ``              |
| [`a989353e`](https://github.com/NixOS/nixpkgs/commit/a989353ef236a9b16f4aa27653d3c89a53168726) | `` nixos/tests/systemd-boot: change garbage-collect-entry test name ``           |
| [`435076cc`](https://github.com/NixOS/nixpkgs/commit/435076cc1ca6e6e5aa8e6bf5cd18f35202daf2df) | `` mpv: use correct nv-codec-headers version ``                                  |
| [`8938a19d`](https://github.com/NixOS/nixpkgs/commit/8938a19d67000d52fd6ceff25a1524077f0bdea1) | `` kustomize: 5.2.1 -> 5.3.0 ``                                                  |
| [`395fc064`](https://github.com/NixOS/nixpkgs/commit/395fc06431dd2d89f2a2718867266df249463598) | `` lib: Add contribution guidelines ``                                           |
| [`6fedcb4f`](https://github.com/NixOS/nixpkgs/commit/6fedcb4fe157db380d63227d8a9f34b69ee12d62) | `` azure-functions-core-tools: 4.0.5441 -> 4.0.5455 ``                           |
| [`9180c571`](https://github.com/NixOS/nixpkgs/commit/9180c5714341293a3fbcae409c3ba8af9e28cedd) | `` azure-functions-core-tools: 4.0.5413 -> 4.0.5441 ``                           |
| [`38fc00eb`](https://github.com/NixOS/nixpkgs/commit/38fc00ebb2445c7837116b6c21d86681213df3d3) | `` azure-functions-core-tools: 4.0.5390 -> 4.0.5413 ``                           |
| [`f217e475`](https://github.com/NixOS/nixpkgs/commit/f217e47591376a4da59e0d8a1377489a51e06ad2) | `` azure-functions-core-tools: 4.0.5348 -> 4.0.5390 ``                           |
| [`a626abc1`](https://github.com/NixOS/nixpkgs/commit/a626abc1321baa9576cc0f6c44333eb7989d8b62) | `` azure-functions-core-tools: build from source ``                              |
| [`eb221a89`](https://github.com/NixOS/nixpkgs/commit/eb221a898f6ff927ea48dc4d4ea2445fb5713c79) | `` nixos/lxd-agent: prevent restarting on change ``                              |