### PR TITLE
chore(flake/chaotic): `40bd292c` -> `028a52d8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1703681480,
-        "narHash": "sha256-UPyRX63LUT5+cEGCo1ksGBfKbnuMOyUCdrw869OVaBE=",
+        "lastModified": 1703776891,
+        "narHash": "sha256-rrrXikaA4q+RhpdcFzFePa7Ssztxbl43S+gXsdzWWY8=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "40bd292c8593bbb0fc642fd283a9e2adaeeeabcb",
+        "rev": "028a52d83d609039bffe2c0f756e33f9b1faf1ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                     |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------- |
| [`028a52d8`](https://github.com/chaotic-cx/nyx/commit/028a52d83d609039bffe2c0f756e33f9b1faf1ee) | `` Bump 20231228-2 (#511) ``                |
| [`4e76c508`](https://github.com/chaotic-cx/nyx/commit/4e76c5089e39ce8b2bd26b981d8029b444a5e74b) | `` builder: create NYX_WD if necessary ``   |
| [`58e115d0`](https://github.com/chaotic-cx/nyx/commit/58e115d0a106fc110a2ec4e0ab3b687e1e77c920) | `` input-leap_git: new desktop unit name `` |
| [`8222f780`](https://github.com/chaotic-cx/nyx/commit/8222f780b56d185183c1fe9c97b17d9652106189) | `` Bump 20231227-2 (#509) ``                |