### PR TITLE
chore(flake/nixpkgs): `7a7cfff8` -> `0fa5a936`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1704397097,
-        "narHash": "sha256-ywXj6ck6q5ArzzRk9wXQX4rGnxdwS/xOCkibrMXOykc=",
+        "lastModified": 1704497359,
+        "narHash": "sha256-i6LgDTXhOhCRIhy8Og4PYvqs1R559flBSOxAjRLZM0Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7a7cfff8915e06365bc2365ff33d4d413184fa9f",
+        "rev": "0fa5a936f203acc1b11ed20fe002320944a8363b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`9121ed44`](https://github.com/NixOS/nixpkgs/commit/9121ed447f1f95b1d320e9d586eb72a01a787a8a) | `` python311Packages.dask-awkward: 2023.12.2 -> 2024.1.0 (#278949) ``           |
| [`6b0de30a`](https://github.com/NixOS/nixpkgs/commit/6b0de30acc8b85caf2389468bc6f4428aedde835) | `` tt-rss-theme-feedly: fix license ``                                          |
| [`46796330`](https://github.com/NixOS/nixpkgs/commit/46796330dc624cfb60d694e4578a84c835ff563a) | `` tt-rss-theme-feedly: 3.1.0 -> 4.1.0 ``                                       |
| [`86fda41d`](https://github.com/NixOS/nixpkgs/commit/86fda41d8a052fc0ee2018e6e2fcbab6703ea019) | `` eclipse-mat: 1.13.0.20220615 -> 1.14.0.20230315 ``                           |
| [`63bdb6b2`](https://github.com/NixOS/nixpkgs/commit/63bdb6b2c2afa0744aad3d9ef73a7c06d73d48d7) | `` palemoon-bin: 32.5.1 -> 32.5.2 ``                                            |
| [`ca6b7b1b`](https://github.com/NixOS/nixpkgs/commit/ca6b7b1b6dd0af0d47b6c53f9ab1fbe5fc4e4a08) | `` libuev: restrict platforms ``                                                |
| [`6998653d`](https://github.com/NixOS/nixpkgs/commit/6998653dd0a1679827b66ed24af0a849fd386e0e) | `` linux_latest-libre: 19453 -> 19459 ``                                        |
| [`a9686a80`](https://github.com/NixOS/nixpkgs/commit/a9686a8009ede52e55bb0701edf2c73ab3a4ebc3) | `` linux-rt_6_1: 6.1.67-rt20 -> 6.1.70-rt21 ``                                  |
| [`f91b4c1b`](https://github.com/NixOS/nixpkgs/commit/f91b4c1b9bc36b2a3a0d5d48d56c5ea9b0036ad1) | `` linux-rt_5_4: 5.4.257-rt87 -> 5.4.264-rt88 ``                                |
| [`7a3b0bad`](https://github.com/NixOS/nixpkgs/commit/7a3b0badbf248ef11edcc18fe6318e8d77f23e5e) | `` linux-rt_5_15: 5.15.141-rt72 -> 5.15.145-rt73 ``                             |
| [`8c163c0d`](https://github.com/NixOS/nixpkgs/commit/8c163c0de372be1c54e13ecaaf8b3c8577cde9a6) | `` linux_5_10: 5.10.205 -> 5.10.206 ``                                          |
| [`7be7d002`](https://github.com/NixOS/nixpkgs/commit/7be7d0024b20f837f346466eaf78aa1b857abb43) | `` linux_5_15: 5.15.145 -> 5.15.146 ``                                          |
| [`897a5686`](https://github.com/NixOS/nixpkgs/commit/897a5686c05d8fa3ca7730e2f14968e1e927a220) | `` linux_6_1: 6.1.69 -> 6.1.71 ``                                               |
| [`d65452f5`](https://github.com/NixOS/nixpkgs/commit/d65452f59e7c314346261869cc9ad3f5137f0b64) | `` linux_6_6: 6.6.8 -> 6.6.10 ``                                                |
| [`70d02d94`](https://github.com/NixOS/nixpkgs/commit/70d02d944d07cee6ed109fb8b5a84a1263f03ad7) | `` linux_testing: 6.7-rc7 -> 6.7-rc8 ``                                         |
| [`150aab9d`](https://github.com/NixOS/nixpkgs/commit/150aab9d0a6745c67b32013ed11f0d9f40f22757) | `` pythonPackages.sabctools: 7.1.2 -> 8.1.0 ``                                  |
| [`a72a7ad7`](https://github.com/NixOS/nixpkgs/commit/a72a7ad723ce2fa1f6c3a5e6d6563b7143cf60a9) | `` nixos/tests/slimserver: regex squeezelite number in log ``                   |
| [`d374e0f0`](https://github.com/NixOS/nixpkgs/commit/d374e0f0614b09416737ee8244a6dda6515107e2) | `` lightburn: vendor qt libraries ``                                            |
| [`a6a93bd7`](https://github.com/NixOS/nixpkgs/commit/a6a93bd71e77050a843c87e9ea28da39e1dae3d8) | `` lightburn: 1.2.01 -> 1.4.05 ``                                               |
| [`781a005d`](https://github.com/NixOS/nixpkgs/commit/781a005d9ed919bd0061ba876cf3fbcc51678d18) | `` resolve-march-native: 2.2.0 -> 5.0.2 ``                                      |
| [`d163ea41`](https://github.com/NixOS/nixpkgs/commit/d163ea4133312f04ebf8eb4875ea4b61400b4b5e) | `` ungoogled-chromium: 120.0.6099.129-1 -> 120.0.6099.199-1 ``                  |
| [`1922bc42`](https://github.com/NixOS/nixpkgs/commit/1922bc428b23986d9716fee48ae3ecdeb79bb3ec) | `` libiconvReal: 1.16 -> 1.17 ``                                                |
| [`c9d145fa`](https://github.com/NixOS/nixpkgs/commit/c9d145fa2a584d04db8995f4401d44a103ebf183) | `` streamlink-twitch-gui-bin: 2.1.0 -> 2.4.1 ``                                 |
| [`a2f22ece`](https://github.com/NixOS/nixpkgs/commit/a2f22ececf5875e682c72b837804ef9648823d89) | `` pipe-viewer: 0.3.0 -> 0.4.8 ``                                               |
| [`c1d8fd1a`](https://github.com/NixOS/nixpkgs/commit/c1d8fd1a899280f7a92914b4ebdeb538842e98e0) | `` nixos/ddclient: make ExecStartPre a list ``                                  |
| [`26319774`](https://github.com/NixOS/nixpkgs/commit/26319774635104e7fea5db4318ae7180e6229674) | `` odin: dev-2023-12 -> dev-2024-01 ``                                          |
| [`e1695859`](https://github.com/NixOS/nixpkgs/commit/e16958593a16a89f3472583d644637a753fdb779) | `` cosmic-launcher: init at unstable-2023-12-13 ``                              |
| [`b2e4fd10`](https://github.com/NixOS/nixpkgs/commit/b2e4fd1049a3e92c898c99adc8832361fa7e1397) | `` graphicsmagick: fix passthru.tests ``                                        |
| [`e43872df`](https://github.com/NixOS/nixpkgs/commit/e43872dfc0f26e5408f11dbacf8ff7f539bd5b98) | `` wireshark: 4.2.1 -> 4.2.2 ``                                                 |
| [`71c0dd30`](https://github.com/NixOS/nixpkgs/commit/71c0dd30ae967cf8911f12f477055702616697ba) | `` resources: 1.2.1 -> 1.3.0 ``                                                 |
| [`1252d2f8`](https://github.com/NixOS/nixpkgs/commit/1252d2f807c0c7029bf32d0ebdfec22615b32661) | `` rustdesk: 1.2.2 -> 1.2.3 ``                                                  |
| [`e11317b0`](https://github.com/NixOS/nixpkgs/commit/e11317b03a50a543a02c6eab30d262e1caeeb92a) | `` {gnome-,}resources: merge, fix up ``                                         |
| [`74b2cb1e`](https://github.com/NixOS/nixpkgs/commit/74b2cb1e9f46daa904d3e8b0c7deee9681384d5f) | `` maintainers: update email address for getpsyched ``                          |
| [`7168adee`](https://github.com/NixOS/nixpkgs/commit/7168adee043daa15243eb4f2509a1617fa6891af) | `` flock: add mainProgram ``                                                    |
| [`e381fef2`](https://github.com/NixOS/nixpkgs/commit/e381fef2a845672af40d8028b94c3163dba3e26e) | `` eff: 5.0 → 5.1 ``                                                            |
| [`ee131404`](https://github.com/NixOS/nixpkgs/commit/ee131404efec2c50ee04c4563c0f87de2db160c7) | `` vscode-extensions.ms-vsliveshare.vsliveshare: 1.0.5834 -> 1.0.5900 ``        |
| [`0e7a6eeb`](https://github.com/NixOS/nixpkgs/commit/0e7a6eeb41d586688410ce53305afe4b45afb834) | `` gocode: remove ``                                                            |
| [`5280b6ef`](https://github.com/NixOS/nixpkgs/commit/5280b6ef6c1c9e95114b1bb0eb163c3eeb1c5565) | `` cinnamon.bulky: 3.1 -> 3.2 ``                                                |
| [`d1a3004c`](https://github.com/NixOS/nixpkgs/commit/d1a3004c22c4138ab460683b5b08fa9d11ad61e9) | `` asusctl: 5.0.6 -> 5.0.7 ``                                                   |
| [`9c51fb06`](https://github.com/NixOS/nixpkgs/commit/9c51fb0606181c9b6b35ccfd8bd8e368d388c154) | `` nvidia-x11: add an assert that `useSettings` implies more than `libsOnly` `` |
| [`fc72865a`](https://github.com/NixOS/nixpkgs/commit/fc72865ab86d6d02e53caa3a70a53ccfa09f8a48) | `` automatic-timezoned: 1.0.138 -> 1.0.139 ``                                   |
| [`851da59d`](https://github.com/NixOS/nixpkgs/commit/851da59daaab65978b405853232a0b7f17d67104) | `` url-parser: 2.0.1 -> 2.0.2 ``                                                |
| [`ab261a05`](https://github.com/NixOS/nixpkgs/commit/ab261a05855419ee10465f1f36caea403fe65d06) | `` trivy: 0.48.1 -> 0.48.2 ``                                                   |
| [`1ed5e047`](https://github.com/NixOS/nixpkgs/commit/1ed5e047af84055afac988e081e54a5c96581f08) | `` civo: 1.0.70 -> 1.0.72 ``                                                    |
| [`9ed34e2e`](https://github.com/NixOS/nixpkgs/commit/9ed34e2ec38d9fa5c47621b4b755254ed2ef5ce4) | `` nvc: 1.11.1 -> 1.11.2 ``                                                     |
| [`f10ff4a1`](https://github.com/NixOS/nixpkgs/commit/f10ff4a12ccbda56b8b2c74630f905ae87802097) | `` ledger-live-desktop: 2.73.0 -> 2.73.1 ``                                     |
| [`930c431d`](https://github.com/NixOS/nixpkgs/commit/930c431df7517a151e9122653fff944f9746ebc9) | `` feather: 2.6.1 -> 2.6.2 ``                                                   |
| [`f30bdc7b`](https://github.com/NixOS/nixpkgs/commit/f30bdc7b063b5989d7b89d9b2bba56e7b6a63491) | `` hyprland-per-window-layout: 2.4 -> 2.5 ``                                    |
| [`77f646e2`](https://github.com/NixOS/nixpkgs/commit/77f646e293a0e1e56e49febc98086b4c84dc32db) | `` just: 1.21.0 -> 1.22.0 ``                                                    |
| [`d7635701`](https://github.com/NixOS/nixpkgs/commit/d7635701af7cb02ccd31c926cf229c9f390bba5d) | `` xcb-imdkit: 1.0.5 -> 1.0.6 ``                                                |
| [`0a86b18d`](https://github.com/NixOS/nixpkgs/commit/0a86b18d8b59b7a6a09d3c8c9f4404a3176539e4) | `` xeus: 3.1.4 -> 3.1.5 ``                                                      |
| [`e6ecfff4`](https://github.com/NixOS/nixpkgs/commit/e6ecfff4509422504ae1f35b2f4eeafc30371db8) | `` tgt: 1.0.89 -> 1.0.90 ``                                                     |
| [`f65e066a`](https://github.com/NixOS/nixpkgs/commit/f65e066a9bded37ca2cb3bb157b71ee7bb508c61) | `` tellico: 3.5.2 -> 3.5.3 ``                                                   |
| [`e9bbedd9`](https://github.com/NixOS/nixpkgs/commit/e9bbedd91a6beb0023105bb074d0ceaaba91a5d2) | `` rwc: 0.2 -> 0.3 ``                                                           |
| [`2481ef21`](https://github.com/NixOS/nixpkgs/commit/2481ef2113f1ea9b3f9fac7881623695a256d856) | `` python310Packages.flowlogs-reader: 5.0.0 -> 5.0.1 ``                         |
| [`26c6b9f5`](https://github.com/NixOS/nixpkgs/commit/26c6b9f5394b2e64649ff18394d61ce5594874e2) | `` rymdport: 3.5.1 -> 3.5.2 ``                                                  |
| [`aa853816`](https://github.com/NixOS/nixpkgs/commit/aa8538161c87bacd00dab74749d2f69a1a5e982b) | `` sqldef: 0.16.13 -> 0.16.14 ``                                                |
| [`da5b9fb2`](https://github.com/NixOS/nixpkgs/commit/da5b9fb2c7d383fa9a24e2ec8dccbd1ac4d842c3) | `` revive: 1.3.4 -> 1.3.5 ``                                                    |
| [`88cab94b`](https://github.com/NixOS/nixpkgs/commit/88cab94bd9491368f0605dc28135b55dac7e587d) | `` wallabag: 2.6.7 -> 2.6.8 ``                                                  |
| [`1b498f74`](https://github.com/NixOS/nixpkgs/commit/1b498f741dc8345d5d9540a680f2a2fcb8eb0763) | `` codeium: 1.6.16 -> 1.6.18 ``                                                 |
| [`ddb6aac5`](https://github.com/NixOS/nixpkgs/commit/ddb6aac521ba3665ff565d0974af8296480489e5) | `` sddm: 0.20.0 -> 0.20.0-unstable-2023-12-29, add Qt6 support ``               |
| [`646b43f8`](https://github.com/NixOS/nixpkgs/commit/646b43f8c52feb8833add707c057710cd7d36f6e) | `` libuev: 2.4.0 -> 2.4.1 ``                                                    |
| [`197f4b11`](https://github.com/NixOS/nixpkgs/commit/197f4b1116960dd98c186f0b123f43bdb1a7c516) | `` golangci-lint-langserver: 0.0.8 -> 0.0.9 ``                                  |
| [`da0c998a`](https://github.com/NixOS/nixpkgs/commit/da0c998a8a02ca852a5193c7ac19ff0a3f711c11) | `` gh-dash: 3.11.0 -> 3.11.1 ``                                                 |
| [`54bda945`](https://github.com/NixOS/nixpkgs/commit/54bda945d515e6f8b77eabd04a63ea7420133824) | `` goldwarden: 0.2.7 -> 0.2.9 ``                                                |
| [`54e2f7e4`](https://github.com/NixOS/nixpkgs/commit/54e2f7e4d6aea5ef7b90adefd9bac5e2b09397b5) | `` crowdin-cli: 3.15.0 -> 3.16.0 ``                                             |
| [`745a56a2`](https://github.com/NixOS/nixpkgs/commit/745a56a2e9c4955cdcbd69df980f342986e04ab3) | `` crow-translate: 2.11.0 -> 2.11.1 ``                                          |
| [`1d2f1699`](https://github.com/NixOS/nixpkgs/commit/1d2f1699b78da960d227fc60ff323385edce6b0d) | `` uptime-kuma: 1.23.10 -> 1.23.11 ``                                           |
| [`1cf54a8c`](https://github.com/NixOS/nixpkgs/commit/1cf54a8ce76a1cef6fcb7bde7faf7ce0675efc01) | `` drone-scp: 1.6.13 -> 1.6.14 ``                                               |
| [`4f2230a4`](https://github.com/NixOS/nixpkgs/commit/4f2230a4a3a0f2b8f501975971db023777cd5f4f) | `` typesense: 0.25.1 -> 0.25.2 ``                                               |
| [`4d8faaaf`](https://github.com/NixOS/nixpkgs/commit/4d8faaaf225a7393ea9b4efc9f214e9be11a6b25) | `` turso-cli: 0.87.7 -> 0.87.8 ``                                               |
| [`df468502`](https://github.com/NixOS/nixpkgs/commit/df4685029e45c39cef68fb8a6f0ed4e80b81a063) | `` treesheets: unstable-2023-12-24 -> unstable-2024-01-03 ``                    |
| [`09ade8db`](https://github.com/NixOS/nixpkgs/commit/09ade8db9b00833df22d0b8b67e0aed1a8fea2e6) | `` texlab: 5.12.0 -> 5.12.1 ``                                                  |
| [`60a04bf3`](https://github.com/NixOS/nixpkgs/commit/60a04bf3809e2865907a0090914e3db1e489d23e) | `` anytype: 0.37.0 -> 0.37.3 ``                                                 |
| [`a4d0aa07`](https://github.com/NixOS/nixpkgs/commit/a4d0aa0797f148a77b50f7539553840051c4f525) | `` taproot-assets: 0.2.3 -> 0.3.2 ``                                            |
| [`c2b81a51`](https://github.com/NixOS/nixpkgs/commit/c2b81a51b3ae6e43c52547ef14fda61aff7ae8f8) | `` mint: 0.15.1 -> 0.15.3 ``                                                    |
| [`f9f9155f`](https://github.com/NixOS/nixpkgs/commit/f9f9155f67df9f7ea684c6203f6ecb0424621c65) | `` svd2rust: 0.31.3 -> 0.31.4 ``                                                |
| [`4664f806`](https://github.com/NixOS/nixpkgs/commit/4664f806a93ea05560c7b1e21f8d53d0bd3e7165) | `` brave: 1.61.109 -> 1.61.114 ``                                               |
| [`07072e24`](https://github.com/NixOS/nixpkgs/commit/07072e248d98ea9763d85ca450814e637ea63728) | `` python3Packages.datadog: unbreak, run subset of tests ``                     |
| [`f08ab3d5`](https://github.com/NixOS/nixpkgs/commit/f08ab3d52802a0319c8b4eaa8555965fafc82da7) | `` vcsh: 2.0.6 -> 2.0.7 ``                                                      |
| [`9051cab2`](https://github.com/NixOS/nixpkgs/commit/9051cab202f52bedd15eb5e73b464884133ba391) | `` buildbot-plugins.react-grid-view: init at 3.10.1 ``                          |
| [`6b6eb045`](https://github.com/NixOS/nixpkgs/commit/6b6eb04575ec6123a234e29f038509558cf4a6cf) | `` buildbot-plugins.react-waterfall-view: init at 3.10.1 ``                     |
| [`a64cc468`](https://github.com/NixOS/nixpkgs/commit/a64cc4682ee541fc76726e0d90a7e527b7b80fb0) | `` buildbot-plugins.react-console-view: init at 3.10.1 ``                       |
| [`43a88eef`](https://github.com/NixOS/nixpkgs/commit/43a88eef2ed0cbcfe3640a62a36176a833f3b2b2) | `` .github/CODEOWNERS: add buildbot ``                                          |
| [`3d0b034e`](https://github.com/NixOS/nixpkgs/commit/3d0b034e8794ad419a1d2615c77ff20ccd0acfd9) | `` maintainers/teams: add buildbot ``                                           |
| [`24d06c17`](https://github.com/NixOS/nixpkgs/commit/24d06c178520184a6d987fc14b81f0daefbdff2d) | `` squeezelite: 1.9.9.1449 -> 1.9.9.1463 ``                                     |
| [`e42f48b9`](https://github.com/NixOS/nixpkgs/commit/e42f48b9c52070c8e6adc2d176c853fe73661e78) | `` supabase-cli: 1.129.1 -> 1.131.2 ``                                          |
| [`834794c9`](https://github.com/NixOS/nixpkgs/commit/834794c97e336b8f23345140d0e5155b555debea) | `` neovide: 0.12.0 -> 0.12.1 ``                                                 |
| [`75524fd8`](https://github.com/NixOS/nixpkgs/commit/75524fd826bed11675d255ef2d34e29f10b61d4b) | `` delve: 1.21.2 -> 1.22.0 ``                                                   |
| [`016680fc`](https://github.com/NixOS/nixpkgs/commit/016680fcf62c2fcd679bbb64a20b46e2156d121c) | `` doc: add documentation conventions to keep a consistent style ``             |
| [`bc0589ab`](https://github.com/NixOS/nixpkgs/commit/bc0589ab0010a5f4b6522b85c9246e6b29937435) | `` vimPlugins.codeium-vim: 2023-12-26 -> 2024-01-03 ``                          |
| [`786f7889`](https://github.com/NixOS/nixpkgs/commit/786f788914f2a6e94cedf361541894e972b8fd23) | `` wavebox: 10.119.8-2 -> 10.120.10-2 ``                                        |
| [`b73a5beb`](https://github.com/NixOS/nixpkgs/commit/b73a5beb843afb31ecad5ec856d88d0160ed4713) | `` python311Packages.github3-py: 3.2.0 -> 4.0.1 ``                              |
| [`a870e5da`](https://github.com/NixOS/nixpkgs/commit/a870e5dad663ce844a63acdbddcd06a049c21146) | `` sidplayfp: 2.5.1 -> 2.6.0 ``                                                 |
| [`f83475a5`](https://github.com/NixOS/nixpkgs/commit/f83475a5054909835e3e63b6b17f398658272ea1) | `` sentry-cli: 2.23.1 -> 2.23.2 ``                                              |
| [`861431f2`](https://github.com/NixOS/nixpkgs/commit/861431f2824867ccc3dd48dba670b771e6d15a45) | `` nixos/tests/bootspec: test `initrd` and `initrdSecrets` a bit stricter ``    |
| [`7c6f6491`](https://github.com/NixOS/nixpkgs/commit/7c6f64914f37903ec3af2ac98ff3fafa970a1d5b) | `` system/activation/bootspec: do not synthesize `initrdSecrets` if unneeded `` |
| [`b3d998e7`](https://github.com/NixOS/nixpkgs/commit/b3d998e7eae49863b09a9edb1956a521a26eeefd) | `` boot/loader/systemd-boot: BootSpec makes `initrdSecrets` optional ``         |
| [`3f90c530`](https://github.com/NixOS/nixpkgs/commit/3f90c530b272d5e90d7526a351013777ff89193b) | `` python311Packages.github3-py: rename from github3_py ``                      |