### PR TITLE
chore(flake/nur): `46403c0c` -> `cf0ae650`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -548,11 +548,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703407429,
-        "narHash": "sha256-l0x5cNnOZUlkqpKpAfWnTXaFkTpC+0Q2HssRMjZOprY=",
+        "lastModified": 1703504518,
+        "narHash": "sha256-swlzsigZPJvGxWtCFPE7WSlFG9do4l6JwAZFCVuNWF8=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "46403c0c8d4d0a4d2e97fcf1548131a7ae9801dc",
+        "rev": "cf0ae650c1a4f524a2b0e6856b18090271ab6c45",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`cf0ae650`](https://github.com/nix-community/NUR/commit/cf0ae650c1a4f524a2b0e6856b18090271ab6c45) | `` automatic update `` |
| [`8bd85177`](https://github.com/nix-community/NUR/commit/8bd851779dbd15b260068fad890c8b0466499646) | `` automatic update `` |
| [`d53544ee`](https://github.com/nix-community/NUR/commit/d53544ee0290e290d2a6e1ea0b0493b49fa17ae4) | `` automatic update `` |
| [`25f99a7b`](https://github.com/nix-community/NUR/commit/25f99a7b75ed5193d0c8c4a467d7a4e005431347) | `` automatic update `` |
| [`a2f3be54`](https://github.com/nix-community/NUR/commit/a2f3be543f385cbd89d213cd79507897e9332be0) | `` automatic update `` |
| [`ae942ec9`](https://github.com/nix-community/NUR/commit/ae942ec93ab6e9f0e9025726dcb45088010713b3) | `` automatic update `` |
| [`2be2b0a4`](https://github.com/nix-community/NUR/commit/2be2b0a484fb74e3cc360977c2b84ae429a17231) | `` automatic update `` |
| [`73644566`](https://github.com/nix-community/NUR/commit/736445669895e3e6db6fd495cfd787aac0324c8c) | `` automatic update `` |
| [`c6b3d226`](https://github.com/nix-community/NUR/commit/c6b3d226dcfb8ce36f0141a9d12ea13e462f88ae) | `` automatic update `` |
| [`8d7e7219`](https://github.com/nix-community/NUR/commit/8d7e72198ea666b5f914dcd09d3a30195018f4c7) | `` automatic update `` |
| [`febd060e`](https://github.com/nix-community/NUR/commit/febd060ec92566ee4ab086bf4d260ae191fe9b2a) | `` automatic update `` |
| [`746e9714`](https://github.com/nix-community/NUR/commit/746e971491423ea3011aef73cc4ea4bab7f04d0e) | `` automatic update `` |
| [`a85c0cd3`](https://github.com/nix-community/NUR/commit/a85c0cd3eb33ac0d0ec92fe33e62b56b5624538f) | `` automatic update `` |
| [`e2139c23`](https://github.com/nix-community/NUR/commit/e2139c23bcc160cc5f0afb76632d7b73d16da6be) | `` automatic update `` |
| [`60c6c679`](https://github.com/nix-community/NUR/commit/60c6c6796240fcda54da0b16695febcd4bb84a40) | `` automatic update `` |
| [`afb0840c`](https://github.com/nix-community/NUR/commit/afb0840c4e331b43ad11917e0940582030a9b957) | `` automatic update `` |
| [`b8afa43a`](https://github.com/nix-community/NUR/commit/b8afa43ae8f8e5bd861fae3f39033593aae79baf) | `` automatic update `` |
| [`aa0a2348`](https://github.com/nix-community/NUR/commit/aa0a23486ef4a8cf1dd5da9013703f72df4b32f5) | `` automatic update `` |
| [`0a9473ee`](https://github.com/nix-community/NUR/commit/0a9473eec8f1a18bd2c42dbaecbad3410f044475) | `` automatic update `` |
| [`0754d379`](https://github.com/nix-community/NUR/commit/0754d379f3d3a9ee951b402775c6289eb7852d38) | `` automatic update `` |
| [`434f3388`](https://github.com/nix-community/NUR/commit/434f338861c39a701740df89d78ef9c8e8211d2a) | `` automatic update `` |
| [`6897f1bc`](https://github.com/nix-community/NUR/commit/6897f1bcf8dcccc980554939f0808c37a0d45113) | `` automatic update `` |
| [`ef0c4a7e`](https://github.com/nix-community/NUR/commit/ef0c4a7ef25cc6fd8be8bda4579a20fef020c467) | `` automatic update `` |
| [`d4a19e55`](https://github.com/nix-community/NUR/commit/d4a19e55673212a350b6f1c3a22eb04173759fab) | `` automatic update `` |
| [`5f9f4107`](https://github.com/nix-community/NUR/commit/5f9f410799cc9cec3873a7cc9c8ad582b31e053a) | `` automatic update `` |
| [`cde7d8b2`](https://github.com/nix-community/NUR/commit/cde7d8b22e81948d7c0426ac5383c908a1be513e) | `` automatic update `` |
| [`7b48502f`](https://github.com/nix-community/NUR/commit/7b48502fd7507a896456b4a73ea946dfd2851b45) | `` automatic update `` |
| [`dba67bdf`](https://github.com/nix-community/NUR/commit/dba67bdf4444c4d9ff4a599ed193f39b6697db99) | `` automatic update `` |
| [`92a14ef8`](https://github.com/nix-community/NUR/commit/92a14ef8777026ad381aaab8648b55c4e675d874) | `` automatic update `` |
| [`01a95bfb`](https://github.com/nix-community/NUR/commit/01a95bfb0a9b80dc67ca7106cdb8261011d1e938) | `` automatic update `` |
| [`2011abbd`](https://github.com/nix-community/NUR/commit/2011abbdb8be03feb7283ac30b36c96305c2c5f8) | `` automatic update `` |
| [`8834fdd0`](https://github.com/nix-community/NUR/commit/8834fdd01835a72406af67263da041f79b7c8b49) | `` automatic update `` |
| [`5392dcef`](https://github.com/nix-community/NUR/commit/5392dcefb7790f08991b7c0c0f29bac99fbc57fb) | `` automatic update `` |
| [`177feff8`](https://github.com/nix-community/NUR/commit/177feff8c83f8d1ae09c90daf314f72ad29633a2) | `` automatic update `` |
| [`1b23cd59`](https://github.com/nix-community/NUR/commit/1b23cd590af6fea03dae2872153236ac928967a8) | `` automatic update `` |
| [`5767f4e7`](https://github.com/nix-community/NUR/commit/5767f4e74738c76e02676a9f7c0978901a4701b2) | `` automatic update `` |
| [`0d2c794f`](https://github.com/nix-community/NUR/commit/0d2c794f23783dfed37135301233ea88e54d0961) | `` automatic update `` |
| [`67820117`](https://github.com/nix-community/NUR/commit/67820117ff715d8428a3240e60e2d9fa6226e6df) | `` automatic update `` |