### PR TITLE
chore(flake/lanzaboote): `47032189` -> `f707a9be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -379,11 +379,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1703546602,
-        "narHash": "sha256-V5UGPWD0eGiDE2rmqMxNZf6kbnW8+1f5pJV0uyw96mY=",
+        "lastModified": 1703662947,
+        "narHash": "sha256-2fp748jkpo0RGFRLlGTuYUUWueZdr6Z7uS+OWdFawxg=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "47032189f75d36fd024cb46a285c116f483e1241",
+        "rev": "f707a9be9f061c86a3e5cc163603dd59b5ee07aa",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                   |
| --------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`a74d5b25`](https://github.com/nix-community/lanzaboote/commit/a74d5b251b180ffd895bbdd52933a3a822fc4c54) | `` add framework specific instructions `` |