### PR TITLE
chore(flake/nur): `c5559571` -> `4a8f8f53`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -555,11 +555,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703808960,
-        "narHash": "sha256-GzOQyP/FghPp5Ddl6Fai/QiQj2F1XnNWI2FbBcd54yY=",
+        "lastModified": 1703879060,
+        "narHash": "sha256-U0dvm3qwldDDnR1jYE7gNNW7XChYCZ6JyUCcSFFDpBs=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "c55595716339a31cc05473395203f1444d546f3f",
+        "rev": "4a8f8f5355cb9d3334d311cb25fc6ab641b501dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4a8f8f53`](https://github.com/nix-community/NUR/commit/4a8f8f5355cb9d3334d311cb25fc6ab641b501dc) | `` automatic update `` |
| [`d33b3175`](https://github.com/nix-community/NUR/commit/d33b31759dd8e3bb431529c0937eb3692c09fa9a) | `` automatic update `` |
| [`89aaaf04`](https://github.com/nix-community/NUR/commit/89aaaf04fadc7ccfc0eedd64a07caead0cc724f4) | `` automatic update `` |
| [`a2d1b337`](https://github.com/nix-community/NUR/commit/a2d1b337dff56fdcd367543c81b83fd3691cd1d2) | `` automatic update `` |
| [`cbadac33`](https://github.com/nix-community/NUR/commit/cbadac330a86378a6329db095e8117b7a1caee74) | `` automatic update `` |
| [`41501f11`](https://github.com/nix-community/NUR/commit/41501f116aa6342148bed96fe95e119ee75c0f10) | `` automatic update `` |
| [`b34bc8a2`](https://github.com/nix-community/NUR/commit/b34bc8a22c11c874c50af0eab9a54936d1309062) | `` automatic update `` |
| [`2ab02ea2`](https://github.com/nix-community/NUR/commit/2ab02ea28ae5c71d3c8222c138fedc21b23a3ac2) | `` automatic update `` |
| [`9971cac4`](https://github.com/nix-community/NUR/commit/9971cac4cee4283043474d8b060c893b11774011) | `` automatic update `` |
| [`b96cc681`](https://github.com/nix-community/NUR/commit/b96cc681612efb6d3792e1a27624b8797dab066d) | `` automatic update `` |
| [`585f717d`](https://github.com/nix-community/NUR/commit/585f717d2a87856781fc5dd1ea455c53acaa365c) | `` automatic update `` |
| [`612af3a2`](https://github.com/nix-community/NUR/commit/612af3a2e918a1ad837e513b5223874a4e22dee4) | `` automatic update `` |
| [`79993d3b`](https://github.com/nix-community/NUR/commit/79993d3b2bdab4bd9e89e63100a394d8acdcc59d) | `` automatic update `` |
| [`ba245e1b`](https://github.com/nix-community/NUR/commit/ba245e1bc1934a2ec910cf2ba662f358930d2bb9) | `` automatic update `` |
| [`2fb90927`](https://github.com/nix-community/NUR/commit/2fb909274c2cd4b4fab94784b9ce0aa357f3e546) | `` automatic update `` |
| [`356e44fb`](https://github.com/nix-community/NUR/commit/356e44fbd597da1b2bd76edfbe79e835292e84b7) | `` automatic update `` |
| [`04460f8e`](https://github.com/nix-community/NUR/commit/04460f8e23bcbd81ca3349f7cd02f1d8e2a2000f) | `` automatic update `` |
| [`d52a4f82`](https://github.com/nix-community/NUR/commit/d52a4f82a23f183e5a4262f2d1d06f709575b668) | `` automatic update `` |
| [`e287e175`](https://github.com/nix-community/NUR/commit/e287e175bfa6bfceced446de1ae35565051b787c) | `` automatic update `` |
| [`bbdb3703`](https://github.com/nix-community/NUR/commit/bbdb3703460e678104c85bc010c5cb6c048a731a) | `` automatic update `` |
| [`363c3de2`](https://github.com/nix-community/NUR/commit/363c3de20f7a3ceebdc26c45763f863bbb4f20e8) | `` automatic update `` |
| [`c7564cb6`](https://github.com/nix-community/NUR/commit/c7564cb6467fe98d6f7d69be744f6c044400ed6c) | `` automatic update `` |