### PR TITLE
chore(flake/nur): `4a8f8f53` -> `74bee334`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -555,11 +555,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1703879060,
-        "narHash": "sha256-U0dvm3qwldDDnR1jYE7gNNW7XChYCZ6JyUCcSFFDpBs=",
+        "lastModified": 1704057136,
+        "narHash": "sha256-+vj3PjcsFrjdo7op/Jb9xND206FsFatntp7SmTzc8W0=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "4a8f8f5355cb9d3334d311cb25fc6ab641b501dc",
+        "rev": "74bee334e8d3cadfe11fefea2ae426e0c25246d7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`74bee334`](https://github.com/nix-community/NUR/commit/74bee334e8d3cadfe11fefea2ae426e0c25246d7) | `` automatic update `` |
| [`e3a2c227`](https://github.com/nix-community/NUR/commit/e3a2c227b7de1a72acd98028d8c0cb6f3e2cec60) | `` automatic update `` |
| [`482be435`](https://github.com/nix-community/NUR/commit/482be435861d41bbd09d9184ad15b29227d08e9a) | `` automatic update `` |
| [`007a7cfd`](https://github.com/nix-community/NUR/commit/007a7cfd5ce34ae23ff23b643e8f10c7c83ad5c1) | `` automatic update `` |
| [`9dea3c00`](https://github.com/nix-community/NUR/commit/9dea3c00808304777d56dfda1b52ef942538c299) | `` automatic update `` |
| [`f675fc1d`](https://github.com/nix-community/NUR/commit/f675fc1d7301e8ad2c0d2c66a8d4970951cb7e58) | `` automatic update `` |
| [`cb219cf4`](https://github.com/nix-community/NUR/commit/cb219cf4a8d325e5033b62d49f199630033daa43) | `` automatic update `` |
| [`dabcec65`](https://github.com/nix-community/NUR/commit/dabcec657ae9207298c8b7aa88ff2311d531a970) | `` automatic update `` |
| [`3863e560`](https://github.com/nix-community/NUR/commit/3863e5608ec295f87d67ce2a24518147ba85e0f9) | `` automatic update `` |
| [`78f570d4`](https://github.com/nix-community/NUR/commit/78f570d42d724fd1f2af27bc8dbcd908c372c702) | `` automatic update `` |
| [`ca692c7f`](https://github.com/nix-community/NUR/commit/ca692c7f2a99c8e7f3b8e0e5dcf46b487f7d070f) | `` automatic update `` |
| [`226929e8`](https://github.com/nix-community/NUR/commit/226929e8cc2b5d634c27b5bf1b1ebb4fcc2ec9d5) | `` automatic update `` |
| [`c1a78c7e`](https://github.com/nix-community/NUR/commit/c1a78c7eeacb194aef527a7f41910f3866e2f14b) | `` automatic update `` |
| [`7872cce6`](https://github.com/nix-community/NUR/commit/7872cce6f656b96c49a1f79b76d97492b87c6185) | `` automatic update `` |
| [`2143145a`](https://github.com/nix-community/NUR/commit/2143145af49db2c3cd1b379b147bf34492e0e0a7) | `` automatic update `` |
| [`630d6092`](https://github.com/nix-community/NUR/commit/630d609286dfd153f2fcd404527d71214196ba8d) | `` automatic update `` |
| [`19501f4f`](https://github.com/nix-community/NUR/commit/19501f4ff5561cd21fce3e6602a9fd6325038fd0) | `` automatic update `` |
| [`4c3eb3a9`](https://github.com/nix-community/NUR/commit/4c3eb3a95083bfe47b5bd0ba58bb161d3abad053) | `` automatic update `` |
| [`8d103e25`](https://github.com/nix-community/NUR/commit/8d103e25b2d71e2e17b0893a3005c757ac79b71a) | `` automatic update `` |
| [`2c3a6ba2`](https://github.com/nix-community/NUR/commit/2c3a6ba262d51397ea99def5b9f792533812970b) | `` automatic update `` |
| [`5b1aa66b`](https://github.com/nix-community/NUR/commit/5b1aa66bea0076ffcf00c2491ae9be1015fd8533) | `` automatic update `` |
| [`ac64c155`](https://github.com/nix-community/NUR/commit/ac64c1551114d5eb7343e55d8a83f2d84d21884b) | `` automatic update `` |
| [`27b04d28`](https://github.com/nix-community/NUR/commit/27b04d2815108642a2427e471ad93695e297fa10) | `` automatic update `` |
| [`796747b3`](https://github.com/nix-community/NUR/commit/796747b378e54debbca6324327ca33b886f54612) | `` automatic update `` |
| [`da98676b`](https://github.com/nix-community/NUR/commit/da98676bb8b9485a0f828aa05653f12bebf93bbf) | `` automatic update `` |
| [`d3aae6da`](https://github.com/nix-community/NUR/commit/d3aae6da4d1546ffe8ee461076ddf79c8aeef142) | `` automatic update `` |
| [`0e355dee`](https://github.com/nix-community/NUR/commit/0e355dee364d5d78cb87db503709bb16bf4b3c52) | `` automatic update `` |
| [`3bd965ac`](https://github.com/nix-community/NUR/commit/3bd965ac372d2d65800cdab1308c47f6adf8f505) | `` automatic update `` |
| [`095f3462`](https://github.com/nix-community/NUR/commit/095f3462691861ac39f3b42e77f8f5bba56bfa88) | `` automatic update `` |
| [`7c6b68d9`](https://github.com/nix-community/NUR/commit/7c6b68d9805e5ba7d62ff169ce16702b59af0a39) | `` automatic update `` |
| [`ad45251f`](https://github.com/nix-community/NUR/commit/ad45251f54e0a7cee3592e3af1ec58b568d2f02c) | `` automatic update `` |
| [`046445f2`](https://github.com/nix-community/NUR/commit/046445f2b38b7a8ddc5c41463e10dad5d1fc01da) | `` automatic update `` |
| [`03922b58`](https://github.com/nix-community/NUR/commit/03922b5827645eb91d9e3b617d9cb3965840fae2) | `` automatic update `` |
| [`6522bf5b`](https://github.com/nix-community/NUR/commit/6522bf5bce59a0bc9960c9d79a70765204f64af0) | `` automatic update `` |
| [`a2e8e02e`](https://github.com/nix-community/NUR/commit/a2e8e02eb768e57c578a9ce4feb1c58e497e34d2) | `` automatic update `` |
| [`945e1bb3`](https://github.com/nix-community/NUR/commit/945e1bb3d8888a3bb2dcf7cfe29e650335055399) | `` automatic update `` |
| [`4f34e72a`](https://github.com/nix-community/NUR/commit/4f34e72a0067ca8dfef7ced6fdff29bc3a09506c) | `` automatic update `` |
| [`f5549b8a`](https://github.com/nix-community/NUR/commit/f5549b8ac21dfaace961708d6b1f0578ef94d82f) | `` automatic update `` |
| [`ba98d148`](https://github.com/nix-community/NUR/commit/ba98d1482678650833e821f1c63e9082d2d1829e) | `` automatic update `` |
| [`97e5f700`](https://github.com/nix-community/NUR/commit/97e5f7007b4d4fc46fad892dd27a145b8bf0a4b9) | `` automatic update `` |
| [`ffba221d`](https://github.com/nix-community/NUR/commit/ffba221d7183cf64704411fc640d213e00413198) | `` automatic update `` |
| [`ada6f2df`](https://github.com/nix-community/NUR/commit/ada6f2dfa25176e735f0a1899e83ec93ff422d46) | `` automatic update `` |
| [`7bfff817`](https://github.com/nix-community/NUR/commit/7bfff817d4921694d50c96571d8702b38d1831cd) | `` automatic update `` |
| [`8a656820`](https://github.com/nix-community/NUR/commit/8a65682071fd22a17950575fdbf5703297ecfb23) | `` automatic update `` |
| [`ae6fb319`](https://github.com/nix-community/NUR/commit/ae6fb319f88d5a995cb8dc4502c2d81c5fc1e578) | `` automatic update `` |
| [`ab31dcd1`](https://github.com/nix-community/NUR/commit/ab31dcd1445522e950a2ce0ae0dc4cbdc32a20fc) | `` automatic update `` |
| [`9286fb2f`](https://github.com/nix-community/NUR/commit/9286fb2fd0d017bc4657678cdfb3c948389f8a0a) | `` automatic update `` |
| [`a41eea0f`](https://github.com/nix-community/NUR/commit/a41eea0f67c4bcc0c735ccb7e4f1b474a2527e3b) | `` automatic update `` |
| [`023410bc`](https://github.com/nix-community/NUR/commit/023410bcd1995f6f27b0dcd36a456d20f9299aa4) | `` automatic update `` |
| [`bc4e5a2c`](https://github.com/nix-community/NUR/commit/bc4e5a2c2894cf2cf7369cb34ed47c72409eb3a7) | `` automatic update `` |
| [`e7438892`](https://github.com/nix-community/NUR/commit/e7438892ac72dca7b5876bb0a0ecdfb1750ccc9a) | `` automatic update `` |
| [`74624d97`](https://github.com/nix-community/NUR/commit/74624d97f4892360083e51a2609ca3d3d10c445b) | `` automatic update `` |
| [`7bccffe7`](https://github.com/nix-community/NUR/commit/7bccffe70f9cba167ab86dfed52d44954c5c2fc1) | `` automatic update `` |
| [`0c1ee9f7`](https://github.com/nix-community/NUR/commit/0c1ee9f70ecc53c62a9621fad899325a043c4ba6) | `` automatic update `` |
| [`0c482ca4`](https://github.com/nix-community/NUR/commit/0c482ca4bf19209dc57596182b0a67104e61e4a8) | `` automatic update `` |
| [`85f9196a`](https://github.com/nix-community/NUR/commit/85f9196afc954e5b23cb9629fb854b746db71575) | `` automatic update `` |
| [`e422ef8f`](https://github.com/nix-community/NUR/commit/e422ef8f4639f5542dae1a5e9ec54a5bb2344f10) | `` automatic update `` |
| [`193c938c`](https://github.com/nix-community/NUR/commit/193c938c3f5ad919dd1f71df64e543b2c7dc2dae) | `` automatic update `` |
| [`ee71b34d`](https://github.com/nix-community/NUR/commit/ee71b34d951f22777efe61347b734e1764c304f5) | `` automatic update `` |
| [`0e6880cf`](https://github.com/nix-community/NUR/commit/0e6880cf5f8ff087e2ec040ba9dcf82699c73da5) | `` automatic update `` |