### PR TITLE
chore(flake/emacs-overlay): `e9e995a2` -> `dbf41b39`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1703866754,
-        "narHash": "sha256-BvHW5KCttQaV7Pxq58uX2ZiFc2ezkEL9dZLa1kgLBRk=",
+        "lastModified": 1703953082,
+        "narHash": "sha256-hSxSE6vXqLze7yK9NpmGlnkYaLbY4hLfez9riVtvKP8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e9e995a2f582217b7c4efe38415fafbbc06274d2",
+        "rev": "dbf41b3900117bb836118f7d3144bae6878a1c5e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`dbf41b39`](https://github.com/nix-community/emacs-overlay/commit/dbf41b3900117bb836118f7d3144bae6878a1c5e) | `` Updated elpa ``         |
| [`abc8913c`](https://github.com/nix-community/emacs-overlay/commit/abc8913c8eb39cca83df7a878195f284af88e3ee) | `` Updated flake inputs `` |
| [`285a626f`](https://github.com/nix-community/emacs-overlay/commit/285a626fe34c40d6f3e3f63f69f4ceb0cfc29e80) | `` Updated elpa ``         |