### PR TITLE
chore(flake/home-manager): `93e804e7` -> `f2942f33`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -287,11 +287,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704980804,
-        "narHash": "sha256-lPNNKdPqIYcjhhYIVwlajNt/HqVWbMOoSdNnwCvOP04=",
+        "lastModified": 1705169127,
+        "narHash": "sha256-j9OEtNxOIPWZWjbECVMkI1TO17SzlpHMm0LnVWKOR/g=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "93e804e7f8a1eb88bde6117cd5046501e66aa4bd",
+        "rev": "f2942f3385f1b35cc8a1abb03a45e29c9cb4d3c8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                            |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`f2942f33`](https://github.com/nix-community/home-manager/commit/f2942f3385f1b35cc8a1abb03a45e29c9cb4d3c8) | `` Remove some formatting exceptions ``            |
| [`6217b735`](https://github.com/nix-community/home-manager/commit/6217b735988ef28fa07d9c4be92d06d5573defa3) | `` listenbrainz-mpd: use sdnotify when possible `` |
| [`0912d26b`](https://github.com/nix-community/home-manager/commit/0912d26b30332ae6a90e1b321ff88e80492127dd) | `` gh: only run migration when required ``         |
| [`7403ed49`](https://github.com/nix-community/home-manager/commit/7403ed49801e1a30ed0ffdec5b60c17f0cbf7bd5) | `` home-manager: internalize uninstall ``          |