### PR TITLE
chore(flake/chaotic): `d53c445e` -> `e567934d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1704799515,
-        "narHash": "sha256-VN3ylhfLh7QdMaBXsI9utky/EmW/GHGzoXSFwzV56KE=",
+        "lastModified": 1704817470,
+        "narHash": "sha256-ZuesjYg+9ipdRLmTBleYvuf/GSZaG4kZ+U/tw+lFz0U=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "d53c445e8e2a89ccdd31449aca530fa90b095d24",
+        "rev": "e567934dc30435bda4d97961423355108dac768d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                      |
| ----------------------------------------------------------------------------------------------- | ---------------------------- |
| [`e567934d`](https://github.com/chaotic-cx/nyx/commit/e567934dc30435bda4d97961423355108dac768d) | `` Bump 20240109-1 (#535) `` |