### PR TITLE
chore(flake/emacs-overlay): `7fd5b5b7` -> `b61ae954`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704125861,
-        "narHash": "sha256-irEN/GpvFmSMS63jmcz6lit2POJUnjlu1Yu99v5lWpk=",
+        "lastModified": 1704232327,
+        "narHash": "sha256-Td6vHEteJ9wc22aSsgK1FHgrmDYrLIdOhlcltexotcs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "7fd5b5b760ea726aa4c7670be7d93623936f9bf3",
+        "rev": "b61ae954d6ccb73f9d650c107e5eef594861d7ee",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                 |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
| [`b61ae954`](https://github.com/nix-community/emacs-overlay/commit/b61ae954d6ccb73f9d650c107e5eef594861d7ee) | `` Revert "Merge pull request #378 from Vonfry/revert/disable-emacs" `` |
| [`8fec7971`](https://github.com/nix-community/emacs-overlay/commit/8fec797146cc0d2b309b2017feae0ae3d39db78c) | `` Revert "Updated emacs" ``                                            |
| [`a8b69407`](https://github.com/nix-community/emacs-overlay/commit/a8b694071f2159f2f0e6c08cbe5bb18abb6fad40) | `` Revert "Revert "Revert "Update bytecomp-revert.patch""" ``           |
| [`3d54e9e2`](https://github.com/nix-community/emacs-overlay/commit/3d54e9e2478562d784f2a01e61c8f1c0b9c91748) | `` Revert "Revert "Revert "fixup! Update bytecomp-revert.patch""" ``    |
| [`c4a8dedd`](https://github.com/nix-community/emacs-overlay/commit/c4a8dedd3f96f3ebe57edb627bb9150fcb4f12bc) | `` Revert "Revert "fixup! Update bytecomp-revert.patch"" ``             |
| [`fed34a0e`](https://github.com/nix-community/emacs-overlay/commit/fed34a0eef8e579e006806e5b8df427d5519b7f4) | `` Revert "Revert "Update bytecomp-revert.patch"" ``                    |
| [`e3fb072d`](https://github.com/nix-community/emacs-overlay/commit/e3fb072d0225fee400a7d0f8106dd555f950a6bd) | `` Updated emacs ``                                                     |
| [`3b8c5f64`](https://github.com/nix-community/emacs-overlay/commit/3b8c5f64c9772497f9e817a69cfe50382f011bc5) | `` Updated elpa ``                                                      |
| [`a72d83f6`](https://github.com/nix-community/emacs-overlay/commit/a72d83f69cd87fc3cb490636b3afab0cb2353a67) | `` Updated nongnu ``                                                    |
| [`3fe6a192`](https://github.com/nix-community/emacs-overlay/commit/3fe6a192ba6247fad6e7abfd90b43b5f7ae47864) | `` Revert "Temporarily disable "emacs" update" ``                       |
| [`575fcd2d`](https://github.com/nix-community/emacs-overlay/commit/575fcd2ddb0e7c40611ba68d4a977e0cdc729669) | `` Updated elpa ``                                                      |
| [`4778b6a4`](https://github.com/nix-community/emacs-overlay/commit/4778b6a4e51b4784b31d57ee5a291d8b6d5d4635) | `` Updated flake inputs ``                                              |