### PR TITLE
chore(flake/nur): `76bf3c9f` -> `a17e7841`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -604,11 +604,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703605930,
-        "narHash": "sha256-NZBd3FttBOpwT6yfJExoVxsJSca87wPr+ss5e6637R4=",
+        "lastModified": 1703634709,
+        "narHash": "sha256-MBzASzznDbUOcBUme32dks8V7gnjdoOEzhAX0L2h/Qc=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "76bf3c9fef2bf7bc97d9126c5866fb6c7939ca9a",
+        "rev": "a17e7841c4d587aa3cb579b0fc156055b3dad82f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a17e7841`](https://github.com/nix-community/NUR/commit/a17e7841c4d587aa3cb579b0fc156055b3dad82f) | `` automatic update `` |
| [`042eb455`](https://github.com/nix-community/NUR/commit/042eb455bd997f3e42d9cc375e040eedeee09bf1) | `` automatic update `` |
| [`14b7a9bb`](https://github.com/nix-community/NUR/commit/14b7a9bbe4279629c3474da4a1b5278f6f59bfcc) | `` automatic update `` |
| [`240f5923`](https://github.com/nix-community/NUR/commit/240f59239abdb11caf595230bf654c9c6b5c3ae2) | `` automatic update `` |
| [`11f71910`](https://github.com/nix-community/NUR/commit/11f7191037b0715f3fe788ffc94167dda60713a1) | `` automatic update `` |
| [`43d8e56b`](https://github.com/nix-community/NUR/commit/43d8e56b63ca8753b0a18996a4a856844aea5277) | `` automatic update `` |
| [`e914f3f1`](https://github.com/nix-community/NUR/commit/e914f3f1c7056da7cb9e98e2ddfeb282edc33a13) | `` automatic update `` |
| [`2dad9f03`](https://github.com/nix-community/NUR/commit/2dad9f03bf72c6033f27e5dd6599e63d3af902d2) | `` automatic update `` |
| [`5eec3223`](https://github.com/nix-community/NUR/commit/5eec32231557faed7d0eeae215396b6477890ec7) | `` automatic update `` |
| [`d427ac6a`](https://github.com/nix-community/NUR/commit/d427ac6aa41cb499a082fec98d4afec26cfd34ab) | `` automatic update `` |
| [`72438aad`](https://github.com/nix-community/NUR/commit/72438aada38bcd28f4d91a4111874362085a67a6) | `` automatic update `` |
| [`af4c919f`](https://github.com/nix-community/NUR/commit/af4c919fc61df96b2bd79ca6242d6d8bf3d877d3) | `` automatic update `` |
| [`364a1bce`](https://github.com/nix-community/NUR/commit/364a1bce5ab42f324ac97799c4882601531937ac) | `` automatic update `` |
| [`af6917e0`](https://github.com/nix-community/NUR/commit/af6917e0727bcbc1077ee3285ef2242aa778dd4a) | `` automatic update `` |
| [`e807c03e`](https://github.com/nix-community/NUR/commit/e807c03ee64bfad00a24b046539e277945a86b07) | `` automatic update `` |
| [`167aa98c`](https://github.com/nix-community/NUR/commit/167aa98c5d06c6cc5358c2a4abca5fb0bda44ec4) | `` automatic update `` |