### PR TITLE
chore(flake/nixpkgs): `eae82ed7` -> `e5af05cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -539,11 +539,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1704015712,
-        "narHash": "sha256-GrsuUCEH5T629Py4jt6tsIzu9nEL/fD2Qt986ib13WI=",
+        "lastModified": 1704060006,
+        "narHash": "sha256-DJqxVZf35Gaw07Vt0qT1cS0pqfzZiuB+WfLTJNJdbgY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "eae82ed71467a19374437376fbb7f5e3ad486aeb",
+        "rev": "e5af05cbf33cf3d4148a4a1ce6cab1c5fb8fec09",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                  |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| [`e79af9e6`](https://github.com/NixOS/nixpkgs/commit/e79af9e68ddaa1c531aaa04eaf7082e3c426e6d5) | `` eigenmath: unstable-2023-12-12 -> unstable-2023-12-31 ``                              |
| [`2207adf4`](https://github.com/NixOS/nixpkgs/commit/2207adf4f7d9fa2535bdf77deccf59f74c102a21) | `` ncpamixer: 1.3.3.3 -> 1.3.7 ``                                                        |
| [`4374f2fe`](https://github.com/NixOS/nixpkgs/commit/4374f2feda09dc518d5e926f45f60640ac2d2fa1) | `` nixos/doc: avoid bash argument list size limit ``                                     |
| [`4a63721f`](https://github.com/NixOS/nixpkgs/commit/4a63721f45453930812fe374f36c174abc4871e5) | `` bloat: unstable-2023-10-25 -> unstable-2023-12-28 ``                                  |
| [`46270047`](https://github.com/NixOS/nixpkgs/commit/46270047fc5d85c6c06be05c38e98da32868e57b) | `` dua: 2.24.1 -> 2.24.2 ``                                                              |
| [`f8c8f843`](https://github.com/NixOS/nixpkgs/commit/f8c8f843507256eac48c969aa9d0d94e698f5bb9) | `` vimPlugins.obsidian-nvim: init at 2023-12-30 ``                                       |
| [`ccb0be32`](https://github.com/NixOS/nixpkgs/commit/ccb0be328b76921e73c5cc705557e658ed4f02a7) | `` vimPlugins.palette-nvim: init at 2023-10-02 ``                                        |
| [`c1272a15`](https://github.com/NixOS/nixpkgs/commit/c1272a1529977a72f25d167e049a437077cfc508) | `` ff2mpv-go: use 'PATH' to invoke 'mpv' ``                                              |
| [`cbe6928c`](https://github.com/NixOS/nixpkgs/commit/cbe6928cc50bdcd82637e12af6ae7d191e5e30d0) | `` winhelpcgi: cleanup ``                                                                |
| [`7738f989`](https://github.com/NixOS/nixpkgs/commit/7738f989d9d5ea47ecde3362ce2b2e122c999947) | `` wleave: 0.3.0 -> 0.3.1 ``                                                             |
| [`4ab598b8`](https://github.com/NixOS/nixpkgs/commit/4ab598b846b83d0c7440de0477eb068626b15ae6) | `` mdbook-admonish: 1.14.0 -> 1.15.0 ``                                                  |
| [`82558eb0`](https://github.com/NixOS/nixpkgs/commit/82558eb0e83824447930a6766d93e0e37aee5508) | `` clipcat: 0.15.0 -> 0.16.0 ``                                                          |
| [`d7723bb9`](https://github.com/NixOS/nixpkgs/commit/d7723bb9427bda97901a710ef94f39505e081b88) | `` meli: 0.8.2 -> 0.8.4 ``                                                               |
| [`2d1eafe6`](https://github.com/NixOS/nixpkgs/commit/2d1eafe65427865c054fe82c24d0c08344bfe342) | `` tinyxml-2: 9.0.0 -> 10.0.0 ``                                                         |
| [`e5ee263c`](https://github.com/NixOS/nixpkgs/commit/e5ee263c70272e8752409f91f6647472f9c75bf7) | `` mdbook-pagetoc: 0.1.7 -> 0.1.8 ``                                                     |
| [`17382308`](https://github.com/NixOS/nixpkgs/commit/173823084ae978b81d9297644b583693c76f5f4f) | `` linux-wifi-hotspot: 4.6.0 -> 4.7.0 ``                                                 |
| [`bab500a2`](https://github.com/NixOS/nixpkgs/commit/bab500a21ac81b122bc9b573429b724eb74225e1) | `` elf-dissector: unstable-2023-06-06 -> unstable-2023-12-24 ``                          |
| [`696735c9`](https://github.com/NixOS/nixpkgs/commit/696735c9d2813ef5db71e110061646603733b4e1) | `` z3_4_12: 4.12.2 -> 4.12.4 ``                                                          |
| [`db43374d`](https://github.com/NixOS/nixpkgs/commit/db43374d324c69afbcec78b1a372b743be307194) | `` templ: init at 0.2.476 ``                                                             |
| [`d56567b8`](https://github.com/NixOS/nixpkgs/commit/d56567b88163d6795564e020919e0992878de41c) | `` maintainers: add luleyleo ``                                                          |
| [`1a8e7315`](https://github.com/NixOS/nixpkgs/commit/1a8e731531aa7e5df8a7a1ac397071fc90e9d5ff) | `` mautrix-signal: 0.4.3 -> unstable-2023-12-30 ``                                       |
| [`9d764b9e`](https://github.com/NixOS/nixpkgs/commit/9d764b9e6bd4b7a089ad3057abbf4ecf454499a5) | `` libsignal-ffi: init at 0.36.1 ``                                                      |
| [`fdce1bcd`](https://github.com/NixOS/nixpkgs/commit/fdce1bcd09199711ccf7c48f828b783424d38466) | `` maintainers: add niklaskorz ``                                                        |
| [`60e2634b`](https://github.com/NixOS/nixpkgs/commit/60e2634b286c3ca338f003f03d9200fa95ef6c5d) | `` comic-mandown: 1.6.0 -> 1.6.1 ``                                                      |
| [`6b20eebd`](https://github.com/NixOS/nixpkgs/commit/6b20eebda510a237326008a8bc8dc9e27bc8efe2) | `` pocketbase: 0.20.1 -> 0.20.2 ``                                                       |
| [`bfdc940c`](https://github.com/NixOS/nixpkgs/commit/bfdc940cbbfd55d71a4fd1483f8b8754507a9bd8) | `` mpvScripts.buildLua: Prevent `patch` from emitting `.orig` files ``                   |
| [`8e5f764d`](https://github.com/NixOS/nixpkgs/commit/8e5f764d6eeca5b9490bae4e19f29f20b8793cd8) | `` mpvScripts.sponsorblock: Refactor with `buildLua` ``                                  |
| [`71b9377f`](https://github.com/NixOS/nixpkgs/commit/71b9377fab4fbab22b069e89dc17179de723ba5a) | `` ripgrep: fix shell completions when cross compiling ``                                |
| [`ea652d40`](https://github.com/NixOS/nixpkgs/commit/ea652d40504c7525a2a829af08f07bf7d0594135) | `` libserdes: add updateScript ``                                                        |
| [`419a2085`](https://github.com/NixOS/nixpkgs/commit/419a2085d9c6e64966f3e0a5417b67be137ca9fd) | `` libserdes: 6.2.0 -> 7.5.3 ``                                                          |
| [`91d347dd`](https://github.com/NixOS/nixpkgs/commit/91d347dd8717adec115923d96e5bac64b6aca7ba) | `` python311Packages.heatzypy: 2.1.9 -> 2.2.0 ``                                         |
| [`2e382a29`](https://github.com/NixOS/nixpkgs/commit/2e382a29eb84ddf5c2661bf05ae737ed2bbfe5f6) | `` fava: 1.26.3 -> 1.26.4 ``                                                             |
| [`fbb8d99e`](https://github.com/NixOS/nixpkgs/commit/fbb8d99ed534cb83d41db30ad203f37ed6505806) | `` python311Packages.boschshcpy: 0.2.83 -> 0.2.84 ``                                     |
| [`b87f0094`](https://github.com/NixOS/nixpkgs/commit/b87f00946401aaa7ae325afffbb57dd20645f9e7) | `` clojure: 1.11.1.1429 -> 1.11.1.1435 ``                                                |
| [`4e9a91af`](https://github.com/NixOS/nixpkgs/commit/4e9a91af1a45f8c79e775075bd3988de267779ce) | `` cargo-show-asm: 0.2.23 -> 0.2.24 ``                                                   |
| [`2a9afc2c`](https://github.com/NixOS/nixpkgs/commit/2a9afc2c75f22fedbbdce672339b3eca3989cff7) | `` rocksndiamonds: 4.3.8.0 -> 4.3.8.1 ``                                                 |
| [`fe74170e`](https://github.com/NixOS/nixpkgs/commit/fe74170e43a445bbfafdf4e18a9f55fa6be7752b) | `` python311Packages.pyunifiprotect: 4.22.3 -> 4.22.4 ``                                 |
| [`8234aab7`](https://github.com/NixOS/nixpkgs/commit/8234aab76565dd52601185b549303141a69261d1) | `` fselect: 0.8.4 -> 0.8.5 ``                                                            |
| [`b1290a07`](https://github.com/NixOS/nixpkgs/commit/b1290a07c2f9761a7a47bcfcc3d92032b5d285b6) | `` blackfire: 2.23.0 -> 2.24.2 ``                                                        |
| [`2810cc8d`](https://github.com/NixOS/nixpkgs/commit/2810cc8d6b9a49355601d9b1732135ee4645e527) | `` beeper: 3.90.11 -> 3.90.22 ``                                                         |
| [`3fffe22f`](https://github.com/NixOS/nixpkgs/commit/3fffe22f0fd2fadcb1b7e8f6621f40b833c824d9) | `` inkscape/silhouette: init at 1.28 ``                                                  |
| [`cfe70ef7`](https://github.com/NixOS/nixpkgs/commit/cfe70ef7c6aa8e3544840f453f101f5fbfe3235c) | `` zram-generator: 1.1.2 -> 1.1.2 ``                                                     |
| [`677e0a46`](https://github.com/NixOS/nixpkgs/commit/677e0a4620e0738fec2e195b0ec1f4308e6b3e57) | `` xcodes: build from source ``                                                          |
| [`b732363e`](https://github.com/NixOS/nixpkgs/commit/b732363eedbc406446521e8193dc889e5beb5162) | `` swiftpm2nix: fix hash mismatch when git submodules exist ``                           |
| [`9aafa9b2`](https://github.com/NixOS/nixpkgs/commit/9aafa9b258a66344b52737c5cbb7fb9ea3088015) | `` darwin.apple_sdk_11_0.libcompression: init at 11.0.0 ``                               |
| [`f53ec63c`](https://github.com/NixOS/nixpkgs/commit/f53ec63c6a5cf6cc184d929e460d992e8960040c) | `` armitage: init at unstable-2022-12-05 ``                                              |
| [`0ee604d3`](https://github.com/NixOS/nixpkgs/commit/0ee604d356beaff4a1c60dd0ed8b48b2bd897a18) | `` whisper-ctranslate2: 0.3.4 -> 0.3.5 ``                                                |
| [`5114a501`](https://github.com/NixOS/nixpkgs/commit/5114a50154fb0561f5b3e5279b826ab419c19892) | `` cnspec: 9.12.1 -> 9.12.2 ``                                                           |
| [`5931919c`](https://github.com/NixOS/nixpkgs/commit/5931919c3f5820fbe6b962408ba8953b4eeb660d) | `` python311Packages.eiswarnung: update disabled ``                                      |
| [`db4f3f38`](https://github.com/NixOS/nixpkgs/commit/db4f3f38315b4b953d58a47440901a1ff10bc318) | `` renode-unstable: init at 1.14.0+20231229gita76dac0ae ``                               |
| [`3e98c29d`](https://github.com/NixOS/nixpkgs/commit/3e98c29d350fbe9aacda8a3ad69a0e044419f01b) | `` renode: init at 1.14.0 ``                                                             |
| [`af593194`](https://github.com/NixOS/nixpkgs/commit/af593194c5e6cdf110d7165ad697ee738b2b692b) | `` python311Packages.datetime: 5.2 -> 5.4 ``                                             |
| [`f2bc00cd`](https://github.com/NixOS/nixpkgs/commit/f2bc00cd90cf7419402dcf6e1aa6861415c9ab80) | `` uxn: unstable-2023-12-05 -> unstable-2023-12-25 ``                                    |
| [`ae5c0c15`](https://github.com/NixOS/nixpkgs/commit/ae5c0c1521e9c4739e955d6a5a949592ce82e580) | `` nixos/nginx: skip adding a comment to acmeLocation in nginx configuration ``          |
| [`7f1b6d45`](https://github.com/NixOS/nixpkgs/commit/7f1b6d45afb5b2ca33d06507198fbb5c2bdbe9ee) | `` nixos/nginx: change position acmeLocation in nginx configuration ``                   |
| [`26d87ddf`](https://github.com/NixOS/nixpkgs/commit/26d87ddf9ae4b2e9e5e99b3c6f89a51ca39e66e8) | `` paperless-ngx: 2.1.2 -> 2.2.1 ``                                                      |
| [`ddebbecf`](https://github.com/NixOS/nixpkgs/commit/ddebbecf8d3c38808ec9dc34e8be390b10ea8f39) | `` python311Packages.apkinspector: init at 1.2.1 ``                                      |
| [`ef4e3bae`](https://github.com/NixOS/nixpkgs/commit/ef4e3baed089ae2d50c17ba6e2d4cc1c1605901b) | `` element-desktop: capitalise startupWMClass desktop attribute ``                       |
| [`dab7f9a0`](https://github.com/NixOS/nixpkgs/commit/dab7f9a0298b5cdcc2cfdffef7b5a3f47f349015) | `` drone-scp: 1.6.12 -> 1.6.13 ``                                                        |
| [`92c3800c`](https://github.com/NixOS/nixpkgs/commit/92c3800caf7e2ab578bd3b3bce683efa0fc72c5e) | `` mockgen: change upstream to uber-go fork ``                                           |
| [`6a5eb745`](https://github.com/NixOS/nixpkgs/commit/6a5eb74568061ec8d24b4133cbdf4483648f11a7) | `` portfolio: 0.66.2 -> 0.67.0 ``                                                        |
| [`3453b42c`](https://github.com/NixOS/nixpkgs/commit/3453b42c7295e3727638d7c00851749621fdbd4b) | `` trealla: 2.31.6 -> 2.32.13 ``                                                         |
| [`76b0b9dd`](https://github.com/NixOS/nixpkgs/commit/76b0b9dd600eda7e62ae3e6fd828a38941bb0884) | `` hysteria: 2.2.2 -> 2.2.3 ``                                                           |
| [`cbe33249`](https://github.com/NixOS/nixpkgs/commit/cbe33249936895d999eafa9d8ad6a16d42ca91f5) | `` quicktun: fix cross compilation, add missing runHook ``                               |
| [`14ef2d11`](https://github.com/NixOS/nixpkgs/commit/14ef2d11be0bfa47ce45549803998a1cbb7a1877) | `` tailwindcss: 3.3.6 -> 3.4.0 ``                                                        |
| [`96496184`](https://github.com/NixOS/nixpkgs/commit/96496184b17453e385f0cdf7670f275ee29f2918) | `` neovim: 0.9.4 -> 0.9.5 ``                                                             |
| [`6cf051ab`](https://github.com/NixOS/nixpkgs/commit/6cf051ab1df9585f6bf7b4f6e5b7966081a471f6) | `` carapace: fix cross compilation ``                                                    |
| [`c78d30f9`](https://github.com/NixOS/nixpkgs/commit/c78d30f97f809ef0e5c32fa67eb8c3c6f8ccd373) | `` roxterm: refactor ``                                                                  |
| [`e15034c5`](https://github.com/NixOS/nixpkgs/commit/e15034c5f1277d561546d945d30e55e7d00c0dae) | `` roxterm: 3.14.2 -> 3.14.3 ``                                                          |
| [`de65ce18`](https://github.com/NixOS/nixpkgs/commit/de65ce18194c6643835506c9eb88068e158b85d9) | `` roxterm: migrate to by-name ``                                                        |
| [`cbebe203`](https://github.com/NixOS/nixpkgs/commit/cbebe20369066f66d88473da8116e9e71b65ce06) | `` ocenaudio: 3.13.2 -> 3.13.3 ``                                                        |
| [`68dcd5fe`](https://github.com/NixOS/nixpkgs/commit/68dcd5fe071dc04460adcf3fc0d5d53f9ac2670c) | `` repgrep: 0.14.3 -> 0.15.0 ``                                                          |
| [`619c4b60`](https://github.com/NixOS/nixpkgs/commit/619c4b605e267f2eae56458d72070d4726ae1a31) | `` yuzu: reorganize everything, use common updater scripts, actually update ``           |
| [`1de3eddb`](https://github.com/NixOS/nixpkgs/commit/1de3eddbc2fa57c1d0433fabc14a844044bfb4f6) | `` libks: 1.8.2 -> 2.0.3 ``                                                              |
| [`3e216857`](https://github.com/NixOS/nixpkgs/commit/3e2168571a66fa553bcee4c9aab50f3a22fda8f0) | `` python311Packages.a2wsgi: 1.9.0 -> 1.10.0 ``                                          |
| [`d4492ac0`](https://github.com/NixOS/nixpkgs/commit/d4492ac0f2c8745173a8ee18212ba9387594dbed) | `` nginxModules.moreheaders: 0.33 -> 0.36; adopt ``                                      |
| [`c71cb77c`](https://github.com/NixOS/nixpkgs/commit/c71cb77cd63ca512eec3cd51f353dc6c3be80e20) | `` nixos/grub: use the correct ZFS version ``                                            |
| [`1843f731`](https://github.com/NixOS/nixpkgs/commit/1843f731e1054a8d9702bf176693c9984f4980e8) | `` opensbi: 1.3.1 -> 1.4 ``                                                              |
| [`256d823f`](https://github.com/NixOS/nixpkgs/commit/256d823f7bc8f6cbe86549b9b750d98c2465dfde) | `` unifi8: 8.0.7 -> 8.0.24 ``                                                            |
| [`f3303134`](https://github.com/NixOS/nixpkgs/commit/f3303134e82bf1864b54f5fd4081a9cc4c10678f) | `` python310Packages.neo4j: 5.15.0 -> 5.16.0 ``                                          |
| [`dfb204b5`](https://github.com/NixOS/nixpkgs/commit/dfb204b5dd966c9077f583c9327f15fe48d73e1f) | `` cargo-llvm-cov: 0.5.39 -> 0.6.0 ``                                                    |
| [`7b6adbf6`](https://github.com/NixOS/nixpkgs/commit/7b6adbf6096bef25692162e9d6afb4a3bb518732) | `` imapfilter: 2.8.1 -> 2.8.2 ``                                                         |
| [`52532b4f`](https://github.com/NixOS/nixpkgs/commit/52532b4f18ff0dff65bfc2a6a451e5ce9c742186) | `` hareThirdParty.hare-ev: unstable-2023-10-31 -> unstable-2023-12-04 ``                 |
| [`ff0dc63a`](https://github.com/NixOS/nixpkgs/commit/ff0dc63ab8c4e69bf717c6d517678be8d7bab21f) | `` inkscape/textext: 1.8.1 -> 1.10.1 ``                                                  |
| [`0d846e8e`](https://github.com/NixOS/nixpkgs/commit/0d846e8e0ee0c4153e64dcf752c37278c10128fc) | `` pdk: 3.0.0 -> 3.0.1 ``                                                                |
| [`75b67b0d`](https://github.com/NixOS/nixpkgs/commit/75b67b0de847d9c18ea5a936058708bd30015c01) | `` OVMF: support `riscv64` suffix ``                                                     |
| [`a2a8651a`](https://github.com/NixOS/nixpkgs/commit/a2a8651aff40d9d480bb9133abadde1c62f4ce86) | `` pocket-updater-utility: 2.38.1 -> 2.41.0 ``                                           |
| [`6a55f7b5`](https://github.com/NixOS/nixpkgs/commit/6a55f7b5b3fa77ce0a2d5aa58925c7999273c4c1) | `` writefreely: add soopyc as maintainer ``                                              |
| [`f3e4983c`](https://github.com/NixOS/nixpkgs/commit/f3e4983cf9284af2cb5a68825c412761f14637c9) | `` writefreely: 0.13.2 -> 0.14.0 ``                                                      |
| [`9cdcfdf9`](https://github.com/NixOS/nixpkgs/commit/9cdcfdf9a3a456015b38b3cd6be3e8a138638f32) | `` maintainers: add soopyc ``                                                            |
| [`84a0f955`](https://github.com/NixOS/nixpkgs/commit/84a0f95559f8bad17806640cc2b53673d306d2bf) | `` swayosd: unstable-2023-07-18 -> unstable-2023-09-26 ``                                |
| [`6c975d08`](https://github.com/NixOS/nixpkgs/commit/6c975d08e31ab6d45647bdc4025891b217dabe45) | `` maintainers: add barab-i ``                                                           |
| [`807ddcc0`](https://github.com/NixOS/nixpkgs/commit/807ddcc02c004ff230468f8d06bd2572a8850dd8) | `` fastfetch: fix darwin x86 ``                                                          |
| [`12b40cf5`](https://github.com/NixOS/nixpkgs/commit/12b40cf56ca5d849f49ac8e7a4c7915a3b3922c3) | `` fastfetch: 2.3.4 -> 2.4.0 ``                                                          |
| [`f0fb6f0a`](https://github.com/NixOS/nixpkgs/commit/f0fb6f0a2696dfb76d79a819bb42bec762fca8f2) | `` doc: update mkBinaryCache section with admonitions and conventions ``                 |
| [`674019e9`](https://github.com/NixOS/nixpkgs/commit/674019e9ba09836797eafc222801bb8673fd3c12) | `` enlightenment.enlightenment: 0.25.4 -> 0.26.0 ``                                      |
| [`da490f0a`](https://github.com/NixOS/nixpkgs/commit/da490f0a167f06979c04ce14595d56785e766540) | `` enlightenment.efl: 1.26.3 -> 1.27.0 ``                                                |
| [`c3b7ccb6`](https://github.com/NixOS/nixpkgs/commit/c3b7ccb6f4fb3f6660631af2a9ac9a0127973582) | `` ibus-libpinyin: 1.15.3 -> 1.15.6 ``                                                   |
| [`de78d939`](https://github.com/NixOS/nixpkgs/commit/de78d9392ed97ac1c03250c0466b06ff9a4b7a4d) | `` vcpkg-tool: 2023-10-18 -> 2023-12-12 ``                                               |
| [`a30b8e10`](https://github.com/NixOS/nixpkgs/commit/a30b8e10112766461a0359ed6606b1ad79de7c22) | `` colloid-kde: make sddm a separate output ``                                           |
| [`f3fb9a91`](https://github.com/NixOS/nixpkgs/commit/f3fb9a9134efb8f1328fa78523c6bc75af649c7a) | `` nixos/tests/prometheus-ping-exporter: init ``                                         |
| [`5d85f0ee`](https://github.com/NixOS/nixpkgs/commit/5d85f0eee8417f340424e20345e8ccb86929a73f) | `` nixos/prometheus-ping-exporter: init ``                                               |
| [`e37552b8`](https://github.com/NixOS/nixpkgs/commit/e37552b8fa859f0ff499485bd643801c94137332) | `` prometheus-ping-exporter: init at 1.1.0 ``                                            |
| [`cefe8f06`](https://github.com/NixOS/nixpkgs/commit/cefe8f0668249d69834c7a429410b0ac3fe536c7) | `` maintainers: add Nudelsalat ``                                                        |
| [`c8560218`](https://github.com/NixOS/nixpkgs/commit/c85602181e005ebfb6d46ce874e3925dd69e1734) | `` bun: 1.0.18 -> 1.0.20 ``                                                              |
| [`c16ffa0a`](https://github.com/NixOS/nixpkgs/commit/c16ffa0a125a6098c094fcb19d63c6c4512072d7) | `` drawterm: add nixos tests ``                                                          |
| [`e5ab70f4`](https://github.com/NixOS/nixpkgs/commit/e5ab70f4eea46d7580edfe8027797cb990e33312) | `` vinegar: 1.5.9 -> 1.6.0 ``                                                            |
| [`54670895`](https://github.com/NixOS/nixpkgs/commit/54670895d39de400393807c0a710e8b2376221ff) | `` drawterm: unstable-2023-09-03 -> unstable-2023-12-23 ``                               |
| [`8547ba30`](https://github.com/NixOS/nixpkgs/commit/8547ba30a26c8d3610939a143be2968dbe5d872c) | `` door-knocker: 0.4.1 -> 0.4.2 ``                                                       |
| [`1ab8b565`](https://github.com/NixOS/nixpkgs/commit/1ab8b565b5ed7337b8735656f7d92a57423b96f9) | `` door-knocker: adopt ``                                                                |
| [`7cd1467a`](https://github.com/NixOS/nixpkgs/commit/7cd1467a773782e350418d5948561470d58499ac) | `` keymapp: init at 1.0.7 ``                                                             |
| [`0c90ac55`](https://github.com/NixOS/nixpkgs/commit/0c90ac55d14af608b00091f35fa22e62af6fb4fe) | `` lomiri.hfd-service: Fix accountsservice interface linking ``                          |
| [`2b2c989c`](https://github.com/NixOS/nixpkgs/commit/2b2c989ce995dcd95b2def3cb7980ad6f8cf2b1a) | `` python310Packages.virt-firmware: 23.10 -> 23.11 ``                                    |
| [`14b11885`](https://github.com/NixOS/nixpkgs/commit/14b118856b8a40493daf401a32de45f2e03fa8db) | `` nix-repl: Disable attribute when allowAliases disabled ``                             |
| [`feb114f7`](https://github.com/NixOS/nixpkgs/commit/feb114f7f0f01295a99c108ed2d97cd0d152f41a) | `` apacheHttpdPackages: Disable renamed/removed attributes when allowAliases disabled `` |
| [`8bbbb78c`](https://github.com/NixOS/nixpkgs/commit/8bbbb78c9ad78dcbb506f673996f51e57ae39457) | `` chia: Disable attributes if allowAliases disabled ``                                  |
| [`1470c52c`](https://github.com/NixOS/nixpkgs/commit/1470c52c18d10107eb599e14ce61fc72140228b1) | `` nextcloud25: Disable attributes when allowAliases disabled ``                         |
| [`38ad4feb`](https://github.com/NixOS/nixpkgs/commit/38ad4feb1ea2817a4d88b99446a40a6a03e39ce3) | `` gofumpt: Fix evaluation when allowAliases disabled ``                                 |
| [`88142110`](https://github.com/NixOS/nixpkgs/commit/88142110d0750cc38841bcac0122de4f5e30e00d) | `` wtk: Use meta.platforms to check for supported platform ``                            |
| [`12e32d6d`](https://github.com/NixOS/nixpkgs/commit/12e32d6dbba5e1b0a7c22c54a31ac684c0b3b4a5) | `` dotnet-sdk: Don't add attributes when allowAliases disabled ``                        |
| [`7f6b8976`](https://github.com/NixOS/nixpkgs/commit/7f6b89769ebed383ad5b6b3aea5da60aca3fbed3) | `` gruvbox-plus-icons: Fix evaluation when allowAliases disabled ``                      |
| [`7d926d19`](https://github.com/NixOS/nixpkgs/commit/7d926d19d3d5259aa93e195c7018020e9e0c0b10) | `` teams: Don't use root-level throw for unsupported platforms ``                        |
| [`91df2cb6`](https://github.com/NixOS/nixpkgs/commit/91df2cb6dc58a5c99e9e1c10dfe96eadfb92743b) | `` livekit: 1.5.1 -> 1.5.2 ``                                                            |
| [`28a0891d`](https://github.com/NixOS/nixpkgs/commit/28a0891db74cdd2f5ddc8829d88084609797a056) | ``  clipqr: 1.1.0 -> 1.2.0 ``                                                            |
| [`4af13554`](https://github.com/NixOS/nixpkgs/commit/4af13554542ef24b20acb3a023c3f7a34f845cff) | `` sysbench: fix cross-compilation ``                                                    |
| [`b39cd260`](https://github.com/NixOS/nixpkgs/commit/b39cd260dd9c0be8e00dc52286e513c2478fba54) | `` libck: cross-compilation fix ``                                                       |
| [`45e93e8d`](https://github.com/NixOS/nixpkgs/commit/45e93e8db0da8d84685b57da831aef409977c877) | `` maintainers: add jankaifer ``                                                         |
| [`418296e3`](https://github.com/NixOS/nixpkgs/commit/418296e34e61d4f5bd7492d5988b5ab9da0875a5) | `` jj: init at 1.9.2 ``                                                                  |
| [`ef92ea83`](https://github.com/NixOS/nixpkgs/commit/ef92ea831ecf13551db5c73a5973ba60e768c82c) | `` cemu: 2.0-59 -> 2.0-61 ``                                                             |
| [`82529fe5`](https://github.com/NixOS/nixpkgs/commit/82529fe5ecaba9291163e80b7e71836a3d562169) | `` x16.emulator: 45 -> 46 ``                                                             |
| [`7d416c7e`](https://github.com/NixOS/nixpkgs/commit/7d416c7e15ff6204541c02ce1a9b884417c8abc7) | `` x16.rom: 45 -> 46 ``                                                                  |
| [`61bd5e07`](https://github.com/NixOS/nixpkgs/commit/61bd5e07615fec93037ae254d41326ffcb082f3d) | `` x16.emulator: 44 -> 45 ``                                                             |
| [`fd6fc06e`](https://github.com/NixOS/nixpkgs/commit/fd6fc06eb9107c9dc6f80d0da3a4d4d19f7fd5a5) | `` x16.rom: 44 -> 45 ``                                                                  |
| [`5f0c17ed`](https://github.com/NixOS/nixpkgs/commit/5f0c17edea433b360b76bb425d21f0157a8a61aa) | `` x16: move from commanderx16 ``                                                        |
| [`bf8db64d`](https://github.com/NixOS/nixpkgs/commit/bf8db64ddb159a9867182a8e1bd61aff88fc6b57) | `` lzsa: init at 1.4.1 ``                                                                |
| [`90c3e121`](https://github.com/NixOS/nixpkgs/commit/90c3e1212c91a74bae73567a43a83e0e56a5b669) | `` hercules: 3.13 -> 4.6 ``                                                              |
| [`646da4a9`](https://github.com/NixOS/nixpkgs/commit/646da4a9152697bd66e937265ef2c2a5cd402771) | `` winhelpcgi: remove override libpng ``                                                 |
| [`47258b38`](https://github.com/NixOS/nixpkgs/commit/47258b38e3837b304987bc77a509b9ed3ee104b4) | `` door-knocker: init at 0.4.1 ``                                                        |
| [`0c50d6ec`](https://github.com/NixOS/nixpkgs/commit/0c50d6ec922c081dd65067e9af7c71ac5161ecd7) | `` nginxModules.{lua,lua-upstream}: switch to luajit_openresty ``                        |
| [`142d83f9`](https://github.com/NixOS/nixpkgs/commit/142d83f90e2903c92a78c8f4fa84a87fe37a0409) | `` nixos/postfix: postalias should not use source file permissions ``                    |
| [`7c9a7925`](https://github.com/NixOS/nixpkgs/commit/7c9a7925b9674a05d0d4279eadf8123e615f8836) | `` thermald: allow ignoring cpuid check ``                                               |
| [`a2f10d63`](https://github.com/NixOS/nixpkgs/commit/a2f10d636612a816eb4218baf8ece3cdcd828b68) | `` beetsPackages.copyartifacts: unstable-2020-02-15 -> 0.1.5 ``                          |