### PR TITLE
chore(flake/nur): `cf0ae650` -> `19c254d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -548,11 +548,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703504518,
-        "narHash": "sha256-swlzsigZPJvGxWtCFPE7WSlFG9do4l6JwAZFCVuNWF8=",
+        "lastModified": 1703541167,
+        "narHash": "sha256-iGIijErfF3UHxDW1avjbfrKT5MMSVOh3NGvXstbtAQQ=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "cf0ae650c1a4f524a2b0e6856b18090271ab6c45",
+        "rev": "19c254d7cbbc4977a0b1d4d8c17b3e4051d67a0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`19c254d7`](https://github.com/nix-community/NUR/commit/19c254d7cbbc4977a0b1d4d8c17b3e4051d67a0e) | `` automatic update `` |
| [`99f14007`](https://github.com/nix-community/NUR/commit/99f1400741982af3ad7f13e21bfb9d7c9d6a6dc5) | `` automatic update `` |
| [`62220a13`](https://github.com/nix-community/NUR/commit/62220a1319013776c2f8aadda5d9c1047444862d) | `` automatic update `` |
| [`19aac52b`](https://github.com/nix-community/NUR/commit/19aac52be07bb798edd26840451ed32d77000205) | `` automatic update `` |
| [`aba36b23`](https://github.com/nix-community/NUR/commit/aba36b23d7f64a6d72ee6af3223c399ed7d1ad6e) | `` automatic update `` |
| [`7204b2e5`](https://github.com/nix-community/NUR/commit/7204b2e5b0fdbe68fa1d456f67dba1945a82644c) | `` automatic update `` |
| [`4755c729`](https://github.com/nix-community/NUR/commit/4755c729f74415413f9404199a82032ee1cbb557) | `` automatic update `` |
| [`a72f5af1`](https://github.com/nix-community/NUR/commit/a72f5af118a5bea87686e780b07cee46cbc77401) | `` automatic update `` |
| [`c40028e5`](https://github.com/nix-community/NUR/commit/c40028e57168bc70831ce85cb450b552e9ad5358) | `` automatic update `` |
| [`411d3d0b`](https://github.com/nix-community/NUR/commit/411d3d0bd23254eb591694935ddb63a6e3240de5) | `` automatic update `` |
| [`c2dce24f`](https://github.com/nix-community/NUR/commit/c2dce24fa5ecdd4da8ca0a8122a9915a9489a855) | `` automatic update `` |
| [`0f9302b0`](https://github.com/nix-community/NUR/commit/0f9302b03b1899c65abb35e4697778bf3dec1884) | `` automatic update `` |
| [`ca57437c`](https://github.com/nix-community/NUR/commit/ca57437cbb179496fa9d10caba1eca69aa413745) | `` automatic update `` |
| [`dd8d2d7b`](https://github.com/nix-community/NUR/commit/dd8d2d7bd31c648dbef0972be283c042e6d6a5aa) | `` automatic update `` |
| [`070e43e0`](https://github.com/nix-community/NUR/commit/070e43e0268bcd138c214cf5a93462b2525ccab4) | `` automatic update `` |
| [`36cbe79f`](https://github.com/nix-community/NUR/commit/36cbe79f4a3a44bda18d28a21a4264a3219cff03) | `` automatic update `` |
| [`747c0cbb`](https://github.com/nix-community/NUR/commit/747c0cbbecc987e67f49680b6753cc0e8ab355c5) | `` automatic update `` |
| [`7413ef75`](https://github.com/nix-community/NUR/commit/7413ef750a3c6b0ee5bd5d8a0c9eb64b52aff5c9) | `` automatic update `` |
| [`cb29cfb5`](https://github.com/nix-community/NUR/commit/cb29cfb57eb08e52760b40424a9e34865f328e1f) | `` automatic update `` |
| [`8d6b455e`](https://github.com/nix-community/NUR/commit/8d6b455ea4c5e26ed42838834829841721cee3f0) | `` automatic update `` |
| [`1174a80c`](https://github.com/nix-community/NUR/commit/1174a80c4f9d8c4bb1f8e4316d3a178b4c8614cb) | `` automatic update `` |
| [`530e43c6`](https://github.com/nix-community/NUR/commit/530e43c6e39e952ca892e8b9cecd008ec49b5b19) | `` automatic update `` |
| [`cc8995b5`](https://github.com/nix-community/NUR/commit/cc8995b5f45a8dcdb23fd9500f99cca4d2a13893) | `` automatic update `` |
| [`b70e9071`](https://github.com/nix-community/NUR/commit/b70e9071b34e018a4e02ec4d0064d712997074c3) | `` automatic update `` |
| [`630c283d`](https://github.com/nix-community/NUR/commit/630c283d02695317dc7ed0bcdc8000e362dd3422) | `` automatic update `` |
| [`d6a24830`](https://github.com/nix-community/NUR/commit/d6a24830e5a6ef2bd39f6955521a2e47f4a14352) | `` automatic update `` |
| [`d28187c0`](https://github.com/nix-community/NUR/commit/d28187c0318868c96feb90abab4aa480f8dfb8f1) | `` automatic update `` |
| [`e331b526`](https://github.com/nix-community/NUR/commit/e331b526016e69228e21edb84ad64ec8eb165849) | `` automatic update `` |
| [`04d097f0`](https://github.com/nix-community/NUR/commit/04d097f0b08d3982f6ce9ba6877f9bffd1a2e31c) | `` automatic update `` |
| [`7b96ac8c`](https://github.com/nix-community/NUR/commit/7b96ac8c339b756a00cb808be1a5d0884944a96d) | `` automatic update `` |
| [`4fd16a70`](https://github.com/nix-community/NUR/commit/4fd16a70589554f5d3990056e0011b2a1ba4433d) | `` automatic update `` |
| [`5472d6ad`](https://github.com/nix-community/NUR/commit/5472d6ada3c0cc06c06511c50cca056ac3c0c1bb) | `` automatic update `` |
| [`e8e245d2`](https://github.com/nix-community/NUR/commit/e8e245d2b49922590321009c9de8f60a14440a1d) | `` automatic update `` |
| [`189dddb9`](https://github.com/nix-community/NUR/commit/189dddb9cd809d39cfdb487764dc6641ab17eeec) | `` automatic update `` |
| [`822160d9`](https://github.com/nix-community/NUR/commit/822160d9746f4efc5456b802c99743781c65a78b) | `` automatic update `` |
| [`d436288c`](https://github.com/nix-community/NUR/commit/d436288c594494f2e5dfcc5f822ca88151b3b178) | `` automatic update `` |
| [`1c2038ad`](https://github.com/nix-community/NUR/commit/1c2038ad2f584ee148185f7dcb9b4efec15d4a28) | `` automatic update `` |
| [`e2c155b8`](https://github.com/nix-community/NUR/commit/e2c155b8797da4a7ac638e7848066881cd4da2c8) | `` automatic update `` |
| [`582e294c`](https://github.com/nix-community/NUR/commit/582e294ca4e56113ad95c40f33264a642a530f85) | `` automatic update `` |