### PR TITLE
chore(flake/nur): `59425032` -> `76bf3c9f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -604,11 +604,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703548790,
-        "narHash": "sha256-YYZ9vYZDSjID013xM8ztXbxl3Y6JrkQPT4Pux2qj9nk=",
+        "lastModified": 1703605930,
+        "narHash": "sha256-NZBd3FttBOpwT6yfJExoVxsJSca87wPr+ss5e6637R4=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "5942503289336c3f00348f16dea95e54e4b43b42",
+        "rev": "76bf3c9fef2bf7bc97d9126c5866fb6c7939ca9a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`76bf3c9f`](https://github.com/nix-community/NUR/commit/76bf3c9fef2bf7bc97d9126c5866fb6c7939ca9a) | `` automatic update `` |
| [`d0e27ec3`](https://github.com/nix-community/NUR/commit/d0e27ec3d4fd51824f429a3828d071a556dbb413) | `` automatic update `` |
| [`18dafae6`](https://github.com/nix-community/NUR/commit/18dafae6daed11a4cba0b0ad3ff20094d2e6727d) | `` automatic update `` |
| [`52f3f4ea`](https://github.com/nix-community/NUR/commit/52f3f4ea1d6b27123b6cba210eb5e65c3e34500a) | `` automatic update `` |
| [`8f651ea6`](https://github.com/nix-community/NUR/commit/8f651ea64c1b8b62c02a176848a36a69a4094f57) | `` automatic update `` |
| [`842cf3e2`](https://github.com/nix-community/NUR/commit/842cf3e24baec3a4c31fe088a59612d3bfeeb985) | `` automatic update `` |
| [`bbe66d72`](https://github.com/nix-community/NUR/commit/bbe66d72d2499b16efeebb0309c7999bc8933dd8) | `` automatic update `` |
| [`fa1000f0`](https://github.com/nix-community/NUR/commit/fa1000f0d3d277a77baa9fb19425826a24afea48) | `` automatic update `` |
| [`6aa07a67`](https://github.com/nix-community/NUR/commit/6aa07a672b781c94206014f96db80da82ffdc376) | `` automatic update `` |
| [`d1b82365`](https://github.com/nix-community/NUR/commit/d1b823656e142b94efd4e09b63bb03ae764ca794) | `` automatic update `` |
| [`7a334094`](https://github.com/nix-community/NUR/commit/7a334094f8fa00eae621dc40c904754f5531bde2) | `` automatic update `` |
| [`21454932`](https://github.com/nix-community/NUR/commit/21454932513cc1d81e45eb9d05d465edd0469066) | `` automatic update `` |
| [`f4e69e16`](https://github.com/nix-community/NUR/commit/f4e69e161f4856613b5aa9cbc4b5f7c646896214) | `` automatic update `` |
| [`6e356c8d`](https://github.com/nix-community/NUR/commit/6e356c8d7e6b5ab411fcbb101f41b0c1784325b7) | `` automatic update `` |
| [`c8acba9b`](https://github.com/nix-community/NUR/commit/c8acba9b876e5e8822fa9f92d6ddf2a877c15f43) | `` automatic update `` |
| [`2dc43692`](https://github.com/nix-community/NUR/commit/2dc4369294f1fc527959b69d137cea724026bada) | `` automatic update `` |
| [`141d25d1`](https://github.com/nix-community/NUR/commit/141d25d192884d9b331d1d2a70d040671c4a9533) | `` automatic update `` |
| [`cffd2441`](https://github.com/nix-community/NUR/commit/cffd2441f3c43b9e02138ac35cebcc24497fd22e) | `` automatic update `` |
| [`c6653d15`](https://github.com/nix-community/NUR/commit/c6653d1530088d079c17238c188024531160cfa3) | `` automatic update `` |
| [`e6a37157`](https://github.com/nix-community/NUR/commit/e6a3715774bfe0f4d0969ad2f2117f43cbb7bc79) | `` automatic update `` |
| [`c22374d8`](https://github.com/nix-community/NUR/commit/c22374d83354ffdeede1a7db643ab1680aa09eb0) | `` automatic update `` |
| [`af764377`](https://github.com/nix-community/NUR/commit/af76437785fb4449474ac15d7b13718e296028a1) | `` automatic update `` |
| [`a0af583f`](https://github.com/nix-community/NUR/commit/a0af583f77d7c1ffa5616777ccf5a3021de939eb) | `` automatic update `` |
| [`648dd9bd`](https://github.com/nix-community/NUR/commit/648dd9bde22367d3d3bb02e4f98d4dd4178b36a7) | `` automatic update `` |
| [`58ae575e`](https://github.com/nix-community/NUR/commit/58ae575ebe56dac6cfdf84461c7db932a73cc283) | `` automatic update `` |
| [`47cd4d0f`](https://github.com/nix-community/NUR/commit/47cd4d0f24be45867459ee161ac1e379942743ab) | `` automatic update `` |
| [`3fefa67e`](https://github.com/nix-community/NUR/commit/3fefa67e081398d0e34ffe1405bea20018f888c2) | `` automatic update `` |
| [`a961113c`](https://github.com/nix-community/NUR/commit/a961113c09bda61f82f29979f1fa24989ac005e4) | `` automatic update `` |
| [`f6ba198c`](https://github.com/nix-community/NUR/commit/f6ba198c3e2b3d0320a7d3297f3ffbbe8b4b565a) | `` automatic update `` |
| [`85e688db`](https://github.com/nix-community/NUR/commit/85e688dbf6f9638101c1aeabad9b7e624589a5c4) | `` automatic update `` |
| [`b3b7f885`](https://github.com/nix-community/NUR/commit/b3b7f8855061c718e19b9ea0e886bde917696212) | `` automatic update `` |
| [`d7117427`](https://github.com/nix-community/NUR/commit/d7117427fcbe57d970b7c92348614b8b39976b3a) | `` automatic update `` |
| [`10525052`](https://github.com/nix-community/NUR/commit/1052505298dd640ed1af8acc952c258dcbfb4495) | `` automatic update `` |
| [`838334d5`](https://github.com/nix-community/NUR/commit/838334d5f54962976267d741be8a85b00ebe95c3) | `` automatic update `` |
| [`c3cdc7aa`](https://github.com/nix-community/NUR/commit/c3cdc7aa92b48127db8f9351bdfcc4843a415fd1) | `` automatic update `` |
| [`a40c29c5`](https://github.com/nix-community/NUR/commit/a40c29c5c7beb812885ef39f0682457655dc6017) | `` automatic update `` |
| [`295bb06b`](https://github.com/nix-community/NUR/commit/295bb06b562f57c7120ff489e8b930354b048291) | `` automatic update `` |
| [`b3967cff`](https://github.com/nix-community/NUR/commit/b3967cffef433fe025ef03ebca93a56376fbcb88) | `` automatic update `` |
| [`556226bd`](https://github.com/nix-community/NUR/commit/556226bda4a6c2be8db9afea16576fb8b89ca7af) | `` automatic update `` |
| [`dfd1f9d6`](https://github.com/nix-community/NUR/commit/dfd1f9d6802a4a4532e9e6260cbc207af2a13126) | `` automatic update `` |
| [`33b141cc`](https://github.com/nix-community/NUR/commit/33b141ccbd4783cc6454c6263cb440c4f454169e) | `` automatic update `` |
| [`3e9e98ff`](https://github.com/nix-community/NUR/commit/3e9e98ffcf3e79c3e83023f6d7b069c0be5bc96b) | `` automatic update `` |