### PR TITLE
chore(flake/nur): `bcd4c2a8` -> `1ded0078`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -638,11 +638,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704446423,
-        "narHash": "sha256-nIc4tSSzoacSN6P8rw6PUvaRBfAtKpKDIR+USjCOje4=",
+        "lastModified": 1704584931,
+        "narHash": "sha256-Ct8RCvA6ha/nB4EWjyX1HpMkgeZYldi5EdbaswLa+tg=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "bcd4c2a8d317b1556605be563abf2070d2b9da31",
+        "rev": "1ded0078d049439eb4285c3d12d7e7892331db05",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1ded0078`](https://github.com/nix-community/NUR/commit/1ded0078d049439eb4285c3d12d7e7892331db05) | `` automatic update `` |
| [`a822fe15`](https://github.com/nix-community/NUR/commit/a822fe1504c778894180e69c4e6ec89358781433) | `` automatic update `` |
| [`184fa856`](https://github.com/nix-community/NUR/commit/184fa8562d7c06507315534a2f578b59faae2877) | `` automatic update `` |
| [`031e5677`](https://github.com/nix-community/NUR/commit/031e567712130530a787ef20b9ab4f5a97b0bfeb) | `` automatic update `` |
| [`bcc95db3`](https://github.com/nix-community/NUR/commit/bcc95db343f527f2d6310d2ffc153eb10980efaa) | `` automatic update `` |
| [`acdb8f53`](https://github.com/nix-community/NUR/commit/acdb8f53b881273db6afbf5c41205928701ac1ef) | `` automatic update `` |
| [`e0226df8`](https://github.com/nix-community/NUR/commit/e0226df82dbe10f4182de91673487c05621c66ee) | `` automatic update `` |
| [`58b45305`](https://github.com/nix-community/NUR/commit/58b453053d52a5c6ff9e76859ff2aa63f0aca4af) | `` automatic update `` |
| [`8a1b4b0c`](https://github.com/nix-community/NUR/commit/8a1b4b0c1574f5f6dafab6d2c087efcea4736e98) | `` automatic update `` |
| [`3fbed9bd`](https://github.com/nix-community/NUR/commit/3fbed9bd2b3c6eced12baea4b61b3a060cd39b8d) | `` automatic update `` |
| [`771d345e`](https://github.com/nix-community/NUR/commit/771d345e77cd35f339bb03c6f61bf619ea25ff41) | `` automatic update `` |
| [`910ab73d`](https://github.com/nix-community/NUR/commit/910ab73d26e2423b3461700eb6cd5b163ab0ddae) | `` automatic update `` |
| [`33ac9895`](https://github.com/nix-community/NUR/commit/33ac9895fdc714eff02e0ccf3b80711a5fd34913) | `` automatic update `` |
| [`1edb3faf`](https://github.com/nix-community/NUR/commit/1edb3fafedb1f417b5dbe3aaf0c99e8f04c12d7c) | `` automatic update `` |
| [`414962dd`](https://github.com/nix-community/NUR/commit/414962ddd2edeeaad1a63a4149061454479eb3c1) | `` automatic update `` |
| [`1afead7f`](https://github.com/nix-community/NUR/commit/1afead7fb8935b36eeb9af9b6101b26a626327ee) | `` automatic update `` |
| [`e2a9e96c`](https://github.com/nix-community/NUR/commit/e2a9e96c34e0aeeb7454396a5a031da1b0510d05) | `` automatic update `` |
| [`607e0e48`](https://github.com/nix-community/NUR/commit/607e0e48c2bf0451acd29f85ffe0b4bdb07fc265) | `` automatic update `` |
| [`17201170`](https://github.com/nix-community/NUR/commit/17201170bc033a8f1847995d7b788668666434eb) | `` automatic update `` |
| [`6093bd1a`](https://github.com/nix-community/NUR/commit/6093bd1aa15508364c814684112c35bb91d9bd5b) | `` automatic update `` |
| [`98989265`](https://github.com/nix-community/NUR/commit/989892658362304e05fdad819c1dea75ab2b6003) | `` automatic update `` |
| [`1dcce361`](https://github.com/nix-community/NUR/commit/1dcce3612333fffb390ab4eacc251d7f8bc1595c) | `` automatic update `` |
| [`d47d3e3d`](https://github.com/nix-community/NUR/commit/d47d3e3df6fa14b1945e4539ce4d3ac0d85b5711) | `` automatic update `` |
| [`effffaab`](https://github.com/nix-community/NUR/commit/effffaabc49fb1ad19f45085165eadb27d2c1c2c) | `` automatic update `` |
| [`e9a91d76`](https://github.com/nix-community/NUR/commit/e9a91d76e3d02eb86e304a91fe0b1486bb2d4fcb) | `` automatic update `` |
| [`9c4f6b66`](https://github.com/nix-community/NUR/commit/9c4f6b66f05fc6f6285df25e89f825b441ec9705) | `` automatic update `` |
| [`6bf44adb`](https://github.com/nix-community/NUR/commit/6bf44adb1f887e5e7e6ee5601a718ab8ae9e8e9b) | `` automatic update `` |
| [`fe2963f0`](https://github.com/nix-community/NUR/commit/fe2963f0e80eb6f9bc3febea2429709c107ddd6f) | `` automatic update `` |
| [`d321e7e7`](https://github.com/nix-community/NUR/commit/d321e7e78110d181d243ec9e2f6534d75547620e) | `` automatic update `` |
| [`a9894300`](https://github.com/nix-community/NUR/commit/a9894300c3f2d966abba98ff8de12b39254f7b60) | `` automatic update `` |
| [`784b598b`](https://github.com/nix-community/NUR/commit/784b598b006e691690283effc8e56115eae99bc8) | `` automatic update `` |
| [`46e3b23d`](https://github.com/nix-community/NUR/commit/46e3b23d86f3ad1a594ecef91327a5c92a18fae9) | `` automatic update `` |
| [`08e5b9ec`](https://github.com/nix-community/NUR/commit/08e5b9ecf1e65b89a66cd0f91927388bab9fedca) | `` automatic update `` |