### PR TITLE
chore(flake/emacs-overlay): `6a88aa2f` -> `3ada6ddb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704444616,
-        "narHash": "sha256-LAc3yBhmhpkTFcxsaUp9KqV+bbFYczOQqPVKndA7qt4=",
+        "lastModified": 1704559748,
+        "narHash": "sha256-dUNZOUCsa1VHAzSET7DJGKfXj1H/odHrt1HM29z3j5M=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "6a88aa2f7cd8e96ca5abc9433c7aea997a4f794e",
+        "rev": "3ada6ddb60f9313cb2ac977106605e09c857ffec",
         "type": "github"
       },
       "original": {
@@ -574,11 +574,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1704295289,
-        "narHash": "sha256-9WZDRfpMqCYL6g/HNWVvXF0hxdaAgwgIGeLYiOhmes8=",
+        "lastModified": 1704420045,
+        "narHash": "sha256-C36QmoJd5tdQ5R9MC1jM7fBkZW9zBUqbUCsgwS6j4QU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0b2c5445c64191fd8d0b31f2b1a34e45a64547d",
+        "rev": "c1be43e8e837b8dbee2b3665a007e761680f0c3d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`3ada6ddb`](https://github.com/nix-community/emacs-overlay/commit/3ada6ddb60f9313cb2ac977106605e09c857ffec) | `` Updated melpa ``        |
| [`96a2809f`](https://github.com/nix-community/emacs-overlay/commit/96a2809fba7398dec610a5367c219d03dde07bf9) | `` Updated elpa ``         |
| [`4a17d22f`](https://github.com/nix-community/emacs-overlay/commit/4a17d22f425279621da0e9a3060031e5769ede0e) | `` Updated flake inputs `` |
| [`85ac1bf8`](https://github.com/nix-community/emacs-overlay/commit/85ac1bf8543d2e179d7748f3788d58b06eacc758) | `` Updated melpa ``        |
| [`0bb376d4`](https://github.com/nix-community/emacs-overlay/commit/0bb376d47272738f7c720f03f1098b96ad3ea0f6) | `` Updated melpa ``        |
| [`4b77b102`](https://github.com/nix-community/emacs-overlay/commit/4b77b102b4dfef209af4875478dabcde03e4dea5) | `` Updated elpa ``         |
| [`5e4e57b1`](https://github.com/nix-community/emacs-overlay/commit/5e4e57b1e3aecf7318550156aebd6605c00e1eb7) | `` Updated melpa ``        |
| [`b6d2d8bd`](https://github.com/nix-community/emacs-overlay/commit/b6d2d8bde643a02e3bc74ecd15a534c31ea328c1) | `` Updated elpa ``         |