### PR TITLE
chore(flake/treefmt-nix): `29613752` -> `31d9d210`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -717,11 +717,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702979157,
-        "narHash": "sha256-RnFBbLbpqtn4AoJGXKevQMCGhra4h6G2MPcuTSZZQ+g=",
+        "lastModified": 1704232924,
+        "narHash": "sha256-NNf2Xv8URY8bn4+boWTPHPphdKH3xVfxFMBLJMAIqMA=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "2961375283668d867e64129c22af532de8e77734",
+        "rev": "31d9d2109d29b23fd6ad300229e9537fa7906026",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                      |
| ---------------------------------------------------------------------------------------------------- | ---------------------------- |
| [`0a78b7d0`](https://github.com/numtide/treefmt-nix/commit/0a78b7d032850d70d3c48b8122c19efab9cb600b) | `` ci: switch to buildbot `` |
| [`8a2b0b96`](https://github.com/numtide/treefmt-nix/commit/8a2b0b9643b835800a63bebc6b1b24232140c114) | `` nix: fix checks ``        |