### PR TITLE
chore(flake/home-manager): `80679ea5` -> `45854459`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -287,11 +287,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703527373,
-        "narHash": "sha256-AjypRssRtS6F3xkf7rE3/bXkIF2WJOZLbTIspjcE1zM=",
+        "lastModified": 1703674883,
+        "narHash": "sha256-Jna6MOmLdfgot+AopHv28L+wpwVDfaiafLtO7E4bkj0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "80679ea5074ab7190c4cce478c600057cfb5edae",
+        "rev": "458544594ba7f0333cf5718045ee7a8eaf5de433",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                           |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`45854459`](https://github.com/nix-community/home-manager/commit/458544594ba7f0333cf5718045ee7a8eaf5de433) | `` gpg-agent: don't set a default for pinentry `` |
| [`2939d490`](https://github.com/nix-community/home-manager/commit/2939d490366251d9ed5a0bd938275c590a1d6fa6) | `` gh: test for existence of hosts file ``        |
| [`d1d95084`](https://github.com/nix-community/home-manager/commit/d1d950841d230490f308f5fcf8c0d4f2bd3f24a7) | `` gh: include version in settings ``             |