### PR TITLE
chore(flake/emacs-overlay): `3eaaeef7` -> `7fd5b5b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704039425,
-        "narHash": "sha256-rckPbxzkdkn7i6yg71K7aMmoC1taLR18Rv1FadWKLPw=",
+        "lastModified": 1704125861,
+        "narHash": "sha256-irEN/GpvFmSMS63jmcz6lit2POJUnjlu1Yu99v5lWpk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3eaaeef710b852dc55ef09b85cc438ca8c7f58b8",
+        "rev": "7fd5b5b760ea726aa4c7670be7d93623936f9bf3",
         "type": "github"
       },
       "original": {
@@ -507,11 +507,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1703900474,
-        "narHash": "sha256-Zu+chYVYG2cQ4FCbhyo6rc5Lu0ktZCjRbSPE0fDgukI=",
+        "lastModified": 1703992652,
+        "narHash": "sha256-C0o8AUyu8xYgJ36kOxJfXIroy9if/G6aJbNOpA5W0+M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9dd7699928e26c3c00d5d46811f1358524081062",
+        "rev": "32f63574c85fbc80e4ba1fbb932cde9619bad25e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`7fd5b5b7`](https://github.com/nix-community/emacs-overlay/commit/7fd5b5b760ea726aa4c7670be7d93623936f9bf3) | `` Updated elpa ``         |
| [`e62cd63f`](https://github.com/nix-community/emacs-overlay/commit/e62cd63fa83d4dd9a81fe3695aa255e1d1d2ddbe) | `` Updated nongnu ``       |
| [`3750376a`](https://github.com/nix-community/emacs-overlay/commit/3750376a60b55eb5f2b62d7e89b34cde0c4f048e) | `` Updated flake inputs `` |
| [`75d58280`](https://github.com/nix-community/emacs-overlay/commit/75d582804c561bb16f726916096ee22272d156cc) | `` Updated elpa ``         |