### PR TITLE
chore(flake/nur): `0b34dc4f` -> `f07c5379`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -638,11 +638,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1704889423,
-        "narHash": "sha256-J1hHDGFyatyQ3it9CXlNybC87BMy1VIttaNR1h7moqk=",
+        "lastModified": 1705192180,
+        "narHash": "sha256-dh25+EexMS/uN3zmS6SElJBkN1Z7nsSBK/iMpsUUWT4=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "0b34dc4f624fe005afd64627f4a68d39315d650c",
+        "rev": "f07c53795b11a0fc780d77ae139c063601564b00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                       |
| -------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`f07c5379`](https://github.com/nix-community/NUR/commit/f07c53795b11a0fc780d77ae139c063601564b00) | `` automatic update ``        |
| [`9f8b664c`](https://github.com/nix-community/NUR/commit/9f8b664cca8d229db1d3958fcae35be23752ea52) | `` automatic update ``        |
| [`b1010ee8`](https://github.com/nix-community/NUR/commit/b1010ee867feb9da82e005fa4c991d933c6bf918) | `` automatic update ``        |
| [`265ac8e4`](https://github.com/nix-community/NUR/commit/265ac8e4270ed0b5292b528a7fc6fc5b36e3c729) | `` automatic update ``        |
| [`e088ec55`](https://github.com/nix-community/NUR/commit/e088ec5514d3b98444a75c40139055589c0a23ac) | `` add brpaz repository ``    |
| [`4cfda477`](https://github.com/nix-community/NUR/commit/4cfda477728a6c1ad73237c4554701a6ee4efe6c) | `` automatic update ``        |
| [`db2db947`](https://github.com/nix-community/NUR/commit/db2db947af6421fade9fd94c20986e1c95e0b41f) | `` automatic update ``        |
| [`81f76b7a`](https://github.com/nix-community/NUR/commit/81f76b7a734327e184886537c0138a5f7259e604) | `` automatic update ``        |
| [`fa51fa6e`](https://github.com/nix-community/NUR/commit/fa51fa6e5130fd056673355eadd724361871ba74) | `` automatic update ``        |
| [`1644e8f5`](https://github.com/nix-community/NUR/commit/1644e8f5bd74b42409fcfe272dfda1d9dd0b1ed1) | `` automatic update ``        |
| [`0de635d9`](https://github.com/nix-community/NUR/commit/0de635d9bc8833a431638f59897abae066ed7719) | `` automatic update ``        |
| [`ed4cff73`](https://github.com/nix-community/NUR/commit/ed4cff7351c0f7f4ed4273da70c5219d9ef055d4) | `` automatic update ``        |
| [`75cca9f7`](https://github.com/nix-community/NUR/commit/75cca9f7b3298ded7044811f5929399f819d9529) | `` automatic update ``        |
| [`d5c04f64`](https://github.com/nix-community/NUR/commit/d5c04f64c74370d924fc9a838896f50b8b2c27be) | `` automatic update ``        |
| [`189f1eb5`](https://github.com/nix-community/NUR/commit/189f1eb56201c5c252d5c762b6eba690fdc6f0c7) | `` automatic update ``        |
| [`0880c3c0`](https://github.com/nix-community/NUR/commit/0880c3c03c2125b267ae20bbf72eb5bebc5a8470) | `` automatic update ``        |
| [`8252c4a2`](https://github.com/nix-community/NUR/commit/8252c4a2edad482d170c4006a680d4e441f90ff6) | `` automatic update ``        |
| [`36535e10`](https://github.com/nix-community/NUR/commit/36535e104e2aa0735d7e8e054a7a49ceec073793) | `` automatic update ``        |
| [`eb257a2f`](https://github.com/nix-community/NUR/commit/eb257a2f64d88dd14eaaf112822160496f6a916f) | `` automatic update ``        |
| [`6b80120e`](https://github.com/nix-community/NUR/commit/6b80120ef1e2758e2b2b6650cb3c54925e46e207) | `` automatic update ``        |
| [`3f38ea75`](https://github.com/nix-community/NUR/commit/3f38ea75d4cd1ce66562e61284e9bd45384d6d59) | `` automatic update ``        |
| [`dce2f751`](https://github.com/nix-community/NUR/commit/dce2f751fb6446b345bcdbee2a89663be4ee89e3) | `` add skiletro repository `` |
| [`025c03cd`](https://github.com/nix-community/NUR/commit/025c03cde3c672df87e508b3844f3992562e053c) | `` automatic update ``        |
| [`39082696`](https://github.com/nix-community/NUR/commit/390826968d682186e2672e6834b899463f10e9d5) | `` automatic update ``        |
| [`3254e29d`](https://github.com/nix-community/NUR/commit/3254e29ddcd7bb07b85630144200c1aaad73de33) | `` automatic update ``        |
| [`6333131e`](https://github.com/nix-community/NUR/commit/6333131eb9d9e67d95fc49c3b566c2354cbecff9) | `` automatic update ``        |
| [`b98d0401`](https://github.com/nix-community/NUR/commit/b98d04014dee60c87f31df0dc6bf62733dc6ee24) | `` automatic update ``        |
| [`11db5fb0`](https://github.com/nix-community/NUR/commit/11db5fb0923cc0fccd62b7372abef632cde18388) | `` automatic update ``        |
| [`075357ea`](https://github.com/nix-community/NUR/commit/075357ead2dbaf5c64120371f6a1e57d1ee23a02) | `` automatic update ``        |
| [`e20fb44b`](https://github.com/nix-community/NUR/commit/e20fb44b07c45c857fbed064fcd79207b1173e01) | `` automatic update ``        |
| [`5ac37bdd`](https://github.com/nix-community/NUR/commit/5ac37bddfaaf98a31cfcb8aa7ebc8cd241d04f4a) | `` automatic update ``        |
| [`e6e04e2a`](https://github.com/nix-community/NUR/commit/e6e04e2a461785b7f3fb468cc07b7d60d37febba) | `` automatic update ``        |
| [`973c8620`](https://github.com/nix-community/NUR/commit/973c862015c5d83fbc757451ab4beb2854c24599) | `` automatic update ``        |
| [`682ca9a3`](https://github.com/nix-community/NUR/commit/682ca9a3a48de850abc5877fd2cbcfff084d92bc) | `` automatic update ``        |
| [`0bfbbaa7`](https://github.com/nix-community/NUR/commit/0bfbbaa7dff7f8c17a376b1552df3d532863a1fb) | `` automatic update ``        |
| [`eda7aba6`](https://github.com/nix-community/NUR/commit/eda7aba60710b9eb60822a4abe6939664031920e) | `` automatic update ``        |
| [`d15592eb`](https://github.com/nix-community/NUR/commit/d15592ebd519a9d603f76cfae32acbc043bd7147) | `` automatic update ``        |
| [`a8597f56`](https://github.com/nix-community/NUR/commit/a8597f56b71b3d1c92c1989d6e0e27ad9121719a) | `` automatic update ``        |
| [`83a28718`](https://github.com/nix-community/NUR/commit/83a28718371d3741673cbc587e2e2cb770ff4226) | `` automatic update ``        |
| [`159f2e6f`](https://github.com/nix-community/NUR/commit/159f2e6f40cbf70be977dee501f5b4df641908d9) | `` automatic update ``        |
| [`01a98cf0`](https://github.com/nix-community/NUR/commit/01a98cf07b402c69ba640b31a7f2b44ff27c3161) | `` automatic update ``        |
| [`29adde8a`](https://github.com/nix-community/NUR/commit/29adde8a4441bda17febf534d76218c0584b3618) | `` automatic update ``        |
| [`78c2da2d`](https://github.com/nix-community/NUR/commit/78c2da2d2cfe95bf6dacaf091cc018ed7bf9b3c8) | `` automatic update ``        |
| [`0b832792`](https://github.com/nix-community/NUR/commit/0b83279250ed154a1bb92978bbce7a17296a5355) | `` automatic update ``        |
| [`2d550df1`](https://github.com/nix-community/NUR/commit/2d550df1e76d9c1b095feb24fb3eee786d36a9d1) | `` automatic update ``        |
| [`5da1d036`](https://github.com/nix-community/NUR/commit/5da1d036dcd69a0f5dddd3845b0ce94f34d2ff3b) | `` automatic update ``        |
| [`49a19a85`](https://github.com/nix-community/NUR/commit/49a19a85ff274c764c6440d854df8a12d6c2f9d0) | `` automatic update ``        |
| [`39c492ef`](https://github.com/nix-community/NUR/commit/39c492ef77c88b1c50fea7c5755f515a66f828cc) | `` automatic update ``        |
| [`59b19303`](https://github.com/nix-community/NUR/commit/59b193033007f646cdd9dbf1e9f8696a04f53d5f) | `` automatic update ``        |
| [`f5650128`](https://github.com/nix-community/NUR/commit/f56501287c4df6117012146ac5a3d2349ef93246) | `` automatic update ``        |
| [`1a43e4b9`](https://github.com/nix-community/NUR/commit/1a43e4b9c02d33694e9d1d0d7a9423fb9b17a947) | `` automatic update ``        |
| [`7792a534`](https://github.com/nix-community/NUR/commit/7792a534e255fcde947f58df04a030d629422ed3) | `` automatic update ``        |
| [`75341885`](https://github.com/nix-community/NUR/commit/753418854902ccec235420cf3ee6b8bb9da3de67) | `` automatic update ``        |
| [`f9278a3b`](https://github.com/nix-community/NUR/commit/f9278a3b6fbdf22c0797a79ef56dd0cb41358b9b) | `` automatic update ``        |
| [`27a28bd4`](https://github.com/nix-community/NUR/commit/27a28bd4863bf31e7d7c422f8f780d6d11cfc786) | `` automatic update ``        |
| [`e39159c3`](https://github.com/nix-community/NUR/commit/e39159c36817a9993b927ebf503be1d3ed4bacdc) | `` automatic update ``        |
| [`d1ddb9f3`](https://github.com/nix-community/NUR/commit/d1ddb9f3facb26e47fa8498508f2de6ac8d51ef4) | `` automatic update ``        |
| [`e001a689`](https://github.com/nix-community/NUR/commit/e001a689b8338fef133330de7ab187eaa3fc9be9) | `` automatic update ``        |
| [`7970185d`](https://github.com/nix-community/NUR/commit/7970185d9e3fd1eed750ca2953469335467ed05b) | `` automatic update ``        |
| [`9fc1df5c`](https://github.com/nix-community/NUR/commit/9fc1df5c3c1599c59668083fae4a9ea6ed9897d1) | `` automatic update ``        |
| [`08aad74d`](https://github.com/nix-community/NUR/commit/08aad74d0910faa799ac332a15ad11c1d9b3e818) | `` automatic update ``        |
| [`3593af22`](https://github.com/nix-community/NUR/commit/3593af227e6c50ece72ec5ffc217c87efbb7f307) | `` automatic update ``        |
| [`7b9e67b3`](https://github.com/nix-community/NUR/commit/7b9e67b39a3b336fe2098d2bd0e2db552480371d) | `` automatic update ``        |
| [`54da7131`](https://github.com/nix-community/NUR/commit/54da71315497f57371fcadb4f02885ae20674bc7) | `` automatic update ``        |
| [`312de864`](https://github.com/nix-community/NUR/commit/312de864bc7aa114e4d2037e5dc8a8138ec07af2) | `` automatic update ``        |
| [`4782fd51`](https://github.com/nix-community/NUR/commit/4782fd513cba8dd02eda30b30d72b8a90585a881) | `` automatic update ``        |
| [`3e09c868`](https://github.com/nix-community/NUR/commit/3e09c86852097d9c944b5f3d8e3887081afae8a6) | `` automatic update ``        |
| [`813d3e60`](https://github.com/nix-community/NUR/commit/813d3e60730dacabd842ac7dbf6c7b46c6ded339) | `` automatic update ``        |
| [`ee3f34cc`](https://github.com/nix-community/NUR/commit/ee3f34ccfee8439d8841118ce6f8931a3c760b12) | `` automatic update ``        |
| [`725e4c11`](https://github.com/nix-community/NUR/commit/725e4c1197f735213c8eb05811fb26a9bd0470df) | `` automatic update ``        |
| [`c733916c`](https://github.com/nix-community/NUR/commit/c733916c1fc8d165335af2c8906345b831fc802a) | `` automatic update ``        |
| [`df2dfc87`](https://github.com/nix-community/NUR/commit/df2dfc870aaed88af16e165d6f51923a4da487e8) | `` automatic update ``        |
| [`2369a187`](https://github.com/nix-community/NUR/commit/2369a187d23f70a03fde7902189772c361da82ff) | `` automatic update ``        |
| [`c701c8c1`](https://github.com/nix-community/NUR/commit/c701c8c10ca74b6f6fffe7be4f995d4ee04d183b) | `` automatic update ``        |
| [`77704096`](https://github.com/nix-community/NUR/commit/77704096cce07855a86f2108525a33cda818283a) | `` automatic update ``        |
| [`950dd31e`](https://github.com/nix-community/NUR/commit/950dd31ee60cde1b6cf6f3e71c5779aca9fedb0d) | `` automatic update ``        |
| [`a02c30dd`](https://github.com/nix-community/NUR/commit/a02c30dd3487ec92a678d904053c1018ae87fbbe) | `` automatic update ``        |
| [`257f6fa9`](https://github.com/nix-community/NUR/commit/257f6fa98b9e9865714ed0908d7d7f2b7894cf01) | `` automatic update ``        |
| [`c637e32e`](https://github.com/nix-community/NUR/commit/c637e32e807063f156814851a47bc2cfc2d63bf2) | `` automatic update ``        |
| [`32d33c9c`](https://github.com/nix-community/NUR/commit/32d33c9c00790e687cbe9984fec35c3d0e03e22d) | `` automatic update ``        |
| [`45a706bc`](https://github.com/nix-community/NUR/commit/45a706bce225239a923b84019d693ba3d656c8ee) | `` automatic update ``        |
| [`9a62b18e`](https://github.com/nix-community/NUR/commit/9a62b18e7f08d7ffae324679d206fac6a9b6e7de) | `` automatic update ``        |
| [`7446d0fc`](https://github.com/nix-community/NUR/commit/7446d0fcbcadfcfcbc9197c5b836cf442896590c) | `` automatic update ``        |
| [`6509c7fd`](https://github.com/nix-community/NUR/commit/6509c7fd6e383a375fe0652a435941b0e63ace08) | `` automatic update ``        |
| [`c29f47e7`](https://github.com/nix-community/NUR/commit/c29f47e7c08d48b7b9188d8accc1ed730b9cf7d0) | `` automatic update ``        |