### PR TITLE
chore(flake/spicetify-nix): `67fdb8e2` -> `416f676d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -736,11 +736,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704514249,
-        "narHash": "sha256-dTd0bQOdmiL46+vxf1S7WCzNNXP0/2jYNDK7szhUBXk=",
+        "lastModified": 1704859834,
+        "narHash": "sha256-LtU7PaokK+IjuSWpoSaaLfjfjO31n7Zn+1ojRhXQEGA=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "67fdb8e2e66e48c2d853d04a907b4fde948e03ac",
+        "rev": "416f676dae5d98b2c24040f603e5429cfe9f5655",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`416f676d`](https://github.com/Gerg-L/spicetify-nix/commit/416f676dae5d98b2c24040f603e5429cfe9f5655) | `` CI update 2024-01-10 (#42) `` |
| [`c261dd07`](https://github.com/Gerg-L/spicetify-nix/commit/c261dd078d06bc8c93a48789f89bd1defb06062a) | `` CI update 2024-01-09 (#41) `` |
| [`22f3ea69`](https://github.com/Gerg-L/spicetify-nix/commit/22f3ea693a75b6a2de7f81e83d37a3946d38850d) | `` CI update 2024-01-08 (#40) `` |