### PR TITLE
chore(flake/chaotic): `028a52d8` -> `5d7c4dc2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1703776891,
-        "narHash": "sha256-rrrXikaA4q+RhpdcFzFePa7Ssztxbl43S+gXsdzWWY8=",
+        "lastModified": 1703857797,
+        "narHash": "sha256-FUo9ut8jgkkwHmyc50cBb/dJvpkvwQ5rTlYN1H5cZRI=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "028a52d83d609039bffe2c0f756e33f9b1faf1ee",
+        "rev": "5d7c4dc2cf946473179e4af3d1dea0320a730643",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                      |
| ----------------------------------------------------------------------------------------------- | ---------------------------- |
| [`5d7c4dc2`](https://github.com/chaotic-cx/nyx/commit/5d7c4dc2cf946473179e4af3d1dea0320a730643) | `` Bump 20231229-1 (#512) `` |