### PR TITLE
chore(flake/nh): `37b0d469` -> `dcaf5bb7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -449,11 +449,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1703024852,
-        "narHash": "sha256-mVJ/99zkqpqDDs68jYIVYyQH6NBgciKnUg8AfWyXSAM=",
+        "lastModified": 1704917398,
+        "narHash": "sha256-q13oPB1fl45E+7cbV1P1VQt1GtGBaSbrHPtC0Y7q83c=",
         "owner": "viperML",
         "repo": "nh",
-        "rev": "37b0d469a328a5b5969eacdf137f1e6b86c75a1d",
+        "rev": "dcaf5bb7cdf7a1a4efb95ab94303c46b39eb193f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                      | Message                                           |
| ------------------------------------------------------------------------------------------- | ------------------------------------------------- |
| [`dcaf5bb7`](https://github.com/viperML/nh/commit/dcaf5bb7cdf7a1a4efb95ab94303c46b39eb193f) | `` unhide search ``                               |
| [`43a7b7ba`](https://github.com/viperML/nh/commit/43a7b7bade9df50a433aa77c09e4b97d712a9fb9) | `` update readme ``                               |
| [`20a7b3da`](https://github.com/viperML/nh/commit/20a7b3da13fb58385d54a69eaab5b4f3b51907f6) | `` tweak format ``                                |
| [`bde5048c`](https://github.com/viperML/nh/commit/bde5048c05a09a1299c0fa9962f9b7706b32eeee) | `` clippy ``                                      |
| [`a403423b`](https://github.com/viperML/nh/commit/a403423b7db3f164538d85b6bd4b4163285494ae) | `` tweak command runners ``                       |
| [`2d319dd6`](https://github.com/viperML/nh/commit/2d319dd6710aa974fd21757fbcdb5ed5eefd1b68) | `` store clean ``                                 |
| [`4a4b1f15`](https://github.com/viperML/nh/commit/4a4b1f159efcb87db92fa318281dea332ab74b5c) | `` completions logging ``                         |
| [`8b147fa4`](https://github.com/viperML/nh/commit/8b147fa444205caf616a691999293d5ae4fc2c78) | `` cleanup logging ``                             |
| [`fc80c10d`](https://github.com/viperML/nh/commit/fc80c10dde226fa809690855f11eae72ef5d4df9) | `` gcroots UX improvements ``                     |
| [`8ab6bae2`](https://github.com/viperML/nh/commit/8ab6bae2f122aaea7b6673385f28d395fa251c04) | `` tweak format ``                                |
| [`7bd098e3`](https://github.com/viperML/nh/commit/7bd098e35cac8303ae6ba59a4d6e8f01eeb5da32) | `` gcroots handling ``                            |
| [`b75d6638`](https://github.com/viperML/nh/commit/b75d6638f26d1882a783516e455e0d072ec35167) | `` inline code ``                                 |
| [`2f2a1952`](https://github.com/viperML/nh/commit/2f2a19527883dfc901161f0613475567c4585227) | `` prompt clean other paths ``                    |
| [`cf8f114b`](https://github.com/viperML/nh/commit/cf8f114b51e816cb55f5f4000db792844d0b50e7) | `` bump version ``                                |
| [`d69c28e8`](https://github.com/viperML/nh/commit/d69c28e8653d6b16ee7f12ee4816d6a6939c3504) | `` clippy ``                                      |
| [`8b6863d7`](https://github.com/viperML/nh/commit/8b6863d78ee9ccac2af158210d21c0ad968f2069) | `` tweak warn logging ``                          |
| [`812a175a`](https://github.com/viperML/nh/commit/812a175ab4b871ec54b261d12b864c38ba0ec9d4) | `` properly search in profiles without failing `` |
| [`84678105`](https://github.com/viperML/nh/commit/84678105927dda6e900cb594f9643c9bd8e8d645) | `` nh clean all impl ``                           |
| [`77e51bb7`](https://github.com/viperML/nh/commit/77e51bb765651dd6580d1a687f2f30a72de0a1bc) | `` print profile ``                               |
| [`50828ce5`](https://github.com/viperML/nh/commit/50828ce5f6776c558eb83ebfd04675dae6f316bf) | `` read dir for profiles ``                       |
| [`b4eec9e6`](https://github.com/viperML/nh/commit/b4eec9e6dc20d1bc6305a02629d17dd4dc7a2cda) | `` clean user ``                                  |
| [`ced290e7`](https://github.com/viperML/nh/commit/ced290e7f69171d59cd64243b558f9833030b1fd) | `` remove files ``                                |
| [`a0570388`](https://github.com/viperML/nh/commit/a05703885afabda9c3c194bdd280d0b762e9adf4) | `` re-add cleanable_generations ``                |
| [`70380024`](https://github.com/viperML/nh/commit/70380024ffeeedf3f3b9344a13a02fced852e8d2) | `` tweak search ``                                |
| [`839b4d00`](https://github.com/viperML/nh/commit/839b4d00ced0bd18fe8044fe734f8e68360e85a8) | `` init ES client ``                              |
| [`fc3ea080`](https://github.com/viperML/nh/commit/fc3ea080c12715594f3016eaa9cce5af7480814c) | `` fixme ``                                       |
| [`90a1298e`](https://github.com/viperML/nh/commit/90a1298e2d6d3d38bcd6f727649634250784c2de) | `` init log rewrite ``                            |