### PR TITLE
chore(flake/nur): `8d246efc` -> `eacde6f9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -555,11 +555,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703676605,
-        "narHash": "sha256-eNG//Mh7valKxkso3H6TG//iwdTBF1fNRdcUr2C87Gc=",
+        "lastModified": 1703699125,
+        "narHash": "sha256-+SbREQK/wr+Fk+Bx6oiQt2hexZ3lxWohbtqtGjf9r2Q=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "8d246efce3b379865a4a745eec421c00d1a0cbb2",
+        "rev": "eacde6f9403222e20a511995f87cb30b3d445b10",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`eacde6f9`](https://github.com/nix-community/NUR/commit/eacde6f9403222e20a511995f87cb30b3d445b10) | `` automatic update `` |
| [`ddd1a3db`](https://github.com/nix-community/NUR/commit/ddd1a3db18697d791c26c5f372948c1afe769e62) | `` automatic update `` |
| [`544f12df`](https://github.com/nix-community/NUR/commit/544f12dfd015f630784a654d31f2dcbad6af3d0d) | `` automatic update `` |
| [`9f98452a`](https://github.com/nix-community/NUR/commit/9f98452a12d5214423cd26a9b2d1c713654b1312) | `` automatic update `` |
| [`1e2a5cb8`](https://github.com/nix-community/NUR/commit/1e2a5cb870dc8f4b04e19b948cacf42053221368) | `` automatic update `` |
| [`9243f9c8`](https://github.com/nix-community/NUR/commit/9243f9c8e1e2ca2b73b62572f7cb1cb1e92fd8c4) | `` automatic update `` |
| [`37316d96`](https://github.com/nix-community/NUR/commit/37316d96a2d37c8d399922483dac769ffd5dbf38) | `` automatic update `` |
| [`363ffe21`](https://github.com/nix-community/NUR/commit/363ffe2170c5ff1bb78ee7c156cfd26fb587e383) | `` automatic update `` |
| [`21c86cf3`](https://github.com/nix-community/NUR/commit/21c86cf3e57d0e0d5259c917ce89c44f0d06a169) | `` automatic update `` |
| [`64dd7ce9`](https://github.com/nix-community/NUR/commit/64dd7ce9a659297cf581c2b034d42c834e896bed) | `` automatic update `` |
| [`ee0dc74d`](https://github.com/nix-community/NUR/commit/ee0dc74d9fe06ab1a7736e505a4523aef74525d6) | `` automatic update `` |
| [`1a15c29d`](https://github.com/nix-community/NUR/commit/1a15c29d2db118ba4bd50fe309fa35642d944881) | `` automatic update `` |
| [`f94da38b`](https://github.com/nix-community/NUR/commit/f94da38b867ae2aa49161a46c0924b3de2adc519) | `` automatic update `` |
| [`f0e4ba44`](https://github.com/nix-community/NUR/commit/f0e4ba441f1b7a9568bc9ef00c5965333935004d) | `` automatic update `` |