### PR TITLE
chore(flake/emacs-overlay): `d72b6439` -> `a405e8be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1703693864,
-        "narHash": "sha256-ILirBd/nTvyVrZINdSj5IJEDs76R0uIgzy4vKMj0Oe4=",
+        "lastModified": 1703796062,
+        "narHash": "sha256-xUcmgr007TeEshv4ZVZLAqTh0QWWCdJV40TltcPkv/c=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d72b6439873ce66a1183d1b28e00a173e8a63ed7",
+        "rev": "a405e8becb24d38d7e0c465b6432ea3155da66c6",
         "type": "github"
       },
       "original": {
@@ -507,16 +507,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1703351344,
-        "narHash": "sha256-9FEelzftkE9UaJ5nqxidaJJPEhe9TPhbypLHmc2Mysc=",
+        "lastModified": 1703467016,
+        "narHash": "sha256-/5A/dNPhbQx/Oa2d+Get174eNI3LERQ7u6WTWOlR1eQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7790e078f8979a9fcd543f9a47427eeaba38f268",
+        "rev": "d02d818f22c777aa4e854efc3242ec451e5d462a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }


### PR DESCRIPTION
| Commit                                                                                                       | Message                              |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------ |
| [`5205fb0c`](https://github.com/nix-community/emacs-overlay/commit/5205fb0c0ac5dfdb3f468b7581cd4fd4e289a4d9) | `` Updated elpa ``                   |
| [`71ccac2c`](https://github.com/nix-community/emacs-overlay/commit/71ccac2c15e3cef22b64de400df51132dbd45fd7) | `` Update github action version ``   |
| [`12a5452d`](https://github.com/nix-community/emacs-overlay/commit/12a5452d0edc6cb0e11391c069aef5538ebed31c) | `` Update nixpkgs-stable to 23.11 `` |
| [`5cd18705`](https://github.com/nix-community/emacs-overlay/commit/5cd18705d47b49e35f760a83fdc33dc6e1e3f757) | `` Updated elpa ``                   |