### PR TITLE
chore(flake/nur): `a17e7841` -> `8d246efc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -604,11 +604,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703634709,
-        "narHash": "sha256-MBzASzznDbUOcBUme32dks8V7gnjdoOEzhAX0L2h/Qc=",
+        "lastModified": 1703676605,
+        "narHash": "sha256-eNG//Mh7valKxkso3H6TG//iwdTBF1fNRdcUr2C87Gc=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "a17e7841c4d587aa3cb579b0fc156055b3dad82f",
+        "rev": "8d246efce3b379865a4a745eec421c00d1a0cbb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8d246efc`](https://github.com/nix-community/NUR/commit/8d246efce3b379865a4a745eec421c00d1a0cbb2) | `` automatic update `` |
| [`1830a38c`](https://github.com/nix-community/NUR/commit/1830a38cc171d76d5e86ca12ab1d70b23beb6110) | `` automatic update `` |
| [`19f42c15`](https://github.com/nix-community/NUR/commit/19f42c15735b6ba7a74b9fec2f56bd27fd0ffc29) | `` automatic update `` |
| [`ce591652`](https://github.com/nix-community/NUR/commit/ce59165220f83fe5eeb5e9ffbe2a6dfa5221ea5b) | `` automatic update `` |
| [`0d2ffe75`](https://github.com/nix-community/NUR/commit/0d2ffe75a173b2d2c187b7a8602bcc708d79ff49) | `` automatic update `` |
| [`77148af8`](https://github.com/nix-community/NUR/commit/77148af843e8f11c0f0c41849c83715744f052da) | `` automatic update `` |
| [`578ae34a`](https://github.com/nix-community/NUR/commit/578ae34abeca4f76eb7ac9a2f74475653b8a3537) | `` automatic update `` |
| [`8e0c5261`](https://github.com/nix-community/NUR/commit/8e0c526141a835dbbc22982b496e5e2e3d6eb435) | `` automatic update `` |
| [`e65636be`](https://github.com/nix-community/NUR/commit/e65636be64a336e7110fc82cf7aab577f1ed8233) | `` automatic update `` |
| [`057540a6`](https://github.com/nix-community/NUR/commit/057540a62d095ef5c3728d2d4e57d627570342fb) | `` automatic update `` |
| [`9e89bb05`](https://github.com/nix-community/NUR/commit/9e89bb052cdd33452d93e8547854676007bf811e) | `` automatic update `` |
| [`2a88d2ed`](https://github.com/nix-community/NUR/commit/2a88d2edda986b90847d29f62137a3a0b6c5b7d8) | `` automatic update `` |
| [`188e6dc1`](https://github.com/nix-community/NUR/commit/188e6dc171c5b75885687c4fd04bfc07c7e73ec0) | `` automatic update `` |
| [`8d5bf37f`](https://github.com/nix-community/NUR/commit/8d5bf37f932e3fd4f55406d318f5f0466c47d250) | `` automatic update `` |
| [`5ab0fe70`](https://github.com/nix-community/NUR/commit/5ab0fe70169261b454aa0d657e750cc336dc2f66) | `` automatic update `` |
| [`6561f85a`](https://github.com/nix-community/NUR/commit/6561f85abf01b5f47ce49407d34ea7b3332d11a7) | `` automatic update `` |
| [`b9dbf025`](https://github.com/nix-community/NUR/commit/b9dbf0253330edcc52bcbd108f20ce7effd1e074) | `` automatic update `` |
| [`e1d82c8f`](https://github.com/nix-community/NUR/commit/e1d82c8f0ed97aede712c874e85eb59542f738e4) | `` automatic update `` |
| [`ad049d15`](https://github.com/nix-community/NUR/commit/ad049d154d06135d90dbb8199f6bbd48186c84a4) | `` automatic update `` |
| [`1da5be11`](https://github.com/nix-community/NUR/commit/1da5be1115392fb61132573830eef294ba91e661) | `` automatic update `` |
| [`fd862845`](https://github.com/nix-community/NUR/commit/fd8628457bdc75039ca1a447fdf468f32076d823) | `` automatic update `` |
| [`a8ef6d3a`](https://github.com/nix-community/NUR/commit/a8ef6d3ae7a298d0b94677063854009e1bfa0651) | `` automatic update `` |
| [`d711c29a`](https://github.com/nix-community/NUR/commit/d711c29a40fa934442e4f83bf30c82b3c2493383) | `` automatic update `` |
| [`a8cc0b15`](https://github.com/nix-community/NUR/commit/a8cc0b155382590d8ea1aa6b300caeb51d759ce2) | `` automatic update `` |
| [`4b648583`](https://github.com/nix-community/NUR/commit/4b648583aa2718a55740bd6f7e2916c9771762c8) | `` automatic update `` |
| [`cf680e25`](https://github.com/nix-community/NUR/commit/cf680e259fbf905d8f90f217e878e633d39c882a) | `` automatic update `` |
| [`c7f3b1f4`](https://github.com/nix-community/NUR/commit/c7f3b1f4a4160a0358dd5f1e13821facb9936353) | `` automatic update `` |
| [`41a397cd`](https://github.com/nix-community/NUR/commit/41a397cd1baee0cdd17fa3964759a1b07befaaa2) | `` automatic update `` |
| [`2bee8895`](https://github.com/nix-community/NUR/commit/2bee8895e3b12a9fdd149bd1d3a0d09f8f6e57d7) | `` automatic update `` |
| [`d49ff8b8`](https://github.com/nix-community/NUR/commit/d49ff8b8bf04de14639ef99f459848fb233d524d) | `` automatic update `` |
| [`ad71e873`](https://github.com/nix-community/NUR/commit/ad71e87321e20a5e1b1a2d4306573bc55b9fb227) | `` automatic update `` |
| [`83b7d78d`](https://github.com/nix-community/NUR/commit/83b7d78d7a50911f8b70ef9fa3050534fc2d8eaa) | `` automatic update `` |