### PR TITLE
chore(flake/chaotic): `5d7c4dc2` -> `f2d920f8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1703857797,
-        "narHash": "sha256-FUo9ut8jgkkwHmyc50cBb/dJvpkvwQ5rTlYN1H5cZRI=",
+        "lastModified": 1703962563,
+        "narHash": "sha256-XMmCmZ5nO1b59fMnaVAyaLwPjRoXAU/517wFNLXgV7Q=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "5d7c4dc2cf946473179e4af3d1dea0320a730643",
+        "rev": "f2d920f8cbb50eb0f5f1ce7f7f29e5302da3df9d",
         "type": "github"
       },
       "original": {
@@ -462,12 +462,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703438236,
-        "narHash": "sha256-aqVBq1u09yFhL7bj1/xyUeJjzr92fXVvQSSEx6AdB1M=",
-        "rev": "5f64a12a728902226210bf01d25ec6cbb9d9265b",
-        "revCount": 562833,
+        "lastModified": 1703637592,
+        "narHash": "sha256-8MXjxU0RfFfzl57Zy3OfXCITS0qWDNLzlBAdwxGZwfY=",
+        "rev": "cfc3698c31b1fb9cdcf10f36c9643460264d0ca8",
+        "revCount": 563471,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.562833%2Brev-5f64a12a728902226210bf01d25ec6cbb9d9265b/018ca9f4-42a7-7828-8331-3bf7a7b1ceb5/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.563471%2Brev-cfc3698c31b1fb9cdcf10f36c9643460264d0ca8/018cba6b-15b2-7220-9cfe-6686400021db/source.tar.gz"
       },
       "original": {
         "type": "tarball",


### PR DESCRIPTION
| Commit                                                                                          | Message                                           |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`f2d920f8`](https://github.com/chaotic-cx/nyx/commit/f2d920f8cbb50eb0f5f1ce7f7f29e5302da3df9d) | `` Bump 20231230-2 (#516) ``                      |
| [`a0a792ad`](https://github.com/chaotic-cx/nyx/commit/a0a792ad7050a49a29bf41bcfa918f5ad857eef5) | `` makeMicroarch: propagate pkgs.config (#515) `` |
| [`7aae2712`](https://github.com/chaotic-cx/nyx/commit/7aae2712f6cc7cdcd4bf9b289f7e061142bdb2b2) | `` nixpkgs: bump to 20231230 ``                   |