### PR TITLE
chore(flake/hyprland): `7e033e48` -> `b240704b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1704475363,
-        "narHash": "sha256-isiBkAsjXIvb/6McVK42/iBbC4h+UL3JRkkLqTSPE48=",
+        "lastModified": 1704829327,
+        "narHash": "sha256-lUU1f6jaBMbbUI4CUHa1H0sf/yxbydK4JbxpGgUMGgk=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "7e033e48ace5406a9bc442f7d403f9ce3af193f3",
+        "rev": "b240704bee1d04eacc27654ea875cf6f15033c7c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                      |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
| [`b240704b`](https://github.com/hyprwm/Hyprland/commit/b240704bee1d04eacc27654ea875cf6f15033c7c) | `` renderer: allow rendering multiple fullscreen windows in third fs pass `` |
| [`71166ef4`](https://github.com/hyprwm/Hyprland/commit/71166ef40b5f7640fcddb1951d84f0f086e198d2) | `` subsurfaceTree: update surface tree protocol feedback on map ``           |
| [`252aaaec`](https://github.com/hyprwm/Hyprland/commit/252aaaecfa3b57eb07822177a8bf3b609aff7115) | `` input: add special_fallthrough ``                                         |
| [`f92a86af`](https://github.com/hyprwm/Hyprland/commit/f92a86af5367778a752ac2a0e9b32afc2e10fe2f) | `` renderer: ignore box offsets for fullscreen windows ``                    |
| [`2ba2c8ae`](https://github.com/hyprwm/Hyprland/commit/2ba2c8aeeee02d022882c825baa71243e1cb1e5d) | `` groupbar: improve gradient handling (#4390) ``                            |
| [`95500965`](https://github.com/hyprwm/Hyprland/commit/955009655d56fc35e75c71535fefc5a5c7b31071) | `` cmake: Propagate NO_XWAYLAND to wlroots building setup (#4385) ``         |
| [`d7d333d1`](https://github.com/hyprwm/Hyprland/commit/d7d333d162da2d3fc852b2c7a3faa2709440cefa) | `` opengl: apply box rot to projections ``                                   |
| [`f5b2fd2b`](https://github.com/hyprwm/Hyprland/commit/f5b2fd2bc36b35850502640d18281350e953b70d) | `` opengl: add renderdata.forceIntrospection ``                              |
| [`44ee9915`](https://github.com/hyprwm/Hyprland/commit/44ee9915e34910aac67ab60f1296eed8be8e7cea) | `` renderer: overhaul renderModifData ``                                     |
| [`9f2bde92`](https://github.com/hyprwm/Hyprland/commit/9f2bde925bde09b4820a2cef369e9ddd930a746b) | `` hyprpm: handle failed compilations gracefully ``                          |
| [`7904188d`](https://github.com/hyprwm/Hyprland/commit/7904188de9ca631436484cde733ef871f518d962) | `` input: allow focusSurface when locked if surfase is sessionLock ``        |
| [`666ee61c`](https://github.com/hyprwm/Hyprland/commit/666ee61c13e67e3a6943cd96157d9fb0967e596a) | `` input: leave special on focus (#4358) ``                                  |