### PR TITLE
chore(flake/nur): `1ded0078` -> `0b34dc4f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -638,11 +638,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704584931,
-        "narHash": "sha256-Ct8RCvA6ha/nB4EWjyX1HpMkgeZYldi5EdbaswLa+tg=",
+        "lastModified": 1704889423,
+        "narHash": "sha256-J1hHDGFyatyQ3it9CXlNybC87BMy1VIttaNR1h7moqk=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "1ded0078d049439eb4285c3d12d7e7892331db05",
+        "rev": "0b34dc4f624fe005afd64627f4a68d39315d650c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                                  |
| -------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`0b34dc4f`](https://github.com/nix-community/NUR/commit/0b34dc4f624fe005afd64627f4a68d39315d650c) | `` automatic update ``                   |
| [`85ccecd5`](https://github.com/nix-community/NUR/commit/85ccecd524665a8ac2a043e9ced63f336476fe94) | `` automatic update ``                   |
| [`d2dc2f25`](https://github.com/nix-community/NUR/commit/d2dc2f25e0ea3ca5409555d4a96f78104b0be173) | `` automatic update ``                   |
| [`6586527c`](https://github.com/nix-community/NUR/commit/6586527c60f58a568fbb91744799dc7c7b6a2982) | `` repo: add NUR for Armaria ``          |
| [`f708a68d`](https://github.com/nix-community/NUR/commit/f708a68dbdce8c1c5688ee8097e47f5cef8e232f) | `` automatic update ``                   |
| [`77e2aeb7`](https://github.com/nix-community/NUR/commit/77e2aeb7e6b566022ff97196e3d75cc01700335e) | `` automatic update ``                   |
| [`cf86a7b9`](https://github.com/nix-community/NUR/commit/cf86a7b9811c2eb26643e92b288a3233f296f347) | `` automatic update ``                   |
| [`9a3b9100`](https://github.com/nix-community/NUR/commit/9a3b9100ab8635b46d1e23d6e369028f66e0e509) | `` automatic update ``                   |
| [`c00d975d`](https://github.com/nix-community/NUR/commit/c00d975d715413a2fa71fb6c65572bf79213a168) | `` automatic update ``                   |
| [`e37b1000`](https://github.com/nix-community/NUR/commit/e37b10005ab2c90fe5ef36a4baa83355247af670) | `` automatic update ``                   |
| [`eeec15e6`](https://github.com/nix-community/NUR/commit/eeec15e61232a9f7d9113035e1a579cb19753a4e) | `` automatic update ``                   |
| [`c72ded2d`](https://github.com/nix-community/NUR/commit/c72ded2df7d24d60c409165864508586b8e8124e) | `` automatic update ``                   |
| [`6f62ac08`](https://github.com/nix-community/NUR/commit/6f62ac0852be8e43cde80fe6e308602c1c0a1f02) | `` automatic update ``                   |
| [`8ddad3f5`](https://github.com/nix-community/NUR/commit/8ddad3f573977c23b1f52034d561dcff59527fe9) | `` automatic update ``                   |
| [`0594b0cb`](https://github.com/nix-community/NUR/commit/0594b0cbb2e8ae1a21cdf995b9c13ff68731284a) | `` automatic update ``                   |
| [`daced2d8`](https://github.com/nix-community/NUR/commit/daced2d8037d91ef3015e463e1ac8b9a7aff845c) | `` automatic update ``                   |
| [`100b3019`](https://github.com/nix-community/NUR/commit/100b3019a02cc3117074526da5c7badba8ffed88) | `` automatic update ``                   |
| [`91e7b02a`](https://github.com/nix-community/NUR/commit/91e7b02a3f520f354fccc85863793482b033c9bb) | `` automatic update ``                   |
| [`b0d642dc`](https://github.com/nix-community/NUR/commit/b0d642dc5a4d2fcf7ca7b5fe10121c77a8e2792d) | `` automatic update ``                   |
| [`e4215b4e`](https://github.com/nix-community/NUR/commit/e4215b4e4763588b931e1d7fdc6807272c63d89b) | `` automatic update ``                   |
| [`4657978e`](https://github.com/nix-community/NUR/commit/4657978e02a45a3f90dcba0f5a878d8d4ff439a5) | `` automatic update ``                   |
| [`2df7b09c`](https://github.com/nix-community/NUR/commit/2df7b09ccbd91a563c8b79e7be76ab5d92cd359b) | `` automatic update ``                   |
| [`1032f991`](https://github.com/nix-community/NUR/commit/1032f99123786d6a85cb853237126b971332fe10) | `` automatic update ``                   |
| [`dba52051`](https://github.com/nix-community/NUR/commit/dba520515e209f3be2fc388374c671635e1a478e) | `` automatic update ``                   |
| [`3db34f87`](https://github.com/nix-community/NUR/commit/3db34f87f0972308898521c41a8bbcc4745066ea) | `` automatic update ``                   |
| [`6fabda40`](https://github.com/nix-community/NUR/commit/6fabda405e6bae2a19226883283a2572a230e7b5) | `` automatic update ``                   |
| [`eec7fbb7`](https://github.com/nix-community/NUR/commit/eec7fbb7e90121aaeac4b5fcdcf7b316d2a29288) | `` automatic update ``                   |
| [`52300ec0`](https://github.com/nix-community/NUR/commit/52300ec091bdc513b81f49d01d044b2c21355520) | `` automatic update ``                   |
| [`6122342e`](https://github.com/nix-community/NUR/commit/6122342ef657331003089bc12cf6086329e2d836) | `` automatic update ``                   |
| [`06ce749f`](https://github.com/nix-community/NUR/commit/06ce749f20d91e8755da6592b5ed4a90d43af558) | `` automatic update ``                   |
| [`45203933`](https://github.com/nix-community/NUR/commit/4520393330946b968ba93cabffe5f753157458f6) | `` automatic update ``                   |
| [`a3103176`](https://github.com/nix-community/NUR/commit/a31031765ea6f8d070074f97f1598e804caea854) | `` automatic update ``                   |
| [`769bc4d6`](https://github.com/nix-community/NUR/commit/769bc4d645f2a638573d84ec6756ce7e48777a9b) | `` automatic update ``                   |
| [`91394f23`](https://github.com/nix-community/NUR/commit/91394f23b0a1b784fa8658116493c4513f1f4153) | `` automatic update ``                   |
| [`f5fa01d7`](https://github.com/nix-community/NUR/commit/f5fa01d70bfaa3de9a243ff1be9fa41f02f7ee4d) | `` automatic update ``                   |
| [`8a064707`](https://github.com/nix-community/NUR/commit/8a06470732be9f1757d5436a3256e793686648e4) | `` automatic update ``                   |
| [`e931d282`](https://github.com/nix-community/NUR/commit/e931d282cfc302d6a6808adf54c5db38b89e7923) | `` automatic update ``                   |
| [`accb175a`](https://github.com/nix-community/NUR/commit/accb175ad48179a7655f36dcd8bfd2187a74d8d7) | `` automatic update ``                   |
| [`fd4b13b7`](https://github.com/nix-community/NUR/commit/fd4b13b7f5e698cbabb8a822e9cf4a78b417ef81) | `` automatic update ``                   |
| [`07a92fab`](https://github.com/nix-community/NUR/commit/07a92fabc8d035feb484592d64b4ca7d83bf752c) | `` automatic update ``                   |
| [`7fd7f053`](https://github.com/nix-community/NUR/commit/7fd7f05372ca0a97691bbf45fbae0964bbadac4a) | `` automatic update ``                   |
| [`9ddd1391`](https://github.com/nix-community/NUR/commit/9ddd139133c202ab77be24be48a6303046729d37) | `` automatic update ``                   |
| [`f53bd4e7`](https://github.com/nix-community/NUR/commit/f53bd4e7be4a0511d74f4c9b977eda365af5cce2) | `` automatic update ``                   |
| [`066bff75`](https://github.com/nix-community/NUR/commit/066bff759bdfd8e8ce30720a493fd1fe7417e0e4) | `` automatic update ``                   |
| [`020ad3ca`](https://github.com/nix-community/NUR/commit/020ad3caef94ba76f2c091c9a1a91c2cd002a9f3) | `` automatic update ``                   |
| [`c99ef039`](https://github.com/nix-community/NUR/commit/c99ef039f11ee2582870f797ed6b4868e074b168) | `` automatic update ``                   |
| [`16f5a6ee`](https://github.com/nix-community/NUR/commit/16f5a6eec7c2eee6189cb23b3af99ccaa59b7508) | `` automatic update ``                   |
| [`8c0c3eda`](https://github.com/nix-community/NUR/commit/8c0c3eda98dc1c35547d1e1d211867b0d5f90251) | `` automatic update ``                   |
| [`30c0d9f4`](https://github.com/nix-community/NUR/commit/30c0d9f4c844bf2c4a8cfe136f873aad83767457) | `` automatic update ``                   |
| [`d4cb17a8`](https://github.com/nix-community/NUR/commit/d4cb17a8108aadd110001d5213a1c2f3526a802e) | `` automatic update ``                   |
| [`530bf879`](https://github.com/nix-community/NUR/commit/530bf87937d1893b306aa045f33d7d1e874ff740) | `` Move federicoschonborn to Codeberg `` |
| [`6b35830e`](https://github.com/nix-community/NUR/commit/6b35830e8b50fd1c6cf096f74a76cb9c5e0793cc) | `` automatic update ``                   |
| [`6559903e`](https://github.com/nix-community/NUR/commit/6559903e1813f675e5f72ca092d6f3afa727e1fc) | `` automatic update ``                   |
| [`3b2effe0`](https://github.com/nix-community/NUR/commit/3b2effe0553470589c7e40fc745ce1227564dfab) | `` automatic update ``                   |
| [`e9bf801b`](https://github.com/nix-community/NUR/commit/e9bf801b54e57f9297040831d819b8db9b2e3c7e) | `` automatic update ``                   |
| [`c8881da4`](https://github.com/nix-community/NUR/commit/c8881da4aaa833f4b60f94cb5a698136a322836c) | `` automatic update ``                   |
| [`0c2e0672`](https://github.com/nix-community/NUR/commit/0c2e0672caa72f21ff4a4ea5ff8141bce26d3f7b) | `` automatic update ``                   |
| [`9544da2c`](https://github.com/nix-community/NUR/commit/9544da2c270234b497a03556afc37c4db2e5263f) | `` automatic update ``                   |
| [`2f3b7670`](https://github.com/nix-community/NUR/commit/2f3b767054ff95e56899f22e090da623de063f3f) | `` automatic update ``                   |
| [`403ae298`](https://github.com/nix-community/NUR/commit/403ae2983f42507b0805cd18551c502906d03e02) | `` automatic update ``                   |
| [`c3c23490`](https://github.com/nix-community/NUR/commit/c3c2349004ff0e29688bb45b755262e80c5881b1) | `` automatic update ``                   |
| [`9053e394`](https://github.com/nix-community/NUR/commit/9053e394278a62488ed10e96f991bf35ff22873a) | `` automatic update ``                   |
| [`af336c86`](https://github.com/nix-community/NUR/commit/af336c86270077428a76457c8f5628d6a3dbf1fc) | `` automatic update ``                   |
| [`ce803108`](https://github.com/nix-community/NUR/commit/ce80310894b5c8c4db0ae20efd881d50dd266e79) | `` automatic update ``                   |
| [`bd8216c0`](https://github.com/nix-community/NUR/commit/bd8216c05cd8dce37217d682b9a1abee45d78933) | `` automatic update ``                   |
| [`c8e668be`](https://github.com/nix-community/NUR/commit/c8e668bef74e9071671b554a13284f6a094a7967) | `` automatic update ``                   |
| [`6febb52d`](https://github.com/nix-community/NUR/commit/6febb52db8402f4b9831577fef1dcc85fc1cd8ff) | `` automatic update ``                   |
| [`a381ca89`](https://github.com/nix-community/NUR/commit/a381ca898bb3e8007c252ce9873b285e3d53017e) | `` automatic update ``                   |
| [`b8fd5ed9`](https://github.com/nix-community/NUR/commit/b8fd5ed94c22502cf037679bd3b7f6f971c9a102) | `` automatic update ``                   |
| [`50c84843`](https://github.com/nix-community/NUR/commit/50c8484371ff46d77678e88c1f78cc5495d7190d) | `` automatic update ``                   |
| [`e72bc8a4`](https://github.com/nix-community/NUR/commit/e72bc8a4fff841c6a131fe40471e4ae401f31096) | `` automatic update ``                   |
| [`a390da03`](https://github.com/nix-community/NUR/commit/a390da03c4a4bc909e45fae408fc6debc3f6e0ae) | `` automatic update ``                   |
| [`6fe0213b`](https://github.com/nix-community/NUR/commit/6fe0213bf13f89a1a0bc725a5a4fe6f9ac72ae05) | `` automatic update ``                   |
| [`4d233ae5`](https://github.com/nix-community/NUR/commit/4d233ae5c39c37b263a1f94869b6113ec38f942c) | `` automatic update ``                   |
| [`a65b1e04`](https://github.com/nix-community/NUR/commit/a65b1e041038c22a20a8a7e91a24c4eb5bcb3440) | `` automatic update ``                   |
| [`7502a833`](https://github.com/nix-community/NUR/commit/7502a8334877f63564a30b9f5be89d7208a006d4) | `` automatic update ``                   |
| [`3a216c26`](https://github.com/nix-community/NUR/commit/3a216c262c910b70e23ee01a4479dcc40c58599b) | `` automatic update ``                   |
| [`a7689677`](https://github.com/nix-community/NUR/commit/a7689677ab9edb9e8c57fc0ee21fde26f0016748) | `` automatic update ``                   |
| [`76d881db`](https://github.com/nix-community/NUR/commit/76d881db6bb44e6625296d1cd9e3856bc0e85763) | `` automatic update ``                   |
| [`1f5d132b`](https://github.com/nix-community/NUR/commit/1f5d132b21378a7bec41677e156d5dd79a43ee75) | `` automatic update ``                   |
| [`b9ed90b3`](https://github.com/nix-community/NUR/commit/b9ed90b36bdba313e0f694fe5cc65848e3d43833) | `` automatic update ``                   |
| [`3b715e8e`](https://github.com/nix-community/NUR/commit/3b715e8ee9f65d6f13a7926be26e4d516a95ae16) | `` automatic update ``                   |
| [`369f7da6`](https://github.com/nix-community/NUR/commit/369f7da63ee6bb0e61d8e0a2622c3b78f9988121) | `` automatic update ``                   |
| [`07c169cf`](https://github.com/nix-community/NUR/commit/07c169cf2be7a709af9f14ba6709ab79034f8af7) | `` automatic update ``                   |