### PR TITLE
chore(flake/spicetify-nix): `0fb5172a` -> `90bc3134`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -652,11 +652,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703995813,
-        "narHash": "sha256-J3XdAfetMeX2hNu2g95GtpOJtxM084cc6DRzlcNBPMg=",
+        "lastModified": 1704082252,
+        "narHash": "sha256-ifveB79w4u3SN5wgysEJmFDcMZ5qhiXdxGVimUYAS0M=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "0fb5172a1ded159d8558a10d9606bc23cbe9937a",
+        "rev": "90bc31349a51e6e4727ce2db800680eca7980c1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`90bc3134`](https://github.com/Gerg-L/spicetify-nix/commit/90bc31349a51e6e4727ce2db800680eca7980c1e) | `` CI update 2024-01-01 (#34) `` |