### PR TITLE
chore(flake/nur): `eacde6f9` -> `de9b2c75`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -555,11 +555,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703699125,
-        "narHash": "sha256-+SbREQK/wr+Fk+Bx6oiQt2hexZ3lxWohbtqtGjf9r2Q=",
+        "lastModified": 1703720483,
+        "narHash": "sha256-v88jI4UbJIkzMNB5CyCpTFAh3RFsxz9pDHx8m3w3hmA=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "eacde6f9403222e20a511995f87cb30b3d445b10",
+        "rev": "de9b2c75516c957d9bcb8dbe37a8579147ce1fb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`de9b2c75`](https://github.com/nix-community/NUR/commit/de9b2c75516c957d9bcb8dbe37a8579147ce1fb2) | `` automatic update `` |
| [`c87af07c`](https://github.com/nix-community/NUR/commit/c87af07ce867559cc69406350b6b83a7b015bd25) | `` automatic update `` |
| [`0976440a`](https://github.com/nix-community/NUR/commit/0976440a978762424e00b29fc3896be286f7dcc4) | `` automatic update `` |
| [`9b29b6af`](https://github.com/nix-community/NUR/commit/9b29b6af5a3189c253f3d558942b6947e61be44b) | `` automatic update `` |
| [`c19379eb`](https://github.com/nix-community/NUR/commit/c19379eb0ff74e34a546cdfec94f5a7313cd0899) | `` automatic update `` |
| [`b121e90a`](https://github.com/nix-community/NUR/commit/b121e90ae08cbd33362c5c3a6c301773803e2f77) | `` automatic update `` |
| [`6b1053d8`](https://github.com/nix-community/NUR/commit/6b1053d885bf5f7a672a53822c7114669e73152b) | `` automatic update `` |
| [`3ac52481`](https://github.com/nix-community/NUR/commit/3ac52481bc380fe84574f76402b6f9abcbe556b7) | `` automatic update `` |
| [`24dfdcb8`](https://github.com/nix-community/NUR/commit/24dfdcb8178ac846687ec5035bc69fb0677bb488) | `` automatic update `` |
| [`706544a2`](https://github.com/nix-community/NUR/commit/706544a26f8415f193d5a9c0f825b90ad463383d) | `` automatic update `` |
| [`d26de410`](https://github.com/nix-community/NUR/commit/d26de4108965a685c8d85fe4db1fc5904e03c359) | `` automatic update `` |
| [`4e02c8a2`](https://github.com/nix-community/NUR/commit/4e02c8a23a7153534306ef5e21a3dc77fe61f931) | `` automatic update `` |
| [`da172d8a`](https://github.com/nix-community/NUR/commit/da172d8ad18cd296f7174e2d1c46ab84625d1c4f) | `` automatic update `` |