### PR TITLE
chore(flake/emacs-overlay): `a405e8be` -> `e9e995a2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1703796062,
-        "narHash": "sha256-xUcmgr007TeEshv4ZVZLAqTh0QWWCdJV40TltcPkv/c=",
+        "lastModified": 1703866754,
+        "narHash": "sha256-BvHW5KCttQaV7Pxq58uX2ZiFc2ezkEL9dZLa1kgLBRk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a405e8becb24d38d7e0c465b6432ea3155da66c6",
+        "rev": "e9e995a2f582217b7c4efe38415fafbbc06274d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`e9e995a2`](https://github.com/nix-community/emacs-overlay/commit/e9e995a2f582217b7c4efe38415fafbbc06274d2) | `` Updated elpa ``         |
| [`86bc6834`](https://github.com/nix-community/emacs-overlay/commit/86bc6834b2e1adffca92c6faf0431c1a453cb73f) | `` Updated nongnu ``       |
| [`a99d70ad`](https://github.com/nix-community/emacs-overlay/commit/a99d70addcc094dfb2c93d74073850c11c0b5a7f) | `` Updated elpa ``         |
| [`ceea404c`](https://github.com/nix-community/emacs-overlay/commit/ceea404cfe880edf745928fe93d7c39172dfce10) | `` Updated flake inputs `` |