### PR TITLE
chore(flake/treefmt-nix): `e434da61` -> `04f25d7b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -816,11 +816,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704233915,
-        "narHash": "sha256-GYDC4HjyVizxnyKRbkrh1GugGp8PP3+fJuh40RPCN7k=",
+        "lastModified": 1704649711,
+        "narHash": "sha256-+qxqJrZwvZGilGiLQj3QbYssPdYCwl7ejwMImgH7VBQ=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e434da615ef74187ba003b529cc72f425f5d941e",
+        "rev": "04f25d7bec9fb29d2c3bacaa48a3304840000d36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                  |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`04f25d7b`](https://github.com/numtide/treefmt-nix/commit/04f25d7bec9fb29d2c3bacaa48a3304840000d36) | `` feat(programs): Add biome.js as a formatter (#147) `` |
| [`4e0914b1`](https://github.com/numtide/treefmt-nix/commit/4e0914b128272cd0fc25c2c63c05c1941e638984) | `` add asmfmt (#148) ``                                  |