### PR TITLE
chore(flake/emacs-overlay): `3ada6ddb` -> `4118d09e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704559748,
-        "narHash": "sha256-dUNZOUCsa1VHAzSET7DJGKfXj1H/odHrt1HM29z3j5M=",
+        "lastModified": 1704876648,
+        "narHash": "sha256-9IQv2/opC02AsYF2QjyW7/UmS1fTfdHIAW86I1Zvv88=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3ada6ddb60f9313cb2ac977106605e09c857ffec",
+        "rev": "4118d09e3b6613425c4d48f4aa4b2ed944e5b801",
         "type": "github"
       },
       "original": {
@@ -574,11 +574,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1704420045,
-        "narHash": "sha256-C36QmoJd5tdQ5R9MC1jM7fBkZW9zBUqbUCsgwS6j4QU=",
+        "lastModified": 1704732714,
+        "narHash": "sha256-ABqK/HggMYA/jMUXgYyqVAcQ8QjeMyr1jcXfTpSHmps=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c1be43e8e837b8dbee2b3665a007e761680f0c3d",
+        "rev": "6723fa4e4f1a30d42a633bef5eb01caeb281adc3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4118d09e`](https://github.com/nix-community/emacs-overlay/commit/4118d09e3b6613425c4d48f4aa4b2ed944e5b801) | `` Updated melpa ``        |
| [`dbcecbaa`](https://github.com/nix-community/emacs-overlay/commit/dbcecbaa6f0e7b59851c395a23dad531efe4b17d) | `` Updated flake inputs `` |
| [`58305b28`](https://github.com/nix-community/emacs-overlay/commit/58305b28029922b981f333229500e9ff34896c72) | `` Updated melpa ``        |
| [`2e9e4ff1`](https://github.com/nix-community/emacs-overlay/commit/2e9e4ff10f436778688759f440917228373b2e82) | `` Updated elpa ``         |
| [`5126615a`](https://github.com/nix-community/emacs-overlay/commit/5126615a62f93c7b2311eb9180e420e460ed8515) | `` Updated melpa ``        |
| [`b5387363`](https://github.com/nix-community/emacs-overlay/commit/b538736308576dcf3665e784ecd83c6d249efcb0) | `` Updated elpa ``         |
| [`223007e4`](https://github.com/nix-community/emacs-overlay/commit/223007e4c62a86896fc662af5f9fd21a11cdb41b) | `` Updated melpa ``        |
| [`bb6e486a`](https://github.com/nix-community/emacs-overlay/commit/bb6e486a9fcb96868b15741ff4ee446cc731db43) | `` Updated melpa ``        |
| [`ab8a9be4`](https://github.com/nix-community/emacs-overlay/commit/ab8a9be49670ca7e8a208de44bfc848ee480560a) | `` Updated elpa ``         |
| [`e765064d`](https://github.com/nix-community/emacs-overlay/commit/e765064de63acb093a8ecb4483dd76860f4d9c70) | `` Updated melpa ``        |
| [`6ca69191`](https://github.com/nix-community/emacs-overlay/commit/6ca691917cbb7a260a58168544d757b915d901ec) | `` Updated elpa ``         |
| [`aa5b925d`](https://github.com/nix-community/emacs-overlay/commit/aa5b925d130417c34a20dc90e50c9812a70f7d9e) | `` Updated nongnu ``       |
| [`3a855a7a`](https://github.com/nix-community/emacs-overlay/commit/3a855a7a6f5f092ef81b45416c84f794b076f7ed) | `` Updated melpa ``        |
| [`0ed4fcf5`](https://github.com/nix-community/emacs-overlay/commit/0ed4fcf55a8d866cfc0f4dcfc37158634da8d251) | `` Updated flake inputs `` |
| [`2e23449b`](https://github.com/nix-community/emacs-overlay/commit/2e23449b445bbe200c9bd8e880662747ef99e4ae) | `` Updated melpa ``        |
| [`475d3b2d`](https://github.com/nix-community/emacs-overlay/commit/475d3b2df3e517d96b60bfa08bf7dfe226b51d5e) | `` Updated elpa ``         |
| [`8966ec83`](https://github.com/nix-community/emacs-overlay/commit/8966ec83cb59493c07a06c12d25f0d7439abfe5e) | `` Updated melpa ``        |
| [`581db622`](https://github.com/nix-community/emacs-overlay/commit/581db622349edd9c3b1110999fd942e1d3271728) | `` Updated elpa ``         |
| [`3bfd4b27`](https://github.com/nix-community/emacs-overlay/commit/3bfd4b274002a4dbbead2d61c93437c5458fed84) | `` Updated melpa ``        |
| [`f769dc27`](https://github.com/nix-community/emacs-overlay/commit/f769dc272f7645f0ec7c50ca79490cef15123e25) | `` Updated melpa ``        |
| [`fd1709ea`](https://github.com/nix-community/emacs-overlay/commit/fd1709ea259d3b2d02ef4f7b5f33886d93313305) | `` Updated elpa ``         |