### PR TITLE
chore(flake/home-manager): `16fcb967` -> `80679ea5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -247,11 +247,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703413401,
-        "narHash": "sha256-pc3SzlsRDe5KW3SqOntNH17Z+/czlln0j2Je2jjeBSg=",
+        "lastModified": 1703527373,
+        "narHash": "sha256-AjypRssRtS6F3xkf7rE3/bXkIF2WJOZLbTIspjcE1zM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "16fcb9674a71220313f91446e0c259bce5c20f0f",
+        "rev": "80679ea5074ab7190c4cce478c600057cfb5edae",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                      |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`80679ea5`](https://github.com/nix-community/home-manager/commit/80679ea5074ab7190c4cce478c600057cfb5edae) | `` flake.lock: Update ``                     |
| [`015a36e9`](https://github.com/nix-community/home-manager/commit/015a36e9c737d97356eb1627d4d7c7bd84976b85) | `` oh-my-posh: enable nushell integration `` |
| [`d5a917ba`](https://github.com/nix-community/home-manager/commit/d5a917bab40daf4e5f82cd27162b8a6656d3beab) | `` Translate using Weblate (French) ``       |