### PR TITLE
chore(flake/emacs-overlay): `4118d09e` -> `53b4803d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1704876648,
-        "narHash": "sha256-9IQv2/opC02AsYF2QjyW7/UmS1fTfdHIAW86I1Zvv88=",
+        "lastModified": 1705164639,
+        "narHash": "sha256-CYXxAkMSacPK+inxWKrcdL/FdJODa8WQVk8GnqkmS8s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4118d09e3b6613425c4d48f4aa4b2ed944e5b801",
+        "rev": "53b4803d6cb623b5b4e3540af99e1b356bbc7f30",
         "type": "github"
       },
       "original": {
@@ -574,11 +574,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1704732714,
-        "narHash": "sha256-ABqK/HggMYA/jMUXgYyqVAcQ8QjeMyr1jcXfTpSHmps=",
+        "lastModified": 1704874635,
+        "narHash": "sha256-YWuCrtsty5vVZvu+7BchAxmcYzTMfolSPP5io8+WYCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6723fa4e4f1a30d42a633bef5eb01caeb281adc3",
+        "rev": "3dc440faeee9e889fe2d1b4d25ad0f430d449356",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`53b4803d`](https://github.com/nix-community/emacs-overlay/commit/53b4803d6cb623b5b4e3540af99e1b356bbc7f30) | `` Updated melpa ``        |
| [`c11eac23`](https://github.com/nix-community/emacs-overlay/commit/c11eac23245ed3571df6eef40831422a3d49ad18) | `` Updated elpa ``         |
| [`8363635c`](https://github.com/nix-community/emacs-overlay/commit/8363635cc3d70d8869e3ead707eb01e03a203f78) | `` Updated melpa ``        |
| [`9e423719`](https://github.com/nix-community/emacs-overlay/commit/9e423719e0c85a4624813489080636f4d696fa3e) | `` Updated melpa ``        |
| [`3ad4e810`](https://github.com/nix-community/emacs-overlay/commit/3ad4e8104948385481e9d1cc37405818f46d9ab4) | `` Updated elpa ``         |
| [`f7a9453d`](https://github.com/nix-community/emacs-overlay/commit/f7a9453dc2173a9cf64fd59ae7a11d9c0aa8ac8b) | `` Updated nongnu ``       |
| [`7931d882`](https://github.com/nix-community/emacs-overlay/commit/7931d882cdb5ce330571f583e989117fdfa808f1) | `` Updated melpa ``        |
| [`9a5b785e`](https://github.com/nix-community/emacs-overlay/commit/9a5b785e55d35fcbbb50c5098cc78917c1a924d4) | `` Updated elpa ``         |
| [`fcd7c360`](https://github.com/nix-community/emacs-overlay/commit/fcd7c360c3f73ec91da70155df6d9a413e4bd128) | `` Updated melpa ``        |
| [`905528b5`](https://github.com/nix-community/emacs-overlay/commit/905528b5c9c5eac4c82c86493aec69f85ea1c050) | `` Updated melpa ``        |
| [`c19de550`](https://github.com/nix-community/emacs-overlay/commit/c19de550027db6d9d1ba85b63b4cb78fdf73ee00) | `` Updated elpa ``         |
| [`b1042ceb`](https://github.com/nix-community/emacs-overlay/commit/b1042cebf0e7cf4a8a805c590f67dcd0c398c0fd) | `` Updated nongnu ``       |
| [`4b0b67c3`](https://github.com/nix-community/emacs-overlay/commit/4b0b67c374297a8dd880fbfc13eddf495197b308) | `` Updated melpa ``        |
| [`aa348140`](https://github.com/nix-community/emacs-overlay/commit/aa3481405e2bcb7f5c7c20c72198fcf0f96057a6) | `` Updated elpa ``         |
| [`2dc2fe68`](https://github.com/nix-community/emacs-overlay/commit/2dc2fe681e05c9bf79755ef605c6a100a510361f) | `` Updated melpa ``        |
| [`9b35a20a`](https://github.com/nix-community/emacs-overlay/commit/9b35a20ab70da97fd1266ce816dd4104f89c88b9) | `` Updated melpa ``        |
| [`4f711094`](https://github.com/nix-community/emacs-overlay/commit/4f7110943cbceeda940b4253e3e22373725dd114) | `` Updated elpa ``         |
| [`6f6f6689`](https://github.com/nix-community/emacs-overlay/commit/6f6f66894593df01cc015a74087a27998792c293) | `` Updated flake inputs `` |
| [`e5d3e66b`](https://github.com/nix-community/emacs-overlay/commit/e5d3e66bb146b77a9c978533dfb6028b9248f2fa) | `` Updated melpa ``        |
| [`15237ecc`](https://github.com/nix-community/emacs-overlay/commit/15237ecc6c37985dcb55574d6df249d333f0dff7) | `` Updated elpa ``         |
| [`96b3adef`](https://github.com/nix-community/emacs-overlay/commit/96b3adefc7df872692b6263a50431662e4426cd6) | `` Updated flake inputs `` |