### PR TITLE
chore(flake/emacs-overlay): `dbf41b39` -> `3eaaeef7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1703953082,
-        "narHash": "sha256-hSxSE6vXqLze7yK9NpmGlnkYaLbY4hLfez9riVtvKP8=",
+        "lastModified": 1704039425,
+        "narHash": "sha256-rckPbxzkdkn7i6yg71K7aMmoC1taLR18Rv1FadWKLPw=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "dbf41b3900117bb836118f7d3144bae6878a1c5e",
+        "rev": "3eaaeef710b852dc55ef09b85cc438ca8c7f58b8",
         "type": "github"
       },
       "original": {
@@ -507,11 +507,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1703467016,
-        "narHash": "sha256-/5A/dNPhbQx/Oa2d+Get174eNI3LERQ7u6WTWOlR1eQ=",
+        "lastModified": 1703900474,
+        "narHash": "sha256-Zu+chYVYG2cQ4FCbhyo6rc5Lu0ktZCjRbSPE0fDgukI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d02d818f22c777aa4e854efc3242ec451e5d462a",
+        "rev": "9dd7699928e26c3c00d5d46811f1358524081062",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`3eaaeef7`](https://github.com/nix-community/emacs-overlay/commit/3eaaeef710b852dc55ef09b85cc438ca8c7f58b8) | `` Updated elpa ``         |
| [`e8ccf1b1`](https://github.com/nix-community/emacs-overlay/commit/e8ccf1b1586e022c8d5ac8667ae78c475f328061) | `` Updated nongnu ``       |
| [`3aa0c5fc`](https://github.com/nix-community/emacs-overlay/commit/3aa0c5fc7e1960258e5894fab855b8d7dc7809bb) | `` Updated flake inputs `` |
| [`fae6a53b`](https://github.com/nix-community/emacs-overlay/commit/fae6a53b30177995da0262a1b539898c48071f4b) | `` Updated elpa ``         |