### PR TITLE
chore(flake/nix-index-database): `f4340c1a` -> `d6510ce1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -423,11 +423,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703387252,
-        "narHash": "sha256-XKJqGj0BaEn/zyctEnkgVIh6Ba1rgTRc+UBi9EU8Y54=",
+        "lastModified": 1703992163,
+        "narHash": "sha256-709CGmwU34dxv8DjSpRBZ+HibVJIVaFcA4JH+GFnhyM=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "f4340c1a42c38d79293ba69bfd839fbd6268a538",
+        "rev": "d6510ce144f5da7dd9bac667ba3d5a4946c00d11",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`d6510ce1`](https://github.com/nix-community/nix-index-database/commit/d6510ce144f5da7dd9bac667ba3d5a4946c00d11) | `` update packages.nix to release 2023-12-31-030821 `` |
| [`2b2e6047`](https://github.com/nix-community/nix-index-database/commit/2b2e6047a258a5522b2ec8e5e01107bea7ae2d0c) | `` flake.lock: Update ``                               |