### PR TITLE
chore(flake/home-manager): `77c698fa` -> `2aff324c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -287,11 +287,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703808179,
-        "narHash": "sha256-svlFDbozZlZJwnnSoeh5yE9jEnCmgmuRMRX866CL4J0=",
+        "lastModified": 1703838268,
+        "narHash": "sha256-SRg5nXcdPnrsQR2MTAp7en0NyJnQ2wB1ivmsgEbvN+o=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "77c698fa4b3081b6019ad77d1bfedf06dbbde0db",
+        "rev": "2aff324cf65f5f98f89d878c056b779466b17db8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`2aff324c`](https://github.com/nix-community/home-manager/commit/2aff324cf65f5f98f89d878c056b779466b17db8) | `` bemenu: add module ``                  |
| [`c48ae40d`](https://github.com/nix-community/home-manager/commit/c48ae40dbbb9193b4766c020bca116e127455ab9) | `` Translate using Weblate (German) ``    |
| [`df7f29a2`](https://github.com/nix-community/home-manager/commit/df7f29a231a483c88cbd00608db99634f854a8e1) | `` zoxide: fix use with recent Nushell `` |