### PR TITLE
chore(flake/chaotic): `e567934d` -> `fe8c91cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1704817470,
-        "narHash": "sha256-ZuesjYg+9ipdRLmTBleYvuf/GSZaG4kZ+U/tw+lFz0U=",
+        "lastModified": 1705153825,
+        "narHash": "sha256-OMXau1nQhtPxg4GlhgAPPd1RKaHss9QwePasgjhJP0A=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "e567934dc30435bda4d97961423355108dac768d",
+        "rev": "fe8c91cf0a6dd2ecafee39e838979bdefdc36612",
         "type": "github"
       },
       "original": {
@@ -529,12 +529,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704538339,
-        "narHash": "sha256-1734d3mQuux9ySvwf6axRWZRBhtcZA9Q8eftD6EZg6U=",
-        "rev": "46ae0210ce163b3cba6c7da08840c1d63de9c701",
-        "revCount": 567011,
+        "lastModified": 1704722960,
+        "narHash": "sha256-mKGJ3sPsT6//s+Knglai5YflJUF2DGj7Ai6Ynopz0kI=",
+        "rev": "317484b1ead87b9c1b8ac5261a8d2dd748a0492d",
+        "revCount": 567746,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.567011%2Brev-46ae0210ce163b3cba6c7da08840c1d63de9c701/018ce71d-40cb-7594-bc00-f31ffedcdfa4/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.567746%2Brev-317484b1ead87b9c1b8ac5261a8d2dd748a0492d/018cf30b-2ac5-7f74-8197-15b6091e04ca/source.tar.gz"
       },
       "original": {
         "type": "tarball",


### PR DESCRIPTION
| Commit                                                                                          | Message                                                  |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`fe8c91cf`](https://github.com/chaotic-cx/nyx/commit/fe8c91cf0a6dd2ecafee39e838979bdefdc36612) | `` Bump 20240113-1 (#542) ``                             |
| [`a4e9fa07`](https://github.com/chaotic-cx/nyx/commit/a4e9fa0795880c3330d9f86cab466a7402d6d4f5) | `` libdrm_git: match drvName with the original (#541) `` |
| [`f2953305`](https://github.com/chaotic-cx/nyx/commit/f2953305e584b99e322ca9d0a4e53a76ce411e31) | `` Bump 20240112-1 (#540) ``                             |
| [`6527f419`](https://github.com/chaotic-cx/nyx/commit/6527f419a06825ba94d1ffdf9d7ab46fa2756dfb) | `` sway_git: update libdrm ``                            |
| [`3e0b2e6e`](https://github.com/chaotic-cx/nyx/commit/3e0b2e6eed37fadacb2ff67f68ea114a570ec27c) | `` Bump 20240111-1 (#539) ``                             |
| [`2925308e`](https://github.com/chaotic-cx/nyx/commit/2925308ed46c247527d2d38678db0da566c91f62) | `` mesa_git: revert MR 24386 (again) (#538) ``           |
| [`48e7b8fd`](https://github.com/chaotic-cx/nyx/commit/48e7b8fd6caed5afdabd4c032f1c2dacedf16392) | `` sdl_git: init at 20240109194312-6407e0c (#537) ``     |
| [`54a2656c`](https://github.com/chaotic-cx/nyx/commit/54a2656c612ee4dcf06f23dbcc02ac81619a96e1) | `` Bump 20240110-1 (#536) ``                             |
| [`a1b38193`](https://github.com/chaotic-cx/nyx/commit/a1b38193e886cf5ee1bf625dd5faac43fb4041d8) | `` nixpkgs: bump to 20240110 ``                          |