### PR TITLE
chore(flake/home-manager): `45854459` -> `77c698fa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -287,11 +287,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703674883,
-        "narHash": "sha256-Jna6MOmLdfgot+AopHv28L+wpwVDfaiafLtO7E4bkj0=",
+        "lastModified": 1703808179,
+        "narHash": "sha256-svlFDbozZlZJwnnSoeh5yE9jEnCmgmuRMRX866CL4J0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "458544594ba7f0333cf5718045ee7a8eaf5de433",
+        "rev": "77c698fa4b3081b6019ad77d1bfedf06dbbde0db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`77c698fa`](https://github.com/nix-community/home-manager/commit/77c698fa4b3081b6019ad77d1bfedf06dbbde0db) | `` zsh: add support for zproof ``                       |
| [`30f9cdd6`](https://github.com/nix-community/home-manager/commit/30f9cdd69d1486a3d5cddaaabef7288d8ed389ee) | `` oh-my-posh: fix test under Darwin ``                 |
| [`ba6b7501`](https://github.com/nix-community/home-manager/commit/ba6b75011b44e85b1b755b6c423f85d0817645f7) | `` alacritty: make compatible with alacritty 0.13 ``    |
| [`f8a4a5c1`](https://github.com/nix-community/home-manager/commit/f8a4a5c18f4fee53ac3016a52a97df2aaeede65b) | `` gh: idempotently consider existing symlinks ``       |
| [`6e2afa5c`](https://github.com/nix-community/home-manager/commit/6e2afa5c3b8bb17bdc7c1a5be896aed177449f59) | `` sftpman: add module ``                               |
| [`c24c2985`](https://github.com/nix-community/home-manager/commit/c24c298562fe41b39909f632c5a7151bbf6b4628) | `` zsh.prezto: fix path in example for 'pmoduleDirs' `` |
| [`0f11c140`](https://github.com/nix-community/home-manager/commit/0f11c140657cc1d78febec4d6aca3836422600d2) | `` osmscout-server: add module ``                       |