### PR TITLE
chore(flake/nur): `c56ab874` -> `c4f5f8be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -555,11 +555,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704146221,
-        "narHash": "sha256-ef2A2VFevlMbRC/+ib/yunON6v4BmxatTQeYRlQpvN4=",
+        "lastModified": 1704224443,
+        "narHash": "sha256-BhoQWg+1Rf6Ie6CnnPwX4rn2bBnQHWsZEKVEnNnkTp8=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "c56ab874a3d53b630e946536612e748a7cd9f2f4",
+        "rev": "c4f5f8beacb9819f19dbae1d1e09c2dfd404d542",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                        |
| -------------------------------------------------------------------------------------------------- | ------------------------------ |
| [`c4f5f8be`](https://github.com/nix-community/NUR/commit/c4f5f8beacb9819f19dbae1d1e09c2dfd404d542) | `` automatic update ``         |
| [`73591ab8`](https://github.com/nix-community/NUR/commit/73591ab82b405fb016505209a5976d728bf0bc74) | `` automatic update ``         |
| [`41ca16a8`](https://github.com/nix-community/NUR/commit/41ca16a8bbaf2c9b4987e12cad98629fb5f9cb86) | `` automatic update ``         |
| [`4756ed6d`](https://github.com/nix-community/NUR/commit/4756ed6d2e9ae5b23cc56a03b9871ba0e90134d7) | `` automatic update ``         |
| [`587d5e66`](https://github.com/nix-community/NUR/commit/587d5e66dea3eea71ef5e195264699e040309d43) | `` automatic update ``         |
| [`50b26b41`](https://github.com/nix-community/NUR/commit/50b26b41841d7f618c9dbe0c6826b2a603acb456) | `` automatic update ``         |
| [`5aaff8bf`](https://github.com/nix-community/NUR/commit/5aaff8bf9354976e682c034b184a3298c8c30f3e) | `` automatic update ``         |
| [`6a4c627e`](https://github.com/nix-community/NUR/commit/6a4c627e8b6504f328d60a0cb1f373f6f6e3f40e) | `` automatic update ``         |
| [`4d8d1aae`](https://github.com/nix-community/NUR/commit/4d8d1aae1d7051cd50ad1edffb5a5a357b309ac4) | `` automatic update ``         |
| [`10d8f5cc`](https://github.com/nix-community/NUR/commit/10d8f5cc60bf34234f7458f7de4c2f6a9a8e269e) | `` automatic update ``         |
| [`e38743b3`](https://github.com/nix-community/NUR/commit/e38743b38ea8d67057d36b71af414e3d8aee68e1) | `` automatic update ``         |
| [`c8fdd6ad`](https://github.com/nix-community/NUR/commit/c8fdd6ad6e3d41b1af7b9547bacf154831533949) | `` add fanbb2333 repository `` |
| [`57697230`](https://github.com/nix-community/NUR/commit/57697230c5cbfab52f2b381c2a3f8a1ba9576840) | `` automatic update ``         |
| [`ecd50a02`](https://github.com/nix-community/NUR/commit/ecd50a0280e27bb4f21226996e9748635116bf66) | `` automatic update ``         |
| [`83b31a89`](https://github.com/nix-community/NUR/commit/83b31a89dd9cdb757f9afbab8671f8b8394ad937) | `` automatic update ``         |
| [`f3ab696b`](https://github.com/nix-community/NUR/commit/f3ab696ba7cb134655e10046fa20a0c416fa0870) | `` automatic update ``         |
| [`f7695851`](https://github.com/nix-community/NUR/commit/f7695851ed39b95d6d76a19074a3cda8a7649c57) | `` automatic update ``         |
| [`5bdfeb3f`](https://github.com/nix-community/NUR/commit/5bdfeb3f39c979ca6316b814334c4473af1a2af2) | `` automatic update ``         |
| [`4de02a5e`](https://github.com/nix-community/NUR/commit/4de02a5e743d4a4c48556c56d6248fbef8b2fe63) | `` automatic update ``         |
| [`53d3ef23`](https://github.com/nix-community/NUR/commit/53d3ef23e9a372e36d297a82788e322cdff9211e) | `` automatic update ``         |
| [`08b00e3e`](https://github.com/nix-community/NUR/commit/08b00e3e5a6934452fbfaeea217e0afe35cd2107) | `` automatic update ``         |
| [`831a8dde`](https://github.com/nix-community/NUR/commit/831a8dde2ee59d3b950981ecfc12472240431d14) | `` automatic update ``         |
| [`820a4b9b`](https://github.com/nix-community/NUR/commit/820a4b9b2f9111fb71d41794b38ffd46bb7e81ed) | `` automatic update ``         |
| [`df1a53ad`](https://github.com/nix-community/NUR/commit/df1a53ad85c6582efda6403ed55ea9cb0cd04725) | `` automatic update ``         |
| [`e536b1fe`](https://github.com/nix-community/NUR/commit/e536b1fe291512fe69a33c3833c5458a4e941f89) | `` automatic update ``         |
| [`68dc852a`](https://github.com/nix-community/NUR/commit/68dc852ad8dd574496177886c6391624aa2d5cf4) | `` automatic update ``         |