### PR TITLE
chore(flake/hyprland): `f013acc6` -> `b25b0643`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -271,11 +271,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1703367702,
-        "narHash": "sha256-w+p9YpnWrsRcpXgYzs/FNBv/bSsY6228Mb56K1eAVq0=",
+        "lastModified": 1703442544,
+        "narHash": "sha256-swV6fiGjZuvuEBY/f9/XBtHW/Fbm7HPI1la7NXeE3Lg=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "f013acc6eec60bb2db499aeb009176f932ea3624",
+        "rev": "b25b06430ba82ebd1977ad75b6cb1b86dd07cb8b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                               |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
| [`b25b0643`](https://github.com/hyprwm/Hyprland/commit/b25b06430ba82ebd1977ad75b6cb1b86dd07cb8b) | `` groupbar: add egl context to refreshGroupBarGradients() (#4238) `` |
| [`5aab4a96`](https://github.com/hyprwm/Hyprland/commit/5aab4a96e3c01cce181b42d51140f7ed4e555d8b) | `` dispatchers: add tiled/floating to cyclenext ``                    |
| [`ff75f991`](https://github.com/hyprwm/Hyprland/commit/ff75f991a50d9e82bb4ee4cacace551225ef2038) | `` compositor: don't block focus if there is no keyboard ``           |