### PR TITLE
chore(flake/nixpkgs): `bc3575c6` -> `939b6987`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -532,11 +532,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1703213509,
-        "narHash": "sha256-BDVzvjPwKk4/yvdCNzjmm1wlDf7Pdbhsf+hV2ybKkrY=",
+        "lastModified": 1703495195,
+        "narHash": "sha256-Ks0d1FnByqHXXzIzDBrUxPmUcimZNOGrAZ11BzkL8p4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bc3575c6cda0c5fc9e322c05d97df6a787066b3e",
+        "rev": "939b69875f078b79c2b6433afff2dec6dd002e3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                             |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
| [`ed1a16e8`](https://github.com/NixOS/nixpkgs/commit/ed1a16e8869a2bf54b9f2bb3e7a7fd48cab7d197) | `` munin: fix missing Date::Parse module error & make test fail w/o a fix ``                        |
| [`b866b626`](https://github.com/NixOS/nixpkgs/commit/b866b626cce208ce9c57ba6bad381e61bb78feb6) | `` python311Packages.aiohttp-zlib-ng: only depend on cpufeature where available ``                  |
| [`2cd1a5ef`](https://github.com/NixOS/nixpkgs/commit/2cd1a5ef3bd2d79b0c99a38ad0f81012f84a8864) | `` python311Packages.cpufeature: add supported platforms ``                                         |
| [`b45547a0`](https://github.com/NixOS/nixpkgs/commit/b45547a0a2b0e8064c445a50aaedc7f3b27e8ff7) | `` nomad: fix licenses ``                                                                           |
| [`f42f362f`](https://github.com/NixOS/nixpkgs/commit/f42f362fee852395a98b2c9e2dcfa5564eea9d57) | `` uncrustify: 0.78.0 -> 0.78.1 ``                                                                  |
| [`8999c9d9`](https://github.com/NixOS/nixpkgs/commit/8999c9d930c526d9f8e8761847e5ee939744590d) | `` npmHooks.npmInstallHook: ignore rather than error for missing bin/man keys in package.json ``    |
| [`41d34686`](https://github.com/NixOS/nixpkgs/commit/41d34686809ef4501d0bd644b1f006a2a38a156d) | `` drone-scp: 1.6.11 -> 1.6.12 ``                                                                   |
| [`0f0bfa83`](https://github.com/NixOS/nixpkgs/commit/0f0bfa834416dfc251e1822e0545b510a3fe0447) | `` gen6dns: fix cross compilation ``                                                                |
| [`fa07eab5`](https://github.com/NixOS/nixpkgs/commit/fa07eab5d12312a5b7880da29037f40e96eacd1e) | `` cudaPackages_10: hotfix eval error in flags.nix ``                                               |
| [`0efa203c`](https://github.com/NixOS/nixpkgs/commit/0efa203c094ae62f830686d48b3cbd2a01da97a4) | `` python311Packages.rapidgzip: 0.11.0 -> 0.11.1 ``                                                 |
| [`35ca6891`](https://github.com/NixOS/nixpkgs/commit/35ca6891195a3ddad5e54877a57bd29f6875fe35) | `` nixos/wrapper: add basename of the wrapped program to the wrappers name to easily identify it `` |
| [`ae0d7e06`](https://github.com/NixOS/nixpkgs/commit/ae0d7e0685ee8bb1169e43f148657e761772b2f8) | `` osu-lazer: 2023.1221.1 -> 2023.1224.0 ``                                                         |
| [`5331d53c`](https://github.com/NixOS/nixpkgs/commit/5331d53cf84ffce7fc87743c8d82d86d33c4adb4) | `` osu-lazer-bin: 2023.1221.0 -> 2023.1224.0 ``                                                     |
| [`f029a8a1`](https://github.com/NixOS/nixpkgs/commit/f029a8a10d7578f67bc706625389af3d8d0a88bb) | `` nixos/harmonia: restart systemd service ``                                                       |
| [`5ed93827`](https://github.com/NixOS/nixpkgs/commit/5ed9382769b4d1713c5f0a673ac722b4625c3b98) | `` typos: 1.16.24 -> 1.16.25 ``                                                                     |
| [`4cf470c9`](https://github.com/NixOS/nixpkgs/commit/4cf470c97cd9d78c31610fdf0806e402a3ffb667) | `` nixos/mandoc: don't create leading double slashes in MANPATH ``                                  |
| [`ad235e50`](https://github.com/NixOS/nixpkgs/commit/ad235e5072beada887fad980bea7314027dc2cc6) | `` nixos/mandoc: add man.conf settings option ``                                                    |
| [`4f3e29f3`](https://github.com/NixOS/nixpkgs/commit/4f3e29f3a3d6f1a115b23ba8fd5dd560b825d6d8) | `` nixos/mandoc: use MANPATH environment variable ``                                                |
| [`ab222895`](https://github.com/NixOS/nixpkgs/commit/ab222895b13252df722fa8f7038d2fd91fd884d9) | `` nixos/mandoc: fix paths don't exist failure ``                                                   |
| [`28fc924c`](https://github.com/NixOS/nixpkgs/commit/28fc924c091c70f942b9e450cf473751b117d705) | `` twilio-cli: 5.16.3 -> 5.17.0 ``                                                                  |
| [`3175627f`](https://github.com/NixOS/nixpkgs/commit/3175627fb85400bcfadc3fa0167ce548b75affe3) | `` tun2socks: 2.5.1 -> 2.5.2 ``                                                                     |
| [`b1f79f5d`](https://github.com/NixOS/nixpkgs/commit/b1f79f5d67691545ada091948604b9a478a88ab2) | `` ecl: 21.2.1 -> 23.9.9 ``                                                                         |
| [`2e9429a8`](https://github.com/NixOS/nixpkgs/commit/2e9429a8bf2f1e591ea2cc2e64569f9359006b5f) | `` trezor-suite: 23.10.1 -> 23.12.3 ``                                                              |
| [`e14f7ae6`](https://github.com/NixOS/nixpkgs/commit/e14f7ae634dfb90427fcb15835504553a46f2211) | `` trino-cli: 434 -> 435 ``                                                                         |
| [`3f5657e5`](https://github.com/NixOS/nixpkgs/commit/3f5657e5ecbecb5de393cabcff32205a74e9734c) | `` traefik: 2.10.6 -> 2.10.7 ``                                                                     |
| [`e6133eb6`](https://github.com/NixOS/nixpkgs/commit/e6133eb6cb46b21530c454f02c1d1c1d9a710ac9) | `` traceroute: 2.1.3 -> 2.1.5 ``                                                                    |
| [`1267c406`](https://github.com/NixOS/nixpkgs/commit/1267c40686feb91806cc4f79ddf9de2621049ae2) | `` traefik-certs-dumper: 2.8.1 -> 2.8.3 ``                                                          |
| [`800af424`](https://github.com/NixOS/nixpkgs/commit/800af4240b3ef56509dec2ca6cc55f578701bed4) | `` nixos/waydroid: Replace requirement for ASHMEM with MEMFD_CREATE ``                              |
| [`1e9e8a0d`](https://github.com/NixOS/nixpkgs/commit/1e9e8a0db0da8081586f76a14a4bdd51dbbb3322) | `` nixos/sudo-rs: Removed unused let-binding ``                                                     |
| [`6c601637`](https://github.com/NixOS/nixpkgs/commit/6c6016379b0f79c9978532ad22eb320832b98b73) | `` tippecanoe: 2.37.1 -> 2.39.0 ``                                                                  |
| [`86555b7f`](https://github.com/NixOS/nixpkgs/commit/86555b7f73ac38c240d7d9350fdaf04d58feb87d) | `` threatest: 1.2.4 -> 1.2.5 ``                                                                     |
| [`e7851986`](https://github.com/NixOS/nixpkgs/commit/e785198679acb94537c17e22f34b500c64e59b6c) | `` terraform-providers.yandex: 0.103.0 -> 0.104.0 ``                                                |
| [`d972d0b3`](https://github.com/NixOS/nixpkgs/commit/d972d0b3aa7a36011806df9a45fb9c11ecbb75b3) | `` terraform-providers.vultr: 2.17.1 -> 2.18.0 ``                                                   |
| [`ace4f12b`](https://github.com/NixOS/nixpkgs/commit/ace4f12bda0a324541beae3633d337074f6f4397) | `` terraform-providers.vsphere: 2.6.0 -> 2.6.1 ``                                                   |
| [`06ccefb5`](https://github.com/NixOS/nixpkgs/commit/06ccefb5aedf19c7903e68a73ca846157ef3e7b0) | `` terraform-providers.vra7: 3.0.11 -> 3.0.12 ``                                                    |
| [`27d996e4`](https://github.com/NixOS/nixpkgs/commit/27d996e41143ec1cef92d268f4914929642a8547) | `` terraform-providers.tencentcloud: 1.81.55 -> 1.81.60 ``                                          |
| [`38a826de`](https://github.com/NixOS/nixpkgs/commit/38a826de72be744480f73202c7109bc2033b610e) | `` terraform-providers.vcd: 3.10.0 -> 3.11.0 ``                                                     |
| [`f6482b17`](https://github.com/NixOS/nixpkgs/commit/f6482b17d8317cfc81e579e680e16c0d2abdfd05) | `` terraform-providers.tfe: 0.50.0 -> 0.51.1 ``                                                     |
| [`fbc6da56`](https://github.com/NixOS/nixpkgs/commit/fbc6da56059cb0a3e719efb60681acca7f96d339) | `` terraform-providers.talos: 0.3.2 -> 0.4.0 ``                                                     |
| [`66ec0b61`](https://github.com/NixOS/nixpkgs/commit/66ec0b61418af7616f8da29ee6c0bc1570999a17) | `` terraform-providers.tailscale: 0.13.11 -> 0.13.13 ``                                             |
| [`1a6b423b`](https://github.com/NixOS/nixpkgs/commit/1a6b423b1dcd4135fed9d506829aeafc551c923e) | `` terraform-providers.snowflake: 0.77.0 -> 0.82.0 ``                                               |
| [`779c866c`](https://github.com/NixOS/nixpkgs/commit/779c866c300c0fbeb56c14c3f3f4a281daf3cd84) | `` terraform-providers.spotinst: 1.151.1 -> 1.156.0 ``                                              |
| [`ffc51c4e`](https://github.com/NixOS/nixpkgs/commit/ffc51c4eae1c5011f884f1f13b853c7acfe0841f) | `` terraform-providers.sentry: 0.11.2 -> 0.12.1 ``                                                  |
| [`7f641aac`](https://github.com/NixOS/nixpkgs/commit/7f641aac3608c168f85d4bb7563793e48df703e8) | `` terraform-providers.scaleway: 2.34.0 -> 2.35.0 ``                                                |
| [`2248bcab`](https://github.com/NixOS/nixpkgs/commit/2248bcab07a05fe56698e400cea904930b3fae89) | `` terraform-providers.selectel: 4.0.1 -> 4.0.2 ``                                                  |
| [`7a2999b3`](https://github.com/NixOS/nixpkgs/commit/7a2999b36a6e0cb7824b12e3dfa27a908edd08c4) | `` terraform-providers.pagerduty: 3.3.0 -> 3.4.0 ``                                                 |
| [`ca250b9e`](https://github.com/NixOS/nixpkgs/commit/ca250b9ed14fd64e48123e8ecdab10426fce3acb) | `` terraform-providers.oci: 5.22.0 -> 5.23.0 ``                                                     |
| [`d6a5f911`](https://github.com/NixOS/nixpkgs/commit/d6a5f911b0241f73d4890ab40e921dd69274c415) | `` terraform-providers.opsgenie: 0.6.34 -> 0.6.35 ``                                                |
| [`50537082`](https://github.com/NixOS/nixpkgs/commit/505370829fe679807a2282add1f20555623ea5e1) | `` terraform-providers.opentelekomcloud: 1.35.13 -> 1.35.14 ``                                      |
| [`48fb8b04`](https://github.com/NixOS/nixpkgs/commit/48fb8b045d585dba6499b9e149e768a1423d0e18) | `` terraform-providers.nomad: 2.0.0 -> 2.1.0 ``                                                     |
| [`9966d406`](https://github.com/NixOS/nixpkgs/commit/9966d4065de0690f4698d41ecb1b379960055f90) | `` terraform-providers.mongodbatlas: 1.13.1 -> 1.14.0 ``                                            |
| [`42c00416`](https://github.com/NixOS/nixpkgs/commit/42c00416c5d3c68b9e89afad3b8c8b37fcaae945) | `` terraform-providers.newrelic: 3.27.7 -> 3.28.1 ``                                                |
| [`662deb75`](https://github.com/NixOS/nixpkgs/commit/662deb7568f5118c0720acb5a4a5b7ee40add2af) | `` terraform-providers.namecheap: 2.1.0 -> 2.1.1 ``                                                 |
| [`ca770e96`](https://github.com/NixOS/nixpkgs/commit/ca770e966500898e13318f33b7e5db69b7d3a8f2) | `` terraform-providers.linode: 2.10.1 -> 2.11.0 ``                                                  |
| [`5d4a4989`](https://github.com/NixOS/nixpkgs/commit/5d4a49892e788ed9680a963d11be527b6a866e2b) | `` terraform-providers.local: 2.4.0 -> 2.4.1 ``                                                     |
| [`914fcc79`](https://github.com/NixOS/nixpkgs/commit/914fcc79e7289b3fcdada6e12b003cb673d283ff) | `` terraform-providers.launchdarkly: 2.16.0 -> 2.17.0 ``                                            |
| [`8db6eb03`](https://github.com/NixOS/nixpkgs/commit/8db6eb037418dca2aeb8996a6403cd7bdd03f61f) | `` terraform-providers.jetstream: 0.0.35 -> 0.1.1 ``                                                |
| [`737c4c0c`](https://github.com/NixOS/nixpkgs/commit/737c4c0cd01f81937457ea5056ab12ac249d23e4) | `` terraform-providers.huaweicloud: 1.58.0 -> 1.59.1 ``                                             |
| [`297a9912`](https://github.com/NixOS/nixpkgs/commit/297a99125c9e13ae595e959bc363b253ebf271e7) | `` terraform-providers.http: 3.4.0 -> 3.4.1 ``                                                      |
| [`fbaacb26`](https://github.com/NixOS/nixpkgs/commit/fbaacb2656a20259e6a26ebc9056902a860d1b44) | `` terraform-providers.grafana: 2.7.0 -> 2.8.0 ``                                                   |
| [`52866fa8`](https://github.com/NixOS/nixpkgs/commit/52866fa86f5456a3bb871bc6d8906be49bda251b) | `` terraform-providers.gridscale: 1.22.0 -> 1.23.0 ``                                               |
| [`798e3a6d`](https://github.com/NixOS/nixpkgs/commit/798e3a6d4ac48d55aa58855e28b0136f30711e08) | `` terraform-providers.google-beta: 5.8.0 -> 5.10.0 ``                                              |
| [`d5ab1b0a`](https://github.com/NixOS/nixpkgs/commit/d5ab1b0aeadb5106401562bd4b34aa29159b9e2b) | `` terraform-providers.google: 5.8.0 -> 5.10.0 ``                                                   |
| [`96a50765`](https://github.com/NixOS/nixpkgs/commit/96a5076566f7464db5d6b5aa39d00641dd83079c) | `` terraform-providers.equinix: 1.20.1 -> 1.22.0 ``                                                 |
| [`9fc0d036`](https://github.com/NixOS/nixpkgs/commit/9fc0d0365a2a7407bccdf7177cbc43053273686a) | `` terraform-providers.dns: 3.3.2 -> 3.4.0 ``                                                       |
| [`869b171d`](https://github.com/NixOS/nixpkgs/commit/869b171dc854940279ef8947c27799cf9c20ddc8) | `` terraform-providers.digitalocean: 2.32.0 -> 2.34.1 ``                                            |
| [`870db7fa`](https://github.com/NixOS/nixpkgs/commit/870db7fa0c9e671e2826991f89a76913a521a27c) | `` terraform-providers.datadog: 3.33.0 -> 3.34.0 ``                                                 |
| [`c0e89d0b`](https://github.com/NixOS/nixpkgs/commit/c0e89d0bce94b9308917d8f34c54be208692ed2f) | `` terraform-providers.dexidp: 0.3.2 -> 0.3.4 ``                                                    |
| [`76702104`](https://github.com/NixOS/nixpkgs/commit/76702104f3ea7fed8833fbf49f7bf39df2b7300e) | `` terraform-providers.cloudamqp: 1.28.0 -> 1.29.1 ``                                               |
| [`42f599f9`](https://github.com/NixOS/nixpkgs/commit/42f599f92bf96139c0ccb9760ceb9395cfc1eaf2) | `` terraform-providers.checkly: 1.7.2 -> 1.7.3 ``                                                   |
| [`ccefe0ca`](https://github.com/NixOS/nixpkgs/commit/ccefe0ca11e47ef318bd729eb41f0da00711029e) | `` terraform-providers.buildkite: 1.1.1 -> 1.2.0 ``                                                 |
| [`8b00a6b5`](https://github.com/NixOS/nixpkgs/commit/8b00a6b571ee2075f47bf8caa2a6170bc6168387) | `` terraform-providers.aws: 5.30.0 -> 5.31.0 ``                                                     |
| [`e1bef93e`](https://github.com/NixOS/nixpkgs/commit/e1bef93ebe2f7148e33e0a4fea1663f0909b55f4) | `` terraform-providers.azurerm: 3.83.0 -> 3.85.0 ``                                                 |
| [`49a3a378`](https://github.com/NixOS/nixpkgs/commit/49a3a378cbefbb382241516bc83edecbe467bdfe) | `` terraform-providers.azuread: 2.46.0 -> 2.47.0 ``                                                 |
| [`efb28bab`](https://github.com/NixOS/nixpkgs/commit/efb28babf51ec2e98234a8040683d0f6de1559b2) | `` terraform-providers.alicloud: 1.213.1 -> 1.214.0 ``                                              |
| [`a3936b04`](https://github.com/NixOS/nixpkgs/commit/a3936b04c94dbf9a61a72a93fff3102c77f9dbd3) | `` terraform-providers.artifactory: 9.9.2 -> 10.0.2 ``                                              |
| [`4d2acbe0`](https://github.com/NixOS/nixpkgs/commit/4d2acbe0f2e30dacfe2df3888e5912689f178ee8) | `` terraform-providers.archive: 2.4.0 -> 2.4.1 ``                                                   |
| [`dc8a6a2c`](https://github.com/NixOS/nixpkgs/commit/dc8a6a2c7615aaf5280bdc9c0159e70a478a209c) | `` terraform-providers.aiven: 4.9.3 -> 4.9.4 ``                                                     |
| [`8faa777a`](https://github.com/NixOS/nixpkgs/commit/8faa777a06bcbd082209be41a211314c36df5a44) | `` terraform-providers.aci: 2.11.1 -> 2.12.0 ``                                                     |
| [`16de34c1`](https://github.com/NixOS/nixpkgs/commit/16de34c184b2e3e2db177eb4a6ffcb91c39c6f55) | `` terragrunt: 0.54.5 -> 0.54.10 ``                                                                 |
| [`2d3b6f4c`](https://github.com/NixOS/nixpkgs/commit/2d3b6f4cceaa15a98cea2f41bdf924a5cf3d1c6c) | `` temporal: 1.22.0 -> 1.22.3 ``                                                                    |
| [`4d60f381`](https://github.com/NixOS/nixpkgs/commit/4d60f38138093f6b9e192b406bc0d70317442fcf) | `` deja-dup: 45.1 → 45.2 ``                                                                         |
| [`319b988c`](https://github.com/NixOS/nixpkgs/commit/319b988c3e8b30c339491d7411adc285b91be45c) | `` tailscale-nginx-auth: 1.48.2 -> 1.56.1 ``                                                        |
| [`e1aa8497`](https://github.com/NixOS/nixpkgs/commit/e1aa8497540da8f368dcc01875653fc7908abb83) | `` lesspipe: add missing dependency on 'strings' ``                                                 |
| [`764f5463`](https://github.com/NixOS/nixpkgs/commit/764f54631c8fd60ffa965dc8065124353fa1c965) | `` mpvScripts: use `overrideAttrs` instead of `override` ``                                         |
| [`f203a40a`](https://github.com/NixOS/nixpkgs/commit/f203a40a13c16b76b1937f23cdbaa478a97549af) | `` mpvScripts: Only emit `tests.single-main-in-script-dir` for dir-packaged scripts ``              |
| [`aaa58053`](https://github.com/NixOS/nixpkgs/commit/aaa58053872824ac23375be8a82ec99b9b3be5e9) | `` syncthingtray: 1.4.9 -> 1.4.11 ``                                                                |
| [`7b3bd0bc`](https://github.com/NixOS/nixpkgs/commit/7b3bd0bcd8884d3bdd29cef804509e153d359894) | `` syft: 0.98.0 -> 0.99.0 ``                                                                        |
| [`54d1f60e`](https://github.com/NixOS/nixpkgs/commit/54d1f60ec46944c7fa91fbb63a6d5b1e1ea0388d) | `` vimPlugins.nvim-treesitter: update grammars ``                                                   |
| [`b0343d30`](https://github.com/NixOS/nixpkgs/commit/b0343d30b0ef12af82d87b66dedd6e64092de20f) | `` surrealdb: 1.0.0 -> 1.0.2 ``                                                                     |
| [`02a9cc0a`](https://github.com/NixOS/nixpkgs/commit/02a9cc0ae91a8fdd351e9ca7459ecd06bbc607d3) | `` vimPlugins: update on 2023-12-24 ``                                                              |
| [`a7fd3db1`](https://github.com/NixOS/nixpkgs/commit/a7fd3db1b4ec69ce25e6655ea23814fe267ac856) | `` vimPlugins.codeium-nvim: init at 2023-12-17 ``                                                   |
| [`b291a521`](https://github.com/NixOS/nixpkgs/commit/b291a521e5a2d4c8bdcdf7189514e4a84eaf2b8c) | `` svd2rust: 0.31.1 -> 0.31.2 ``                                                                    |
| [`20258871`](https://github.com/NixOS/nixpkgs/commit/202588714c719d56acbc2a74109ebae87ab0e66b) | `` libreoffice-unwrapped: fix default --with-help build value ``                                    |
| [`17edec32`](https://github.com/NixOS/nixpkgs/commit/17edec32a2ee8959bfe69382d544380a782e91b2) | `` supersonic-wayland: 0.8.1 -> 0.8.2 ``                                                            |
| [`2275f51d`](https://github.com/NixOS/nixpkgs/commit/2275f51db8e298d4b8ba051f3b38a18c44fb8f74) | `` sile: 0.14.13 -> 0.14.14 ``                                                                      |
| [`9b99a225`](https://github.com/NixOS/nixpkgs/commit/9b99a22585cb935670c8892fa0fee174dabe2a7d) | `` mbox: remove ``                                                                                  |
| [`928a5d00`](https://github.com/NixOS/nixpkgs/commit/928a5d009f15ddebf8bdff803b2b038a9a122330) | `` athens: remove timpath flag, don't use pname as repo ``                                          |
| [`7ad281a1`](https://github.com/NixOS/nixpkgs/commit/7ad281a1c3d2f91077053b1806c0b77fe6d78085) | `` athens: add version test ``                                                                      |
| [`bfe1dfee`](https://github.com/NixOS/nixpkgs/commit/bfe1dfee4af4ac347684f6c4d591fe2a439d8b7f) | `` kodiPackages.netflix: 1.23.0 -> 1.23.1 ``                                                        |
| [`8106e2d7`](https://github.com/NixOS/nixpkgs/commit/8106e2d74e8b476d6588ecfc6b3eb2f0590de15f) | `` kodiPackages.netflix: 1.22.3 -> 1.23.0 ``                                                        |
| [`fa159633`](https://github.com/NixOS/nixpkgs/commit/fa159633943de14e914fbb67115875d0509d474a) | `` kodiPackages.inputstream-adaptive: 20.3.13 -> 20.3.14 ``                                         |
| [`e9bd0e68`](https://github.com/NixOS/nixpkgs/commit/e9bd0e68af5d6d70b28ab598da200ebfb6002416) | `` athens: drop buildGo121Module ``                                                                 |
| [`72dcff17`](https://github.com/NixOS/nixpkgs/commit/72dcff1759ce12a2a91b09cc9259e09782623802) | `` postgresqlPackages.plpgsql_check: 2.7.0 -> 2.7.1 ``                                              |
| [`fc92e8a6`](https://github.com/NixOS/nixpkgs/commit/fc92e8a6893fa38534edc1fdecd843b65079f570) | `` postgresqlPackages.pgtap: 1.3.0 -> 1.3.1 ``                                                      |
| [`b67c0eb1`](https://github.com/NixOS/nixpkgs/commit/b67c0eb16be4f08023c9f40dc38c3099980c847d) | `` ArchiSteamFarm: 5.4.13.4 -> 5.5.0.11 ``                                                          |
| [`3b28ee0f`](https://github.com/NixOS/nixpkgs/commit/3b28ee0f3b67502a542991941c1561274ee0bb13) | `` waybar: remove jtbx from maintainers ``                                                          |
| [`42e82652`](https://github.com/NixOS/nixpkgs/commit/42e82652225b63f1b1008f17751599919ea124cd) | `` inspircd: 3.16.1 -> 3.17.0 ``                                                                    |
| [`3432170d`](https://github.com/NixOS/nixpkgs/commit/3432170d3fe34850e56cf2c8676d24ef1d47fbe9) | `` naev: 0.10.6 -> 0.11.0 ``                                                                        |
| [`3eeb0bf3`](https://github.com/NixOS/nixpkgs/commit/3eeb0bf3eedc04951620c64ac1b70ebe22335428) | `` kubent: 0.7.0 -> 0.7.1 ``                                                                        |
| [`308f3882`](https://github.com/NixOS/nixpkgs/commit/308f38826e60ee864a249e3ae7aecd02674bfedb) | `` yabai: 6.0.1 -> 6.0.2 ``                                                                         |
| [`7f8d624c`](https://github.com/NixOS/nixpkgs/commit/7f8d624c1c46423f27c8282dbae89d896028548f) | `` invidtui: 0.3.6 -> 0.3.7 ``                                                                      |
| [`9f46de92`](https://github.com/NixOS/nixpkgs/commit/9f46de92e8f2713600cdd86f59a264030c976a20) | `` scaleway-cli: added `kashw2` as a maintainer ``                                                  |
| [`da84afe3`](https://github.com/NixOS/nixpkgs/commit/da84afe312230ca7c2ddf604df7f273a5a60cd43) | `` scaleway-cli: configured `installCheckPhase` ``                                                  |
| [`6a64808f`](https://github.com/NixOS/nixpkgs/commit/6a64808fc877bb901aceca2143a9e4cbb8995dcc) | `` scaleway-cli: re-enabled `checkPhase` ``                                                         |
| [`4b41bb45`](https://github.com/NixOS/nixpkgs/commit/4b41bb45ca1f63259c4cfa20bdb4db93184eda8c) | `` scaleway-cli: 2.25.0 -> 2.26.0 ``                                                                |
| [`934f780f`](https://github.com/NixOS/nixpkgs/commit/934f780f63ca1ef1abc462c7ef01d4db768b8555) | `` python311Packages.env-canada: 0.6.0 -> 0.6.1 ``                                                  |
| [`77a17f4b`](https://github.com/NixOS/nixpkgs/commit/77a17f4be60e89260de82a2953437511f9561538) | `` opentabletdriver: 0.6.3.0 -> 0.6.4.0 ``                                                          |
| [`691d59c5`](https://github.com/NixOS/nixpkgs/commit/691d59c589e7b7012c07152eb33e4bcbf02cbc94) | `` ocamlPackages.kqueue: init at 0.3.0 ``                                                           |
| [`3e632f05`](https://github.com/NixOS/nixpkgs/commit/3e632f05d9bcf96077654f37382936aefd6a016a) | `` terrascan: 1.18.9 -> 1.18.11 ``                                                                  |
| [`ee2d1ac6`](https://github.com/NixOS/nixpkgs/commit/ee2d1ac62bb1aac428d2cd7082f61e1924566216) | `` trufflehog: 3.63.5 -> 3.63.7 ``                                                                  |
| [`b1543269`](https://github.com/NixOS/nixpkgs/commit/b15432693b4bc50cb0854dc9d77b44870dc3e6ae) | `` python311Packages.sqltrie: 0.9.0 -> 0.11.0 ``                                                    |
| [`67d64071`](https://github.com/NixOS/nixpkgs/commit/67d640710092e0b0d9a6548873e67222344f0930) | `` python311Packages.hachoir: 3.2.0 -> 3.3.0 ``                                                     |
| [`fa5f38e1`](https://github.com/NixOS/nixpkgs/commit/fa5f38e14fb9bda49d179457812b0f0f97347dfd) | `` python311Packages.hahomematic: 2023.11.4 -> 2023.12.4 ``                                         |
| [`b9b3fe28`](https://github.com/NixOS/nixpkgs/commit/b9b3fe2818827950f5aa5c53da1ab54107c524ac) | `` python311Packages.botocore-stubs: 1.34.2 -> 1.34.7 ``                                            |
| [`861e3d24`](https://github.com/NixOS/nixpkgs/commit/861e3d2486f98f2cfa3a9e98786cc5d64a60484a) | `` python311Packages.boto3-stubs: 1.34.2 -> 1.34.7 ``                                               |
| [`bb61a1af`](https://github.com/NixOS/nixpkgs/commit/bb61a1af8e14e09e88ce5f48c42187a9df4ed1ec) | `` gimoji: 0.6.1 -> 0.7.1 ``                                                                        |
| [`132d6f7f`](https://github.com/NixOS/nixpkgs/commit/132d6f7fd479c5f1e967445497724762b129d431) | `` datasette: 0.64.5 -> 0.64.6 ``                                                                   |
| [`982c2172`](https://github.com/NixOS/nixpkgs/commit/982c21722a3aa69b18f01252642425caeb008777) | `` ustream-ssl-wolfssl: add missing openssl dependency ``                                           |
| [`2ec8defc`](https://github.com/NixOS/nixpkgs/commit/2ec8defc0afd09f04fc00f47c0d15d796642347d) | `` pwru: init at 1.0.5 ``                                                                           |
| [`0b7c65fb`](https://github.com/NixOS/nixpkgs/commit/0b7c65fbae5ed91ab6528cef51008a5ea78f92c4) | `` tuba: 0.5.0 -> 0.6.1 ``                                                                          |
| [`898c9a7c`](https://github.com/NixOS/nixpkgs/commit/898c9a7ce6a915b22975a2ec72cf7d3a0f307b33) | `` kismet: fix cross compilation ``                                                                 |