### PR TITLE
chore(flake/impermanence): `123e9420` -> `3d599bd6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
     },
     "impermanence": {
       "locked": {
-        "lastModified": 1702984171,
-        "narHash": "sha256-reIUBrUXibohXmvXRsgpvtlCE0QQSvWSA+qQCKohgR0=",
+        "lastModified": 1703606475,
+        "narHash": "sha256-ztFe33E2f+XmrvOFOy9NDvQCkvfQUE6K/BBV+ZtCZLs=",
         "owner": "nix-community",
         "repo": "impermanence",
-        "rev": "123e94200f63952639492796b8878e588a4a2851",
+        "rev": "3d599bd65eb383bc36191ba39ed6084674b0d7b2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                              |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
| [`3d599bd6`](https://github.com/nix-community/impermanence/commit/3d599bd65eb383bc36191ba39ed6084674b0d7b2) | `` Partial revert of 8d16ac97980b3641078dd7c11337bfaa77b45789 ``     |
| [`8d16ac97`](https://github.com/nix-community/impermanence/commit/8d16ac97980b3641078dd7c11337bfaa77b45789) | `` lib: Remove sanitizeName, replace usage with escapeSystemdPath `` |