### PR TITLE
chore(flake/nix-index-database): `d6510ce1` -> `f46800ac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -490,11 +490,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703992163,
-        "narHash": "sha256-709CGmwU34dxv8DjSpRBZ+HibVJIVaFcA4JH+GFnhyM=",
+        "lastModified": 1704596958,
+        "narHash": "sha256-BK3Ohsz7m8X6qVKFxDtr8KVcHipfr5hYE9PDIJevHbQ=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "d6510ce144f5da7dd9bac667ba3d5a4946c00d11",
+        "rev": "f46800ac5a6e9f892fe36e50821c5d85794ecc62",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`f46800ac`](https://github.com/nix-community/nix-index-database/commit/f46800ac5a6e9f892fe36e50821c5d85794ecc62) | `` update packages.nix to release 2024-01-07-030820 `` |
| [`5243a943`](https://github.com/nix-community/nix-index-database/commit/5243a943a37fa010e9d8f141c07a6870fde1060b) | `` flake.lock: Update ``                               |