### PR TITLE
chore(flake/lanzaboote): `81f7a56f` -> `a454a589`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -397,11 +397,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1704230057,
-        "narHash": "sha256-YTkPHIM/RF1WtWqRAxlaE2lqvzEBa58SZzQZB2sx4PY=",
+        "lastModified": 1704497899,
+        "narHash": "sha256-eyImNjgTHaF+be2fnNFY+Lv73rWVj7yOGxrafZNB/gI=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "81f7a56f0ee6bb454284feeeb192df56e39d98d1",
+        "rev": "a454a5894700db8b85d0e08ae1bb870c4b88ef77",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                       |
| --------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`05cb051f`](https://github.com/nix-community/lanzaboote/commit/05cb051f0523b36cca55d120f85c7bf2a1fb3641) | `` Use the original os-release file parser `` |