### PR TITLE
chore(flake/lanzaboote): `f707a9be` -> `7229dd85`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -330,11 +330,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1703662947,
-        "narHash": "sha256-2fp748jkpo0RGFRLlGTuYUUWueZdr6Z7uS+OWdFawxg=",
+        "lastModified": 1703712542,
+        "narHash": "sha256-317EoHaQ5OwRLEjwjQUY57FpLDl75kEBbrohH7zbfRQ=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "f707a9be9f061c86a3e5cc163603dd59b5ee07aa",
+        "rev": "7229dd85f98341520b02fd46662f38d0af511d6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                                        |
| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`f06680ea`](https://github.com/nix-community/lanzaboote/commit/f06680ea681ff6675122a49d44081ef1cf77a604) | `` add more helpful message in case of append_initrd_secrets script failure `` |