### PR TITLE
chore(flake/emacs-overlay): `cf14f3f6` -> `995ac3a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1703607431,
-        "narHash": "sha256-WE3h5WyD5k0hnTRdNVQsRfbtBVz4YcrHcC4N4VmRef4=",
+        "lastModified": 1703664928,
+        "narHash": "sha256-nkJTUz2dqXX4S/Niod1iydmkkQ/oTPsQF/CvoWQN5zs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cf14f3f673227631fda56daf01d87e983da76efb",
+        "rev": "995ac3a4535431f4236df0e7e0b1c0f669cdb02d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`995ac3a4`](https://github.com/nix-community/emacs-overlay/commit/995ac3a4535431f4236df0e7e0b1c0f669cdb02d) | `` Updated flake inputs `` |
| [`c84fbd9b`](https://github.com/nix-community/emacs-overlay/commit/c84fbd9be553628e6295efb1cdb8c9d261e5bdff) | `` Updated elpa ``         |