### PR TITLE
chore(flake/nur): `de9b2c75` -> `c5559571`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -555,11 +555,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703720483,
-        "narHash": "sha256-v88jI4UbJIkzMNB5CyCpTFAh3RFsxz9pDHx8m3w3hmA=",
+        "lastModified": 1703808960,
+        "narHash": "sha256-GzOQyP/FghPp5Ddl6Fai/QiQj2F1XnNWI2FbBcd54yY=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "de9b2c75516c957d9bcb8dbe37a8579147ce1fb2",
+        "rev": "c55595716339a31cc05473395203f1444d546f3f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`c5559571`](https://github.com/nix-community/NUR/commit/c55595716339a31cc05473395203f1444d546f3f) | `` automatic update `` |
| [`cee45814`](https://github.com/nix-community/NUR/commit/cee4581467953d2c1be3e57450fb0023d52f342e) | `` automatic update `` |
| [`d52c3b8e`](https://github.com/nix-community/NUR/commit/d52c3b8e906cc63efe311ae6277867f7b68f3bca) | `` automatic update `` |
| [`e8be9903`](https://github.com/nix-community/NUR/commit/e8be990308f12ae81ecf8a64df7ae1e015420911) | `` automatic update `` |
| [`f844dc36`](https://github.com/nix-community/NUR/commit/f844dc36ea88877a0a673f938668e36954e57683) | `` automatic update `` |
| [`1f7ee403`](https://github.com/nix-community/NUR/commit/1f7ee403b664b9e7c48805b57435e49fb37ba84a) | `` automatic update `` |
| [`35b54f7a`](https://github.com/nix-community/NUR/commit/35b54f7a8f4965f07422b8aa21b06678b24b676c) | `` automatic update `` |
| [`f058750c`](https://github.com/nix-community/NUR/commit/f058750c396c0afab41384476bae177d5d483624) | `` automatic update `` |
| [`e3a23952`](https://github.com/nix-community/NUR/commit/e3a23952344fd903df67ff1d4cc895f354e18631) | `` automatic update `` |
| [`734119e8`](https://github.com/nix-community/NUR/commit/734119e8a0a9eb808fafb9226d11386308a6df73) | `` automatic update `` |
| [`e348ad64`](https://github.com/nix-community/NUR/commit/e348ad64a29ac9e47a59db9d4e2d7467363d1b95) | `` automatic update `` |
| [`a3457762`](https://github.com/nix-community/NUR/commit/a3457762e421ad9ea74a4ffc68fcf96c44836669) | `` automatic update `` |
| [`1ab2dd64`](https://github.com/nix-community/NUR/commit/1ab2dd641dcc59d6c8f19f130ea138ff27c0e3a0) | `` automatic update `` |
| [`db2144bf`](https://github.com/nix-community/NUR/commit/db2144bf7f54ce3d0c9519dfd6d342f761e7159e) | `` automatic update `` |
| [`0e68c96e`](https://github.com/nix-community/NUR/commit/0e68c96e8fc25b76666cd0ed5daa822eb8aa6ed7) | `` automatic update `` |
| [`2b0eeddf`](https://github.com/nix-community/NUR/commit/2b0eeddf3204f2af77ab051f911f372d6f6ccea7) | `` automatic update `` |
| [`8df7eb39`](https://github.com/nix-community/NUR/commit/8df7eb39e347fe6cf2d172d3cda9a93cd9e6b6ba) | `` automatic update `` |
| [`f0dd3564`](https://github.com/nix-community/NUR/commit/f0dd356478a436d94891481336471d6061da527a) | `` automatic update `` |
| [`e4ff8935`](https://github.com/nix-community/NUR/commit/e4ff893588c411ce803042b407c054e1a9c4a66e) | `` automatic update `` |
| [`4d4e8575`](https://github.com/nix-community/NUR/commit/4d4e8575055b7d834bc711ed8bdec7e5e9f3af65) | `` automatic update `` |
| [`6dd0993a`](https://github.com/nix-community/NUR/commit/6dd0993a099f6ddc68c8dbe564b673e1189a3e63) | `` automatic update `` |
| [`bcac070e`](https://github.com/nix-community/NUR/commit/bcac070e0ecea73adf9d6dd43559c81743e741fd) | `` automatic update `` |
| [`b00fc2a5`](https://github.com/nix-community/NUR/commit/b00fc2a535d4a2d869460da829bb0a08dbb63be2) | `` automatic update `` |
| [`2461abc7`](https://github.com/nix-community/NUR/commit/2461abc793980def8d06f23bb846ef94adb6c90d) | `` automatic update `` |
| [`c2fac218`](https://github.com/nix-community/NUR/commit/c2fac2182a694971a3974018371027a931da1ff6) | `` automatic update `` |
| [`f6d4cb01`](https://github.com/nix-community/NUR/commit/f6d4cb01806cf5836cf907bad740ee4d768b47c8) | `` automatic update `` |
| [`5f831c8d`](https://github.com/nix-community/NUR/commit/5f831c8dba3b92c863497c5422652ed46b53fd01) | `` automatic update `` |
| [`e21bafac`](https://github.com/nix-community/NUR/commit/e21bafac0b2de6947ce95cdc7a17058fb98a6fe8) | `` automatic update `` |
| [`83306ebb`](https://github.com/nix-community/NUR/commit/83306ebb8cca356a168ecfd9697664766245707f) | `` automatic update `` |
| [`89c7ff47`](https://github.com/nix-community/NUR/commit/89c7ff47b90fe0e6cf91ade4e5cffbe83492fe32) | `` automatic update `` |
| [`e1001856`](https://github.com/nix-community/NUR/commit/e1001856d8f2c5cc72f9288754122da84459bf49) | `` automatic update `` |
| [`5ffa50aa`](https://github.com/nix-community/NUR/commit/5ffa50aa486e9e203bec5d0374354d4b0eac69b8) | `` automatic update `` |