### PR TITLE
chore(flake/nixpkgs): `e5af05cb` -> `e2e36d8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -588,11 +588,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1704060006,
-        "narHash": "sha256-DJqxVZf35Gaw07Vt0qT1cS0pqfzZiuB+WfLTJNJdbgY=",
+        "lastModified": 1704177376,
+        "narHash": "sha256-6AV8TWX/juwV8delRDtlbUzi1X8irrtCfrtcYByVhCs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e5af05cbf33cf3d4148a4a1ce6cab1c5fb8fec09",
+        "rev": "e2e36d8af3b7c465311f11913b7dedd209633c84",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -222,7 +222,7 @@
     },
     "flake-utils_2": {
       "inputs": {
-        "systems": "systems_3"
+        "systems": "systems_4"
       },
       "locked": {
         "lastModified": 1694529238,
@@ -297,6 +297,55 @@
       "original": {
         "owner": "nix-community",
         "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "hyprland": {
+      "inputs": {
+        "hyprland-protocols": "hyprland-protocols",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_3",
+        "wlroots": "wlroots",
+        "xdph": "xdph"
+      },
+      "locked": {
+        "lastModified": 1703673853,
+        "narHash": "sha256-Tg6m2UCvt/uKRYEQhfvNc9/6sOame+29R1bulV1GIng=",
+        "owner": "hyprwm",
+        "repo": "hyprland",
+        "rev": "6cd82d948f93be98d0fe5516722a9228f22315d1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprland",
+        "type": "github"
+      }
+    },
+    "hyprland-protocols": {
+      "inputs": {
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1691753796,
+        "narHash": "sha256-zOEwiWoXk3j3+EoF3ySUJmberFewWlagvewDRuWYAso=",
+        "owner": "hyprwm",
+        "repo": "hyprland-protocols",
+        "rev": "0c2ce70625cb30aef199cb388f99e19a61a6ce03",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprland-protocols",
         "type": "github"
       }
     },
@@ -607,6 +656,7 @@
         "ez-configs": "ez-configs",
         "flake-parts": "flake-parts",
         "home-manager": "home-manager_2",
+        "hyprland": "hyprland",
         "impermanence": "impermanence",
         "lanzaboote": "lanzaboote",
         "nh": "nh",
@@ -697,6 +747,21 @@
     },
     "systems_3": {
       "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
+      }
+    },
+    "systems_4": {
+      "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
@@ -727,6 +792,54 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "wlroots": {
+      "flake": false,
+      "locked": {
+        "host": "gitlab.freedesktop.org",
+        "lastModified": 1701368958,
+        "narHash": "sha256-7kvyoA91etzVEl9mkA/EJfB6z/PltxX7Xc4gcr7/xlo=",
+        "owner": "wlroots",
+        "repo": "wlroots",
+        "rev": "5d639394f3e83b01596dcd166a44a9a1a2583350",
+        "type": "gitlab"
+      },
+      "original": {
+        "host": "gitlab.freedesktop.org",
+        "owner": "wlroots",
+        "repo": "wlroots",
+        "rev": "5d639394f3e83b01596dcd166a44a9a1a2583350",
+        "type": "gitlab"
+      }
+    },
+    "xdph": {
+      "inputs": {
+        "hyprland-protocols": [
+          "hyprland",
+          "hyprland-protocols"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1703514399,
+        "narHash": "sha256-VRr5Xc4S/VPr/gU3fiOD3vSIL2+GJ+LUrmFTWTwnTz4=",
+        "owner": "hyprwm",
+        "repo": "xdg-desktop-portal-hyprland",
+        "rev": "0a318a7a217a6402b0b705837cd5b50b0e94b31b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "xdg-desktop-portal-hyprland",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -126,6 +126,11 @@
       inputs.flake-parts.follows = "flake-parts";
     };
 
+    hyprland = {
+      url = "github:hyprwm/hyprland";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     nh = {
       url = "github:viperML/nh";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/home-modules/graphical/hyprland/default.nix
+++ b/home-modules/graphical/hyprland/default.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  inputs,
   ...
 }@args:
 let
@@ -28,7 +29,7 @@ in
 
     wayland.windowManager.hyprland = {
       enable = true;
-      package = pkgs.hyprland;
+      package = inputs.hyprland.packages.${pkgs.system}.default;
       settings = import ./settings.nix args;
     };
   };

--- a/nixos-modules/graphical/games/gamemode.nix
+++ b/nixos-modules/graphical/games/gamemode.nix
@@ -2,6 +2,7 @@
   config,
   lib,
   pkgs,
+  inputs,
   ...
 }:
 let
@@ -24,7 +25,7 @@ in
       let
         programs = lib.makeBinPath (
           with pkgs; [
-            hyprland
+            inputs.hyprland.packages.${pkgs.system}.default
             gojq
             systemd
           ]


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`6f5773d2`](https://github.com/NixOS/nixpkgs/commit/6f5773d213a50584521986e08ada523fe1b0950e) | `` maintainers: update handle for dixslyf ``                                  |
| [`18a01f3f`](https://github.com/NixOS/nixpkgs/commit/18a01f3fd956de7fc6d32e5e241e949671e7e8bf) | `` haskellPackages: mark builds failing on hydra as broken ``                 |
| [`c60ed181`](https://github.com/NixOS/nixpkgs/commit/c60ed18170048087f93d0305f11e2db571e66eb0) | `` terraform-providers.migadu: init at 2023.12.21 ``                          |
| [`111c8d73`](https://github.com/NixOS/nixpkgs/commit/111c8d73a479f707e920307564c0a16285d1d41a) | `` haskellPackages.postgrest: Add more build-depends for 12.0.2 ``            |
| [`677d868c`](https://github.com/NixOS/nixpkgs/commit/677d868ca34ccf131ec0c1b3a18e5fa5ee79af00) | `` haskellPackages.postgrest: 11.2.2 -> 12.0.2 ``                             |
| [`d9e17456`](https://github.com/NixOS/nixpkgs/commit/d9e1745681105a35cf50bc4ddb1052edaa622c7e) | `` postgrest: add top-level package ``                                        |
| [`36f775a9`](https://github.com/NixOS/nixpkgs/commit/36f775a9bcc6be3195ddceb304183c647478afab) | `` haskellPackages.postgrest: 10.1.1 -> 11.2.2 and fix build ``               |
| [`86d4d1ad`](https://github.com/NixOS/nixpkgs/commit/86d4d1ad174b228b0a56e639b20abc11bc30ac0b) | `` bambu-studio: add gst-plugins-good (#274383) ``                            |
| [`5ff78113`](https://github.com/NixOS/nixpkgs/commit/5ff7811393346a6d6e50e29ab3aade411a5cc3fe) | `` makeInitrdNGTool: 0.1.0 -> 0.1.0 ``                                        |
| [`ccac72b1`](https://github.com/NixOS/nixpkgs/commit/ccac72b1471e56c9cfa96ba61f89ee715c87ee47) | `` satty: add myself as maintainer ``                                         |
| [`c82f8a6e`](https://github.com/NixOS/nixpkgs/commit/c82f8a6ed73ec33590b8e809b4e4a799d7b71442) | `` satty: add shell completions ``                                            |
| [`9e33a4c6`](https://github.com/NixOS/nixpkgs/commit/9e33a4c688915a1a105b09650e49ee232da6d8d0) | `` baboossh: 1.2.0 -> 1.2.1 ``                                                |
| [`4985198d`](https://github.com/NixOS/nixpkgs/commit/4985198defdc9f3c85fcaa459da31de2056184a7) | `` the-way: 0.20.1 -> 0.20.2 ``                                               |
| [`38f96462`](https://github.com/NixOS/nixpkgs/commit/38f96462bf8db319baaf9a59c93f37c3f822116c) | `` newsraft: refactor ``                                                      |
| [`2ee82b8b`](https://github.com/NixOS/nixpkgs/commit/2ee82b8bb13551577468dc899035fd05ba188b78) | `` licensure: init at 0.3.2 ``                                                |
| [`5518af0a`](https://github.com/NixOS/nixpkgs/commit/5518af0a558dde9ce869098799be461bc74485ab) | `` haskellPackages: Fix eval errors ``                                        |
| [`7b4156ed`](https://github.com/NixOS/nixpkgs/commit/7b4156eddac0142fc02dba8f88c958f71e9d0baa) | `` haskellPackages: Fix eval errors ``                                        |
| [`dffa76ad`](https://github.com/NixOS/nixpkgs/commit/dffa76ad6e59a366e08a30e6d81fb4a320e0452e) | `` release-haskell.nix: Cleanup missing compiler names ``                     |
| [`2684e3ea`](https://github.com/NixOS/nixpkgs/commit/2684e3ea4ba048d751f1b60cd45554fa7fa3ea1d) | `` haskellPackages: mark builds failing on hydra as broken ``                 |
| [`823ca129`](https://github.com/NixOS/nixpkgs/commit/823ca129c50a150505d6485de1ed23e32c7b1f70) | `` cockpit: 306 -> 307 ``                                                     |
| [`15257e45`](https://github.com/NixOS/nixpkgs/commit/15257e4500f260e7cbfb3783db2d8aabd17e4114) | `` haskellPackages: regenerate package set based on current config ``         |
| [`ca53b826`](https://github.com/NixOS/nixpkgs/commit/ca53b82688e52bcb1600646b10a0802696bf6281) | `` fzf-make: 0.13.0 -> 0.14.0 ``                                              |
| [`79b42007`](https://github.com/NixOS/nixpkgs/commit/79b42007faf67d2dd13a6761b8356f941116dc10) | `` trompeloeil: 46 -> 47 ``                                                   |
| [`4f9e9890`](https://github.com/NixOS/nixpkgs/commit/4f9e98905e1ba032cd0fa76145994448d86f107f) | `` nixos/auditd: fix typo ``                                                  |
| [`309913ce`](https://github.com/NixOS/nixpkgs/commit/309913ce73327a0e2e424efd08b050c544adbd10) | `` templ: 0.2.476 -> 0.2.501 ``                                               |
| [`c8b5413f`](https://github.com/NixOS/nixpkgs/commit/c8b5413fa6838f65a62a0682a1cd56008fd028bb) | `` haskell.packages.ghc865Binary: drop unevaluatable packages ``              |
| [`e649d536`](https://github.com/NixOS/nixpkgs/commit/e649d536183f9839afe0f42fec628bfbd0af0271) | `` haskell.packages.ghc810: drop unevaluatable packages ``                    |
| [`aa84d903`](https://github.com/NixOS/nixpkgs/commit/aa84d903e16ebfe60fecac34133c091045a8f29a) | `` haskellPackages.compact: Unmark broken ``                                  |
| [`8345efda`](https://github.com/NixOS/nixpkgs/commit/8345efdaae25188aba8123cdafd3b623e0631aac) | `` dump1090: fix build on darwin ``                                           |
| [`6f10b0ed`](https://github.com/NixOS/nixpkgs/commit/6f10b0edb23c09fa308799146054096915d5fff3) | `` redis-plus-plus: 1.3.10 -> 1.3.11 ``                                       |
| [`258151d1`](https://github.com/NixOS/nixpkgs/commit/258151d138300f381bf1d94ddd4228045ceec901) | `` haskellPackages.update-nix-fetchgit: Fix build ``                          |
| [`a55180dc`](https://github.com/NixOS/nixpkgs/commit/a55180dc5f14ab9b03e09cef6f222fa9b759c7bd) | `` mlib: 0.7.0 -> 0.7.2 ``                                                    |
| [`9f37ee33`](https://github.com/NixOS/nixpkgs/commit/9f37ee33d7bbda521af2e4b6b5106f11216bbcc8) | `` zigbee2mqtt: 1.34.0 -> 1.35.0 ``                                           |
| [`9d21cb87`](https://github.com/NixOS/nixpkgs/commit/9d21cb87393ba0d70ad7ca1abec2a9e34c280905) | `` mainsail: 2.9.0 -> 2.9.1 ``                                                |
| [`b629581d`](https://github.com/NixOS/nixpkgs/commit/b629581dc93787c611962c0b2580e8295b2991ac) | `` release-haskell: Correctly disable hls jobs on ghc 8.10.7 ``               |
| [`a02e31d0`](https://github.com/NixOS/nixpkgs/commit/a02e31d0a59efcbad44903b019845e7b0ce4a836) | `` gimoji: 0.7.1 -> 0.7.2 ``                                                  |
| [`f86e2d36`](https://github.com/NixOS/nixpkgs/commit/f86e2d36bdb8dd56d4c4f64d32d919a44c76c4ec) | `` fzf-make: 0.12.0 -> 0.13.0 ``                                              |
| [`c83c12f4`](https://github.com/NixOS/nixpkgs/commit/c83c12f444f6ed4e8351cd249e3ad4840cfe3f29) | `` go2rtc: 1.8.4 -> 1.8.5 ``                                                  |
| [`393a1229`](https://github.com/NixOS/nixpkgs/commit/393a1229937944b1a1aaae93b0dd0fbf40d24f5f) | `` dq: 20230101 -> 20240101 ``                                                |
| [`48d6f26d`](https://github.com/NixOS/nixpkgs/commit/48d6f26deb058a929061d71fbc7807edd037f5f5) | `` libayatana-common: 0.9.9 -> 0.9.10 ``                                      |
| [`0c9dbdf9`](https://github.com/NixOS/nixpkgs/commit/0c9dbdf9a5d92bcfbab9e9a357d99a6dc10c7396) | `` cargo-tally: 1.0.32 -> 1.0.33 ``                                           |
| [`ed9ebf83`](https://github.com/NixOS/nixpkgs/commit/ed9ebf8375f14c8a4b5d296c9bd92ff69cca3a8c) | `` gtksourceview4: Backport Nix syntax highlighting support ``                |
| [`b813848d`](https://github.com/NixOS/nixpkgs/commit/b813848d317724cb98c76bf2a70d839cb666bdb1) | `` miniaudicle: 1.5.0.7 -> 1.5.2.0 ``                                         |
| [`14183718`](https://github.com/NixOS/nixpkgs/commit/1418371835e49be9cb191ccc92cdd541672ee9b7) | `` python311Packages.plugwise: refactor ``                                    |
| [`695eb35d`](https://github.com/NixOS/nixpkgs/commit/695eb35d6d220f76b344fe3484cc6b776cd8cf1b) | `` python311Packages.plugwise: 0.35.4 -> 0.36.2 ``                            |
| [`ab1ab1e4`](https://github.com/NixOS/nixpkgs/commit/ab1ab1e437fc1fa8c0d79579786f6edf2beb8ae9) | `` keybase: 6.2.3 -> 6.2.4 ``                                                 |
| [`10c06cb0`](https://github.com/NixOS/nixpkgs/commit/10c06cb0608bfad0ad3b1e83017f208fca859cdb) | `` nginx: enable ktls support by default ``                                   |
| [`23a4b38a`](https://github.com/NixOS/nixpkgs/commit/23a4b38ac8d2d0d12e0256dbb15ccc3c8f622fb4) | `` openresty: 1.21.4.1 -> 1.21.4.3 ``                                         |
| [`709a88aa`](https://github.com/NixOS/nixpkgs/commit/709a88aa440570f203b0622b2d990109b3d227e5) | `` fzf: 0.44.1 -> 0.45.0 ``                                                   |
| [`94d804a2`](https://github.com/NixOS/nixpkgs/commit/94d804a2c98abf0360964dea5609d02dd51f626a) | `` act: 0.2.56 -> 0.2.57 ``                                                   |
| [`cb12e6ca`](https://github.com/NixOS/nixpkgs/commit/cb12e6cac5f8f13ddd32df8419f50dc95dad550c) | `` wmfocus: 1.4.0 -> 1.5.0 ``                                                 |
| [`c4d3826a`](https://github.com/NixOS/nixpkgs/commit/c4d3826a946c420116973a4fbd7dd1d3bd76a36a) | `` spicetify-cli: 2.28.1 -> 2.29.1 ``                                         |
| [`79489683`](https://github.com/NixOS/nixpkgs/commit/79489683b0c57c896c777ce3b53e34a16621d7df) | `` python311Packages.sanic-routing: 23.6.0 -> 23.12.0 ``                      |
| [`ae04b3b5`](https://github.com/NixOS/nixpkgs/commit/ae04b3b5457ffbff907962264b2cf9bfe6072cad) | `` python311Packages.pyschlage: 2023.12.0 -> 2023.12.1 ``                     |
| [`d6515b70`](https://github.com/NixOS/nixpkgs/commit/d6515b70b349da586c922efc43a25c8abde73cba) | `` python311Packages.mdformat-mkdocs: 1.1.0 -> 1.1.2 ``                       |
| [`9e9e68f4`](https://github.com/NixOS/nixpkgs/commit/9e9e68f4086fd59cbee925101a55ea9f84dfb720) | `` python311Packages.gspread: 5.12.3 -> 5.12.4 ``                             |
| [`a279d74f`](https://github.com/NixOS/nixpkgs/commit/a279d74f99d44f3a20748b39cdb7a3a55cc1c062) | `` plocate: 1.1.19 -> 1.1.20 ``                                               |
| [`914edb9f`](https://github.com/NixOS/nixpkgs/commit/914edb9f66f64d1ba5e84588a076be871bf298b6) | `` ibus-engines.typing-booster-unwrapped: 2.24.5 -> 2.24.10 ``                |
| [`eeae22ce`](https://github.com/NixOS/nixpkgs/commit/eeae22cecc71765269b3e7f46a2cc9a4fa35eb24) | `` dump1090: 8.2 -> 9.0 ``                                                    |
| [`7c70bf80`](https://github.com/NixOS/nixpkgs/commit/7c70bf8082afea729ddeaf620279b002315233b1) | `` arping: 2.23 -> 2.24 ``                                                    |
| [`6115d4af`](https://github.com/NixOS/nixpkgs/commit/6115d4af56e1f25572f028890482071aac75e7e4) | `` fend: 1.3.3 -> 1.4.0 ``                                                    |
| [`0d1851c0`](https://github.com/NixOS/nixpkgs/commit/0d1851c0c9f2dd2cd3a694bd500a8ce9ab2d3a77) | `` maintainers: add shard7 ``                                                 |
| [`47705cf8`](https://github.com/NixOS/nixpkgs/commit/47705cf81cf0f13ecd4e80bdd1b29725bf4acf35) | `` git-mit: 5.12.181 -> 5.12.182 ``                                           |
| [`e9591a61`](https://github.com/NixOS/nixpkgs/commit/e9591a61dab61dd824678eb93c8394a29b5f830b) | `` gickup: 0.10.24 -> 0.10.25 ``                                              |
| [`3e1111f2`](https://github.com/NixOS/nixpkgs/commit/3e1111f227d977e181e9dd88774b9873ddb61bf8) | `` go: set meta.mainProgram to go ``                                          |
| [`04e49fa8`](https://github.com/NixOS/nixpkgs/commit/04e49fa8ecf11e1739c2de43fd22d934038cbdf5) | `` maintainers/maintainer-list.nix: Update details for OPNA2608 ``            |
| [`0ef56bec`](https://github.com/NixOS/nixpkgs/commit/0ef56bec7281e2372338f2dfe7c13327ce96f6bb) | `` codux: 15.16.2 -> 15.17.2 ``                                               |
| [`a318f323`](https://github.com/NixOS/nixpkgs/commit/a318f323b5e369b2ca4cd233bd685a03d6a5c2e0) | `` broot: 1.30.2 -> 1.31.0 ``                                                 |
| [`b0291f7e`](https://github.com/NixOS/nixpkgs/commit/b0291f7e32d028fd251e340e536b7b955da8e09b) | `` audiobookshelf: 2.7.0 -> 2.7.1 ``                                          |
| [`53682610`](https://github.com/NixOS/nixpkgs/commit/5368261014def1ba113f1d67128df863bfdc4f26) | `` liferea: enable parallel builds ``                                         |
| [`c5be9c5b`](https://github.com/NixOS/nixpkgs/commit/c5be9c5bb60a4dff813a0f8209971604616d94e4) | `` ruff: use `ruff-lsp`, not the `python3.pkgs.ruff-lsp` alias ``             |
| [`592a779f`](https://github.com/NixOS/nixpkgs/commit/592a779f3c5e7bce1a02027abe11b7996816223f) | `` erlang_26: 26.2 -> 26.2.1 ``                                               |
| [`4c1d5da1`](https://github.com/NixOS/nixpkgs/commit/4c1d5da1b298f6f0316a52349c5b085c6c02db8e) | `` bruno: package from source ``                                              |
| [`4b1dcd35`](https://github.com/NixOS/nixpkgs/commit/4b1dcd356d0db6e6952f6fbe0f920cac6d02b376) | `` maltego: init at 4.6.0 ``                                                  |
| [`2a2c4edd`](https://github.com/NixOS/nixpkgs/commit/2a2c4edd4f587c7b74b4401236f49e9adbc56c57) | `` erlang_24: 24.3.4.14 -> 24.3.4.15 ``                                       |
| [`fe404786`](https://github.com/NixOS/nixpkgs/commit/fe40478617e57befb064f42de8e14e62f9bcb95f) | `` erlang_25: 25.3.2.7 -> 25.3.2.8 ``                                         |
| [`d996dfce`](https://github.com/NixOS/nixpkgs/commit/d996dfce0985bfa9cff280ce91f3ffef6f56b80d) | `` prismlauncher: fix meta using lib.version instead of finalAttrs.version `` |
| [`3b4bd150`](https://github.com/NixOS/nixpkgs/commit/3b4bd150c643adfe1fa9f3b886e55f687f7d92e5) | `` aliyun-cli: 3.0.190 -> 3.0.191 ``                                          |
| [`8a527465`](https://github.com/NixOS/nixpkgs/commit/8a527465d3823b3bc7f22a7d324a511f2acaddd7) | `` python311Packages.unidata-blocks: 0.0.8 -> 0.0.9 ``                        |
| [`46553919`](https://github.com/NixOS/nixpkgs/commit/465539197794e0f0250cad662d1c5de2d25de51e) | `` home-assistant: update component packages ``                               |
| [`6af26577`](https://github.com/NixOS/nixpkgs/commit/6af265770334659e9487c9ac5b3e4f711eec49ec) | `` python311Packages.vacuum-map-parser-roborock: init at 0.1.1 ``             |
| [`950bd2aa`](https://github.com/NixOS/nixpkgs/commit/950bd2aa0b4286db62338de3678212cf6bc40c26) | `` python311Packages.vacuum-map-parser-base: init at 0.1.2 ``                 |
| [`b278574a`](https://github.com/NixOS/nixpkgs/commit/b278574a83aae9631caabfd2907263bacf06bc42) | `` eask: 0.9.1 -> 0.9.2 ``                                                    |
| [`c387a33b`](https://github.com/NixOS/nixpkgs/commit/c387a33b18f9663343b8d51b92845268b6c4e22a) | `` extism-cli: 0.1.0 -> 0.3.8 ``                                              |
| [`b8f0396b`](https://github.com/NixOS/nixpkgs/commit/b8f0396bb10c71bba9e03fe8e413073216819270) | `` maintainers: add shipko ``                                                 |
| [`47fc482e`](https://github.com/NixOS/nixpkgs/commit/47fc482e58db71ece395f385d9cd3eebfa235911) | `` llama-cpp: fix cuda support; integrate upstream ``                         |
| [`bba65682`](https://github.com/NixOS/nixpkgs/commit/bba65682952119723ec4cab1e0511cd781398e8a) | `` npm-lockfile-fix: init at 0.1.0 ``                                         |
| [`7916e168`](https://github.com/NixOS/nixpkgs/commit/7916e168a86155befb8476796717a8dfddfab449) | `` fixup! bazel_7: Check-in the main lockfile ``                              |
| [`5dfd885f`](https://github.com/NixOS/nixpkgs/commit/5dfd885ff0e1a4b94b716d712ec55575b3b05e1a) | `` python311Packages.botocore-stubs: 1.34.8 -> 1.34.11 ``                     |
| [`766d9001`](https://github.com/NixOS/nixpkgs/commit/766d900167f2276228eca1c7bca8cb37ef59aa7b) | `` maintainers: update GH username for yana lunaterra/teras ``                |
| [`e8e45bc8`](https://github.com/NixOS/nixpkgs/commit/e8e45bc82ee3fc58c39bb4408acdd92a6840f020) | `` bazel_7: Check-in the main lockfile ``                                     |
| [`87716d06`](https://github.com/NixOS/nixpkgs/commit/87716d062255157323da603437e6ac2c99fe21cc) | `` bazel_7: fix remaining tests ``                                            |
| [`3d0cc02a`](https://github.com/NixOS/nixpkgs/commit/3d0cc02a4662094c457389f345c633de484f0920) | `` python3Packages.pypdf: 3.16.0 -> 3.17.4 ``                                 |
| [`535d6021`](https://github.com/NixOS/nixpkgs/commit/535d6021c2cb5c3dd60b83bc9a8b00084eba1de7) | `` freshrss: 1.23.0 -> 1.23.1 ``                                              |
| [`fd522475`](https://github.com/NixOS/nixpkgs/commit/fd522475ce533de20f65142d75a9af6d59b38e89) | `` gnome-latex: 3.44.0 → 3.46.0 ``                                            |
| [`166e47c5`](https://github.com/NixOS/nixpkgs/commit/166e47c58b24b8f5dadfc49133713d537ec72186) | `` bazel_7: improve lockfile parsing ``                                       |
| [`fc0ec239`](https://github.com/NixOS/nixpkgs/commit/fc0ec239225fa7d51be9e4fcd1542346af12823a) | `` gedit: 44.2 → 46.1 ``                                                      |
| [`f0283e42`](https://github.com/NixOS/nixpkgs/commit/f0283e42848cc1fa1e990260f099b3092bdb50c5) | `` tepl: 6.4.0 → 6.8.0 ``                                                     |
| [`0e4d873e`](https://github.com/NixOS/nixpkgs/commit/0e4d873e289beaba632bec8eca8887fd952b6a80) | `` libgedit-gtksourceview: init at 299.0.5 ``                                 |
| [`ced24ce9`](https://github.com/NixOS/nixpkgs/commit/ced24ce9f3500a6140a2843882428f81fb3adafa) | `` libgedit-amtk: 5.6.1 → 5.8.0, renamed from amtk ``                         |
| [`304caff4`](https://github.com/NixOS/nixpkgs/commit/304caff45e8f9a5d9da78c5635f333b9d4ae7289) | `` amtk: Move dbus to nativeCheckInputs ``                                    |
| [`c391bdee`](https://github.com/NixOS/nixpkgs/commit/c391bdeedc95768003174ef3e98372a04e1960a6) | `` amtk: Propagate glib and gtk3 ``                                           |
| [`12898d84`](https://github.com/NixOS/nixpkgs/commit/12898d840c547bcc609529d54a4bc0ec24de39ed) | `` python311Packages.habluetooth: 2.0.0 -> 2.0.1 ``                           |
| [`eb5939ed`](https://github.com/NixOS/nixpkgs/commit/eb5939edd1c43cb4a7143ed284066a49b3e9b089) | `` python311Packages.sensorpush-ble: 1.5.5 -> 1.6.1 ``                        |
| [`84ab5674`](https://github.com/NixOS/nixpkgs/commit/84ab5674ddccd8853535f00c77ae7946d7a83b2c) | `` ccache: 4.8.3 -> 4.9 ``                                                    |
| [`520fa986`](https://github.com/NixOS/nixpkgs/commit/520fa986205d6a6570c4404e0b17f74c659f158e) | `` ibus-engines.cangjie: init at unstable-2023-07-25 ``                       |
| [`71a28e5d`](https://github.com/NixOS/nixpkgs/commit/71a28e5d380bfc15d98835cc0339a24e3f0e9dc3) | `` python311Packages.scikit-survival: 0.22.1 -> 0.22.2 ``                     |
| [`b1e1a05e`](https://github.com/NixOS/nixpkgs/commit/b1e1a05e8a0b5932f975e514f7c4810794bc4451) | `` pwninit: 3.3.0 -> 3.3.1 ``                                                 |
| [`60b6d5ff`](https://github.com/NixOS/nixpkgs/commit/60b6d5ff925b42cc958bf40898d70872acadae14) | `` c2fmzq: 0.4.16 -> 0.4.17 ``                                                |
| [`17d6576d`](https://github.com/NixOS/nixpkgs/commit/17d6576d856306cf710e430cd408980d8e905aa4) | `` tree-sitter-grammars: add bitbake ``                                       |
| [`e8a4189b`](https://github.com/NixOS/nixpkgs/commit/e8a4189be09cfba3b30e97b2ebf7fde4d2a90dd4) | `` vivaldi: 6.5.3206.39 -> 6.5.3206.48 ``                                     |
| [`37fef59a`](https://github.com/NixOS/nixpkgs/commit/37fef59ab4d7a9b0c6d1d03c3502d1ee5c594c01) | `` vdrPlugins.softhddevice: 2.0.6 -> 2.0.7 ``                                 |
| [`05734032`](https://github.com/NixOS/nixpkgs/commit/05734032da293ccd314054e1aaf0eeefd694c62b) | `` vdrPluings.markad: 3.3.6 -> 3.4.2 ``                                       |
| [`409d4fd4`](https://github.com/NixOS/nixpkgs/commit/409d4fd458574b932d9b83d5662e7954b80988de) | `` vdr: 2.6.4 -> 2.6.5 ``                                                     |
| [`1c326dcb`](https://github.com/NixOS/nixpkgs/commit/1c326dcb4f7a2b9c7629304b894c80d3c07a84e8) | `` nixos/vdr: wait for network ``                                             |
| [`95776cb0`](https://github.com/NixOS/nixpkgs/commit/95776cb0c15d796f3907ddf302c5e9c0c5cb02f6) | `` quartus-prime-lite: 20.1.1.720 -> 22.1std.2.922 ``                         |
| [`1ace7d96`](https://github.com/NixOS/nixpkgs/commit/1ace7d96885d6acfafb3bb4ea6e5e895bacbc568) | `` twitch-tui: 2.6.0 -> 2.6.2 ``                                              |
| [`bda241c1`](https://github.com/NixOS/nixpkgs/commit/bda241c1be949d710146f5f7768cd5cb8120671b) | `` octodns: move pytestCheckHook to nativeCheckInputs ``                      |
| [`46b946ea`](https://github.com/NixOS/nixpkgs/commit/46b946ea18f77a7ba0b5c2ce5f7a8113e5bb1900) | `` pypy2Packages.attrs: fix `tests` eval ``                                   |
| [`308846a1`](https://github.com/NixOS/nixpkgs/commit/308846a111d1786c1d0d9f212beae5c1869d8243) | `` netpbm: 11.4.5 -> 11.5.1 ``                                                |
| [`70f1e03e`](https://github.com/NixOS/nixpkgs/commit/70f1e03e56df869c5c8442d6f091335d18cd61ee) | `` python311Packages.lightgbm: 4.1.0 -> 4.2.0 ``                              |
| [`e712a047`](https://github.com/NixOS/nixpkgs/commit/e712a04790a9f9e658c7d770e4ad514c38481b1a) | `` python311Packages.lightgbm: fix build on linux and with cuda ``            |
| [`ebadc33f`](https://github.com/NixOS/nixpkgs/commit/ebadc33f34a52a6b92c4a93344989cf577277240) | `` python311Packages.nbconvert: 7.13.0 -> 7.13.1 ``                           |
| [`c4f86061`](https://github.com/NixOS/nixpkgs/commit/c4f86061ce2d80960a48c1755627c8c00087084b) | `` python311Packages.jupyter-server-terminals: 0.5.0 -> 0.5.1 ``              |
| [`eb2b0245`](https://github.com/NixOS/nixpkgs/commit/eb2b02456ec19e26e5b21dc71729f9bbda2b73db) | `` lbzip2: apply implicit function definition patch; fix darwin ``            |
| [`0929716b`](https://github.com/NixOS/nixpkgs/commit/0929716b020676b5bf337c13db3ae51cfbf46134) | `` nixos/tor: fix transport plugin exe name ``                                |
| [`e4776929`](https://github.com/NixOS/nixpkgs/commit/e4776929d17ecdae10c21cb25ccd848faabdc14f) | `` rtx: add simple version test ``                                            |
| [`b0b9f0df`](https://github.com/NixOS/nixpkgs/commit/b0b9f0df249534c6193fa7d19830513108d2903b) | `` monetdb: 11.47.17 -> 11.49.1 ``                                            |
| [`ffd53dab`](https://github.com/NixOS/nixpkgs/commit/ffd53dab60e5c4a5ac0041e815540e5c62e1c400) | `` maintainers: add d3vil0p3r ``                                              |
| [`1fbb559b`](https://github.com/NixOS/nixpkgs/commit/1fbb559b84b1662449fe4509b9e1b2f3a994dff9) | `` polylith: 0.2.15-alpha -> 0.2.18 ``                                        |
| [`bc3cba38`](https://github.com/NixOS/nixpkgs/commit/bc3cba38457f5e44c00e0c5f5d7acf5936cbfa11) | `` bazel_7: Cleanup tests a bit ``                                            |
| [`ca89b111`](https://github.com/NixOS/nixpkgs/commit/ca89b111a551efb722f3906a4ebb55bf15caa6c8) | `` agdaPackages.agdarsec: mark as broken ``                                   |