### PR TITLE
chore(flake/chaotic): `b9df8e79` -> `a4864705`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1704375014,
-        "narHash": "sha256-+XWvjxMe+EZ3tKs/lzAcoVRyAqygszpWfe6Db6NiHHM=",
+        "lastModified": 1704556578,
+        "narHash": "sha256-aCCT4796b07jPY+7D61MGghR9qrH6QAn1hH2cWWQ3fI=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "b9df8e79c8778d224b79d5ab4d90cdbe6dc9b1fb",
+        "rev": "a486470595d1c6414865b252dd96d988c0aad8f2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                      |
| ----------------------------------------------------------------------------------------------- | ---------------------------- |
| [`a4864705`](https://github.com/chaotic-cx/nyx/commit/a486470595d1c6414865b252dd96d988c0aad8f2) | `` Bump 20240106-1 (#528) `` |
| [`a8173214`](https://github.com/chaotic-cx/nyx/commit/a817321463a1a09b7df4e9c33cf0712a7665134a) | `` Bump 20240105-2 (#527) `` |
| [`94ec7904`](https://github.com/chaotic-cx/nyx/commit/94ec79046323db8cfcd603f289d4bbdd0bc71285) | `` Bump 20240105-1 (#526) `` |