### PR TITLE
chore(flake/chaotic): `80d0d925` -> `40bd292c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1703606540,
-        "narHash": "sha256-3hAf+mcr6iZj7dGL3UBPSlHpi7iukAQx3Um2Px4DyDs=",
+        "lastModified": 1703681480,
+        "narHash": "sha256-UPyRX63LUT5+cEGCo1ksGBfKbnuMOyUCdrw869OVaBE=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "80d0d925101f84a36db5c2b85cb69266e0d95391",
+        "rev": "40bd292c8593bbb0fc642fd283a9e2adaeeeabcb",
         "type": "github"
       },
       "original": {
@@ -462,12 +462,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703255338,
-        "narHash": "sha256-Z6wfYJQKmDN9xciTwU3cOiOk+NElxdZwy/FiHctCzjU=",
-        "rev": "6df37dc6a77654682fe9f071c62b4242b5342e04",
-        "revCount": 562218,
+        "lastModified": 1703438236,
+        "narHash": "sha256-aqVBq1u09yFhL7bj1/xyUeJjzr92fXVvQSSEx6AdB1M=",
+        "rev": "5f64a12a728902226210bf01d25ec6cbb9d9265b",
+        "revCount": 562833,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.562218%2Brev-6df37dc6a77654682fe9f071c62b4242b5342e04/018c99c5-83a2-762d-ae43-a38f3be5b2d9/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.562833%2Brev-5f64a12a728902226210bf01d25ec6cbb9d9265b/018ca9f4-42a7-7828-8331-3bf7a7b1ceb5/source.tar.gz"
       },
       "original": {
         "type": "tarball",


### PR DESCRIPTION
| Commit                                                                                          | Message                                 |
| ----------------------------------------------------------------------------------------------- | --------------------------------------- |
| [`40bd292c`](https://github.com/chaotic-cx/nyx/commit/40bd292c8593bbb0fc642fd283a9e2adaeeeabcb) | `` river_git: return to wlroots_0_16 `` |
| [`10ad0dea`](https://github.com/chaotic-cx/nyx/commit/10ad0dea4067e606810bfd258e4ee7135961d34f) | `` wlroots_git: update postOverrides `` |
| [`958f0d8f`](https://github.com/chaotic-cx/nyx/commit/958f0d8f09cee3b973d7dc54f24838595f2ed4f1) | `` nixpkgs: bump to 20231227 ``         |