### PR TITLE
chore(flake/chaotic): `1da8a8ce` -> `80d0d925`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1703605076,
-        "narHash": "sha256-5M4ycYaA2aMJOeLUGpmLNrnXHMF+gpk5yaYvpki9Oug=",
+        "lastModified": 1703606540,
+        "narHash": "sha256-3hAf+mcr6iZj7dGL3UBPSlHpi7iukAQx3Um2Px4DyDs=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "1da8a8ce3f56121920fb04ecbe5d49c60631052c",
+        "rev": "80d0d925101f84a36db5c2b85cb69266e0d95391",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                  |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
| [`80d0d925`](https://github.com/chaotic-cx/nyx/commit/80d0d925101f84a36db5c2b85cb69266e0d95391) | `` build(deps): bump actions/deploy-pages from 3 to 4 (#505) ``          |
| [`c3a9eeba`](https://github.com/chaotic-cx/nyx/commit/c3a9eeba64cd36b536728a88de4f4eee9228d5b0) | `` build(deps): bump actions/upload-pages-artifact from 2 to 3 (#506) `` |