### PR TITLE
chore(flake/nixpkgs): `0fa5a936` -> `7bb62b90`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1704497359,
-        "narHash": "sha256-i6LgDTXhOhCRIhy8Og4PYvqs1R559flBSOxAjRLZM0Y=",
+        "lastModified": 1704835834,
+        "narHash": "sha256-2XSWpm+0GBPHnCZmm/ell+yuPx3aP7zbitFFkFq7zlg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0fa5a936f203acc1b11ed20fe002320944a8363b",
+        "rev": "7bb62b90ef7f7e76603bcd52d7e10ddb6d589f15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`8ebf6518`](https://github.com/NixOS/nixpkgs/commit/8ebf6518d71b9ce886d65406263baa49d11cb663) | `` gh: 2.40.1 -> 2.41.0 ``                                                            |
| [`ae34cddb`](https://github.com/NixOS/nixpkgs/commit/ae34cddb51a9ed2c1c32b0fd7d5d6f8029509c4c) | `` linuxPackages.systemtap: 4.8 -> 5.0a, add nixos tests (#276840) ``                 |
| [`c64c04e8`](https://github.com/NixOS/nixpkgs/commit/c64c04e8bf17967aecce87a9389b062ae3ee749b) | `` pythonInterpreters.pypy39_prebuilt: fix `tests` eval (#278950) ``                  |
| [`a6671578`](https://github.com/NixOS/nixpkgs/commit/a6671578ffa6336bfd1238f1b2a00662b5ab1b34) | `` buildFHSEnv: bind dbus session bus into place when privateTmp enabled (#278917) `` |
| [`68790ace`](https://github.com/NixOS/nixpkgs/commit/68790acea8c65808bb753e77c1c810c537190b82) | `` bearer: 1.33.1 -> 1.34.0 ``                                                        |
| [`f98ec4f7`](https://github.com/NixOS/nixpkgs/commit/f98ec4f73c762223d62bee706726138cb6ea27cc) | `` treewide: update meta.description to fit the guidelines ``                         |
| [`116280fa`](https://github.com/NixOS/nixpkgs/commit/116280fa9f4b1795973e72a4288d8f9d86f60af0) | `` trufflehog: 3.63.7 -> 3.63.8 ``                                                    |
| [`f1166a35`](https://github.com/NixOS/nixpkgs/commit/f1166a3501bf2d6ae773b971e82a770878811cc6) | `` python311Packages.rlax: fix build ``                                               |
| [`30535095`](https://github.com/NixOS/nixpkgs/commit/30535095d529b6365cb0c72b7d052338c4e6d3c5) | `` python311Packages.plotnine: 0.12.3 -> 0.12.4 ``                                    |
| [`f3ca2ad4`](https://github.com/NixOS/nixpkgs/commit/f3ca2ad4f108f9aed08fae8a4c1c4480f66a43bb) | `` python311Packages.mizani: 0.10.0 -> 0.9.3 ``                                       |
| [`24d7e572`](https://github.com/NixOS/nixpkgs/commit/24d7e572bfefbbd96c4aab839b8bd129f9c771ff) | `` cp2k: 2023.2 -> 2024.1 ``                                                          |
| [`5f089dc8`](https://github.com/NixOS/nixpkgs/commit/5f089dc8db399b1095e8bc65446a1044ad6e8cd2) | `` copilot-cli: use `v${version}` for version ``                                      |
| [`08831e7e`](https://github.com/NixOS/nixpkgs/commit/08831e7e0ac145db69e89ec65739be0ee055e39e) | `` linux-router: 0.6.7 -> 0.7.1 ``                                                    |
| [`4b046dc5`](https://github.com/NixOS/nixpkgs/commit/4b046dc5a7afe651a5ac9152db0a10d80f605a3d) | `` python311Packages.rich-click: 1.7.2 -> 1.7.3 ``                                    |
| [`61ad5d8a`](https://github.com/NixOS/nixpkgs/commit/61ad5d8a7b4f151b5714e9b405e075dd3239e41b) | `` herwig: 7.2.3 -> 7.3.0 ``                                                          |
| [`4e92bad9`](https://github.com/NixOS/nixpkgs/commit/4e92bad9a81a79d839a7189155dfca348d8ded51) | `` fastjet-contrib: 1.052 -> 1.053 ``                                                 |
| [`fd098272`](https://github.com/NixOS/nixpkgs/commit/fd09827299827c1a7af0f677677ad3d3580c015e) | `` scribus: 1.6.0 -> 1.6.1 ``                                                         |
| [`e60846e9`](https://github.com/NixOS/nixpkgs/commit/e60846e9ff62db0228880659e231a47eec443c3f) | `` ferretdb: 1.17.0 -> 1.18.0 (#279837) ``                                            |
| [`ca477fa9`](https://github.com/NixOS/nixpkgs/commit/ca477fa90c5f26cb92925c76f9c000e0b4c228b6) | `` ibus-engines.typing-booster-unwrapped: 2.24.10 -> 2.24.11 ``                       |
| [`7d993cf0`](https://github.com/NixOS/nixpkgs/commit/7d993cf0b9305e98320b6614f51e829e0fe4d37e) | `` qemu: fix virtio-gpu display issues ``                                             |
| [`f60c3382`](https://github.com/NixOS/nixpkgs/commit/f60c338229425ce5d33d766a9146ba64bf8539ef) | `` mox: 0.0.8 -> 0.0.9 ``                                                             |
| [`d2c77480`](https://github.com/NixOS/nixpkgs/commit/d2c774803b275421037d17a96a60171c6b49cbd5) | `` kubeclarity: 2.23.0 -> 2.23.1 ``                                                   |
| [`e0773e3c`](https://github.com/NixOS/nixpkgs/commit/e0773e3caf2ebb425ffdbb55e77896d1da27df0f) | `` tbb: fix patch hash ``                                                             |
| [`d863f893`](https://github.com/NixOS/nixpkgs/commit/d863f893b64b8a83ed6c512c27efe5c75df449f2) | `` python311Packages.rapidgzip: 0.11.1 -> 0.12.1 ``                                   |
| [`930e7fe5`](https://github.com/NixOS/nixpkgs/commit/930e7fe5d198e688653204cfcff352e44bb64b32) | `` cp2k: fix CUDA support ``                                                          |
| [`3b6ef523`](https://github.com/NixOS/nixpkgs/commit/3b6ef5231a8b5cad9f047a38811cd97df493f244) | `` minder: 1.15.6 -> 1.16.0 ``                                                        |
| [`96068643`](https://github.com/NixOS/nixpkgs/commit/960686435108e922b8ce67af13fd03a75fef2bc8) | `` symfony-cli: 5.7.8 -> 5.8.0 ``                                                     |
| [`234f17ec`](https://github.com/NixOS/nixpkgs/commit/234f17ec4805daa498b2353212dc7d32bc514aa2) | `` jwx: 2.0.18 -> 2.0.19 ``                                                           |
| [`0fdcf9a6`](https://github.com/NixOS/nixpkgs/commit/0fdcf9a6a987dc4c311e0c3b5ec6c28b569e5479) | `` python311Packages.pygraphviz: 1.11 -> 1.12 ``                                      |
| [`0b3fbec3`](https://github.com/NixOS/nixpkgs/commit/0b3fbec39d1426331e57c0e289d20a6911218c12) | `` nixosTests.paperless: Convert paperless extraConfig to settings ``                 |
| [`b6ef6a50`](https://github.com/NixOS/nixpkgs/commit/b6ef6a50160eae4dfac1697708611f18f142d827) | `` telegraf: 1.29.1 -> 1.29.2 ``                                                      |
| [`32a919a3`](https://github.com/NixOS/nixpkgs/commit/32a919a3efb0a7f6e21bd2b07f6917d1313e2dfe) | `` linux_latest-libre: 19459 -> 19473 ``                                              |
| [`c3be7928`](https://github.com/NixOS/nixpkgs/commit/c3be792800ab8d92cc66f8f0a364cd0d30c73a7c) | `` linux_4_19: 4.19.303 -> 4.19.304 ``                                                |
| [`5eb2024d`](https://github.com/NixOS/nixpkgs/commit/5eb2024dfcd8f712dfcf653884ee6c69a114254e) | `` linux_5_4: 5.4.265 -> 5.4.266 ``                                                   |
| [`5df8c87c`](https://github.com/NixOS/nixpkgs/commit/5df8c87c209a4c101c784914f1a4ff5e7da72abf) | `` abcm2ps: add version test ``                                                       |
| [`89b2ff77`](https://github.com/NixOS/nixpkgs/commit/89b2ff773c47c912f3cff38d978f8cabab5c6144) | `` stern: 1.27.0 -> 1.28.0 ``                                                         |
| [`cc63c0ab`](https://github.com/NixOS/nixpkgs/commit/cc63c0ab1c23cb6bf039736477a9bea00ff23783) | `` renode-dts2repl: unstable-2024-01-06 -> unstable-2024-01-09 ``                     |
| [`38e5c168`](https://github.com/NixOS/nixpkgs/commit/38e5c16823c3cba37be3942e7267785608c38a8f) | `` python311Packages.pywemo: 1.3.1 -> 1.4.0 ``                                        |
| [`f8870b21`](https://github.com/NixOS/nixpkgs/commit/f8870b21f55e31248a04a1b52d838f9a5757e47e) | `` yutto: 2.0.0b31 -> 2.0.0b32 ``                                                     |
| [`27773929`](https://github.com/NixOS/nixpkgs/commit/277739296ad2c764c40a727108f0e0b4a894a05e) | `` enc: 1.1.2 -> 1.1.3 ``                                                             |
| [`c8a3490a`](https://github.com/NixOS/nixpkgs/commit/c8a3490aa128e1f925ae70a418bcee9198345252) | `` ctranslate2: 3.23.0 -> 3.24.0 ``                                                   |
| [`39cf6330`](https://github.com/NixOS/nixpkgs/commit/39cf6330bd18e161b797ca87072ea2e584a49083) | `` rclone: 1.65.0 -> 1.65.1 ``                                                        |
| [`00985e97`](https://github.com/NixOS/nixpkgs/commit/00985e97dd6f3d00cfaefe6be2322ae700f22888) | `` ncdc: 1.23.1 -> 1.24 ``                                                            |
| [`2e38d63c`](https://github.com/NixOS/nixpkgs/commit/2e38d63c37fb54be625f66fd9e206ee3f91200f8) | `` cbfmt: fix compilation with new clang ``                                           |
| [`8410d41f`](https://github.com/NixOS/nixpkgs/commit/8410d41f5d8e200cc60c0c1518fdd3019c5a8f2e) | `` comic-mandown: 1.6.1 -> 1.7.0 ``                                                   |
| [`94e7fbc6`](https://github.com/NixOS/nixpkgs/commit/94e7fbc6d32ece63839f2b6cd1dfe8aa426ecf49) | `` telegram-desktop: 4.14.3 -> 4.14.4 ``                                              |
| [`2ffff308`](https://github.com/NixOS/nixpkgs/commit/2ffff3083e0d8769831a15ec466e2367477cf3a7) | `` python310Packages.pyathena: 3.0.10 -> 3.1.0 ``                                     |
| [`d7af1d96`](https://github.com/NixOS/nixpkgs/commit/d7af1d962d2abc1d9e0768aeab891f3577a16905) | `` jasmin: make deterministic and clean up ``                                         |
| [`cf3a576e`](https://github.com/NixOS/nixpkgs/commit/cf3a576e495cf3e41ef4d0d3b5a1c0989d4823c7) | `` python311Packages.py-serializable: refactor ``                                     |
| [`ee460d30`](https://github.com/NixOS/nixpkgs/commit/ee460d300573b9e92e1aec2d11501c172ea30738) | `` matrix-sliding-sync: 0.99.13 -> 0.99.14 ``                                         |
| [`a51bef69`](https://github.com/NixOS/nixpkgs/commit/a51bef69e4c92cbaa47cda21a53e833604dfd13b) | `` python311Packages.connect-box: refactor ``                                         |
| [`3a93306b`](https://github.com/NixOS/nixpkgs/commit/3a93306b1602add42d1147ad03dde44776dc8f33) | `` python311Packages.connect-box: 0.3.0 -> 0.3.1 ``                                   |
| [`edb804f8`](https://github.com/NixOS/nixpkgs/commit/edb804f869f4af2fb19a453404602ea0852a82d7) | `` abcm2ps: 8.14.14 -> 8.14.15 ``                                                     |
| [`23300732`](https://github.com/NixOS/nixpkgs/commit/233007328b761c1084cdbab3cb61d0c5e4919d16) | `` python311Packages.evohome-async: 0.4.16 -> 0.4.17 ``                               |
| [`6165ccef`](https://github.com/NixOS/nixpkgs/commit/6165ccef7a5ca4ce11d33cd1b4075ef0d58610d2) | `` python311Packages.environs: 10.0.0 -> 10.1.0 ``                                    |
| [`ab0cacde`](https://github.com/NixOS/nixpkgs/commit/ab0cacdea07c735e361487c36d8eeadc7a69e093) | `` python311Packages.botocore-stubs: 1.34.14 -> 1.34.15 ``                            |
| [`7dd9a0fe`](https://github.com/NixOS/nixpkgs/commit/7dd9a0febe2a5f1127f240be1a88a2c77615b604) | `` python311Packages.boto3-stubs: 1.34.14 -> 1.34.15 ``                               |
| [`759d213f`](https://github.com/NixOS/nixpkgs/commit/759d213f898d943d0cdd401c506e325161eee056) | `` python310Packages.py-serializable: 0.16.0 -> 0.17.1 ``                             |
| [`52ac5367`](https://github.com/NixOS/nixpkgs/commit/52ac53673ee4ddbe34fdb1eb13a118a9ba82f190) | `` python311Packages.flow-record: refactor ``                                         |
| [`43b6a271`](https://github.com/NixOS/nixpkgs/commit/43b6a2713d693094f3d9666a39d224061345ae89) | `` python311Packages.mkdocstrings-python: refactor ``                                 |
| [`ac27bb0a`](https://github.com/NixOS/nixpkgs/commit/ac27bb0a73c38ffe0af60ba0032928cbb86f486c) | `` portfolio: 0.67.0 -> 0.67.1 ``                                                     |
| [`9a524caf`](https://github.com/NixOS/nixpkgs/commit/9a524cafe130cce465519cce10c3c095c53af607) | `` python310Packages.pex: 2.1.153 -> 2.1.156 ``                                       |
| [`de56cb2c`](https://github.com/NixOS/nixpkgs/commit/de56cb2c816363792c8dd6429c5dd2de27329a12) | `` python310Packages.pdb2pqr: 3.6.1 -> 3.6.2 ``                                       |
| [`f41ba74b`](https://github.com/NixOS/nixpkgs/commit/f41ba74b961ca985a8235f47e35da1649f796137) | `` python310Packages.pdf2image: 1.16.3 -> 1.17.0 ``                                   |
| [`3db4e9d3`](https://github.com/NixOS/nixpkgs/commit/3db4e9d3fa6a709e1abc4184cfb934ba6412c625) | `` python310Packages.packageurl-python: 0.13.1 -> 0.13.4 ``                           |
| [`d96ecde8`](https://github.com/NixOS/nixpkgs/commit/d96ecde86fff24714303dc49186f8e27464914eb) | `` python310Packages.opencensus-ext-azure: 1.1.12 -> 1.1.13 ``                        |
| [`4044f8ad`](https://github.com/NixOS/nixpkgs/commit/4044f8adf222de589c185dfdcdacfb59db8a0f61) | `` python310Packages.opencensus: 0.11.3 -> 0.11.4 ``                                  |
| [`a317b9cf`](https://github.com/NixOS/nixpkgs/commit/a317b9cf28d7b9ee5110c6ba201866ab96924feb) | `` python310Packages.open-clip-torch: 2.23.0 -> 2.24.0 ``                             |
| [`3a87e742`](https://github.com/NixOS/nixpkgs/commit/3a87e7420450aca8717cb51fc78ae5bcf7ad2a98) | `` python310Packages.oelint-parser: 2.13.3 -> 2.13.11 ``                              |
| [`dda9955c`](https://github.com/NixOS/nixpkgs/commit/dda9955c59e94cbe23181f5c4d59d2f8fd06b3d9) | `` python310Packages.mkdocstrings-python: 1.7.5 -> 1.8.0 ``                           |
| [`5369d844`](https://github.com/NixOS/nixpkgs/commit/5369d84405a1bbd74393d1634ef8f412f2a38d26) | `` weasis: init at 4.2.1 ``                                                           |
| [`3a3c015c`](https://github.com/NixOS/nixpkgs/commit/3a3c015cd11d85e9f6903b4ea7d4cd31cd637fdc) | `` python310Packages.laspy: 2.5.2 -> 2.5.3 ``                                         |
| [`3b178d68`](https://github.com/NixOS/nixpkgs/commit/3b178d68eda5c899a6d6c51e9cc7f5a2688d45a5) | `` python310Packages.kaggle: 1.5.16 -> 1.6.1 ``                                       |
| [`322bc480`](https://github.com/NixOS/nixpkgs/commit/322bc48009d848b664f955943e8794308d877da0) | `` cnquery: 9.12.3 -> 9.13.0 ``                                                       |
| [`61a31a9e`](https://github.com/NixOS/nixpkgs/commit/61a31a9e7f8c484142560147c9389dce75848544) | `` python310Packages.huawei-lte-api: 1.7.3 -> 1.8.1 ``                                |
| [`63c4175c`](https://github.com/NixOS/nixpkgs/commit/63c4175cb0fb03cab301d7ba058e4937bec464e2) | `` ocamlPackages.torch: use libtorch-bin 2.0 ``                                       |
| [`492e3331`](https://github.com/NixOS/nixpkgs/commit/492e3331eb57e4eb13cf91d7d272f94ffc07dd49) | `` flyctl: 0.1.136 -> 0.1.137 ``                                                      |
| [`9a3f06cf`](https://github.com/NixOS/nixpkgs/commit/9a3f06cf957a72e9999fa0bd91b119be2dc045e9) | `` python310Packages.hepunits: 2.3.2 -> 2.3.3 ``                                      |
| [`82eaf5d6`](https://github.com/NixOS/nixpkgs/commit/82eaf5d690655ae800b0be93ce4baf771fa8d0c9) | `` python310Packages.google-cloud-org-policy: 1.9.0 -> 1.10.0 ``                      |
| [`f04e24b6`](https://github.com/NixOS/nixpkgs/commit/f04e24b61369b377095c6bad2fb2511c237af19f) | `` megapixels: Drop OPNA2608 from maintainers ``                                      |
| [`b4db0582`](https://github.com/NixOS/nixpkgs/commit/b4db0582a1d6c964b30c223c0424de8463801ce5) | `` qemu: add rutabaga support ``                                                      |
| [`28257606`](https://github.com/NixOS/nixpkgs/commit/28257606653cef6913d4ccd76ead276f050507e1) | `` rutabaga_gfx: init at 0.1.2 ``                                                     |
| [`e31df9c9`](https://github.com/NixOS/nixpkgs/commit/e31df9c9d7fce4b15c806d88e108bf7c3ccbd481) | `` gfxstream: init at 0.1.2 ``                                                        |
| [`046df5a4`](https://github.com/NixOS/nixpkgs/commit/046df5a4ca990e13a924c86731430bee3ce3f582) | `` python311Packages.pytedee-async: init at 0.2.10 ``                                 |
| [`be6412af`](https://github.com/NixOS/nixpkgs/commit/be6412af4117ce73e8de3d9b063fdc16dfb6a027) | `` python311Packages.reolink-aio: 0.8.5 -> 0.8.6 ``                                   |
| [`6b73be0c`](https://github.com/NixOS/nixpkgs/commit/6b73be0ca5c37221ab1ce22f087753dbc0108a45) | `` nixos/no-x-libs: add gjs ``                                                        |
| [`f58f4734`](https://github.com/NixOS/nixpkgs/commit/f58f4734b68da24438b659660cf961a5d40f668d) | `` responder: 3.1.3.0 -> 3.1.4.0 ``                                                   |
| [`945a05f5`](https://github.com/NixOS/nixpkgs/commit/945a05f5ab1030ec5519113d6c68af56c60aca15) | `` gjs: add option to avoid installing tests to avoid dependency on gtk3 ``           |
| [`252f1645`](https://github.com/NixOS/nixpkgs/commit/252f1645839a945119fce2205090407b55be2c9f) | `` python311Packages.djangorestframework-stubs: 3.14.2 -> 3.14.5 ``                   |
| [`5e9c7784`](https://github.com/NixOS/nixpkgs/commit/5e9c7784fd88776ccccce87c6c38d67e34b25605) | `` python310Packages.ftputil: 5.0.4 -> 5.1.0 ``                                       |
| [`e0cdc47c`](https://github.com/NixOS/nixpkgs/commit/e0cdc47c59209494f50856779c3d7d237aa1eaf6) | `` python311Packages.dvc-ssh: 2.2.22 -> 3.0.0 ``                                      |
| [`89cdf713`](https://github.com/NixOS/nixpkgs/commit/89cdf71325eecb07f183269c490c2a761c885135) | `` mdbook-i18n-helpers: 0.2.4 -> 0.3.0 ``                                             |
| [`e56a4298`](https://github.com/NixOS/nixpkgs/commit/e56a4298366d4007a85c01608ad8fe2e7bebf8cd) | `` python311Packages.django-stubs-ext: refactor ``                                    |
| [`c63cf0c8`](https://github.com/NixOS/nixpkgs/commit/c63cf0c8b0a7b7be09c1f7a31c7fc35481292b00) | `` python311Packages.django-stubs-ext: 4.2.5 -> 4.2.7 ``                              |
| [`8bc72925`](https://github.com/NixOS/nixpkgs/commit/8bc72925aa9079e6bf8ec07715417b64603b2a5f) | `` python311Packages.types-markdown: init at 3.5.0.20240106 ``                        |
| [`619acc81`](https://github.com/NixOS/nixpkgs/commit/619acc8193eda810261c56f7546c47e5e5758088) | `` python310Packages.flow-record: 3.13 -> 3.14 ``                                     |
| [`78a929ca`](https://github.com/NixOS/nixpkgs/commit/78a929caf9cad5a6ba1961109dd5d0bd766abfa6) | `` python311Packages.django-stubs: 4.2.6 -> 4.2.7 ``                                  |
| [`7734045d`](https://github.com/NixOS/nixpkgs/commit/7734045d162843dbcee87ec8fb33d1165c941d86) | `` python311Packages.django-stubs: add optional-dependencies ``                       |
| [`1e99cf2c`](https://github.com/NixOS/nixpkgs/commit/1e99cf2c07606c7fc874227450f2248b99846177) | `` python311Packages.pymeteoclimatic: refactor ``                                     |
| [`6ed7e90a`](https://github.com/NixOS/nixpkgs/commit/6ed7e90a0616b57a22c88cdd2c4137db2b96be46) | `` python311Packages.pymeteoclimatic: 0.0.6 -> 0.1.0 ``                               |
| [`28909b35`](https://github.com/NixOS/nixpkgs/commit/28909b356fb26dec854972340fa7ea0086daf75b) | `` qovery-cli: 0.79.2 -> 0.80.0 ``                                                    |
| [`422122bb`](https://github.com/NixOS/nixpkgs/commit/422122bbc7eb8e02c7aca2a5bfb4cc540b9b810a) | `` python311Packages.pycfmodel: 0.21.1 -> 0.21.2 ``                                   |
| [`a3473425`](https://github.com/NixOS/nixpkgs/commit/a3473425e552397895230291b532e18cbf6edbf3) | `` pip-audit: 2.6.2 -> 2.6.3 ``                                                       |
| [`e2833883`](https://github.com/NixOS/nixpkgs/commit/e2833883c511eb7220b97cc9668cc8d20fb45f03) | `` ipinfo: 3.2.0 -> 3.3.0 ``                                                          |
| [`d79d3de8`](https://github.com/NixOS/nixpkgs/commit/d79d3de85f3f9348dce369460a5a08f461eb9a86) | `` cudaPackages.cuda-library-samples: Only enable on Linux, fix channel ``            |
| [`a9544429`](https://github.com/NixOS/nixpkgs/commit/a9544429263d81a3a45270559bb84c568cd5aa9b) | `` dayon: make deterministic and clean up ``                                          |
| [`402e9460`](https://github.com/NixOS/nixpkgs/commit/402e9460315019175b9b64dd7f4137971671b918) | `` ddns-go: 5.7.0 -> 5.7.1 ``                                                         |
| [`bae96abd`](https://github.com/NixOS/nixpkgs/commit/bae96abd0516a26b9eab0fe3648c5ff5d41c63a8) | `` python311Packages.pyzabbix: init at 1.3.1 ``                                       |