### PR TITLE
chore(flake/nur): `19c254d7` -> `59425032`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -604,11 +604,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703541167,
-        "narHash": "sha256-iGIijErfF3UHxDW1avjbfrKT5MMSVOh3NGvXstbtAQQ=",
+        "lastModified": 1703548790,
+        "narHash": "sha256-YYZ9vYZDSjID013xM8ztXbxl3Y6JrkQPT4Pux2qj9nk=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "19c254d7cbbc4977a0b1d4d8c17b3e4051d67a0e",
+        "rev": "5942503289336c3f00348f16dea95e54e4b43b42",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`59425032`](https://github.com/nix-community/NUR/commit/5942503289336c3f00348f16dea95e54e4b43b42) | `` automatic update `` |
| [`9f82e437`](https://github.com/nix-community/NUR/commit/9f82e4376347bcd5be44dce39d45231e0618f642) | `` automatic update `` |
| [`1c3043eb`](https://github.com/nix-community/NUR/commit/1c3043ebc64237b37979a9878fb95c6eb7bb39a8) | `` automatic update `` |
| [`4c682e65`](https://github.com/nix-community/NUR/commit/4c682e6595400dd3cec580b326823cc0ddc48c38) | `` automatic update `` |
| [`32d45bbe`](https://github.com/nix-community/NUR/commit/32d45bbeee96eee2eaf254d03550195791593f95) | `` automatic update `` |
| [`42a183f8`](https://github.com/nix-community/NUR/commit/42a183f8e1d936983acf75e2f76b588b7cf84d15) | `` automatic update `` |