### PR TITLE
chore(flake/nixpkgs): `7bb62b90` -> `a3ada00f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -622,11 +622,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1704835834,
-        "narHash": "sha256-2XSWpm+0GBPHnCZmm/ell+yuPx3aP7zbitFFkFq7zlg=",
+        "lastModified": 1705157111,
+        "narHash": "sha256-zMphhlAFOlFgnZLNTsqIqUHfAhw2hCh7uO0Hy0H87Rk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7bb62b90ef7f7e76603bcd52d7e10ddb6d589f15",
+        "rev": "a3ada00f8a297a06617b2882a0943c26c8f3f424",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`4f8902a7`](https://github.com/NixOS/nixpkgs/commit/4f8902a71294581033dca051addd6c8f658e5280) | `` python311Packages.mpris-server: 0.8.1 -> 0.4.2; revert python-updates `` |
| [`f7340561`](https://github.com/NixOS/nixpkgs/commit/f734056102ac70e840f624326c582c35298e10a6) | `` stdenv: fix evaluation if !stdenv.cc.hasCC ``                            |
| [`7fcfa4f0`](https://github.com/NixOS/nixpkgs/commit/7fcfa4f0d60cc2b934dfb854ee067e6ce0cdabbb) | `` modules/trackpoint: fix quote ``                                         |
| [`ceed1d1f`](https://github.com/NixOS/nixpkgs/commit/ceed1d1f24abec2fb793d716316c7ae66ac7ea7c) | `` python311Packages.ansible-compat: 4.1.10 -> 4.1.11 ``                    |
| [`3d673c9b`](https://github.com/NixOS/nixpkgs/commit/3d673c9b54914a44379632f05ca11104056e8569) | `` linux/hardened/patches/6.6: 6.6.10-hardened1 -> 6.6.11-hardened1 ``      |
| [`51372c01`](https://github.com/NixOS/nixpkgs/commit/51372c01b3a89ea397c87ec7eaee158c54082475) | `` linux_5_10: 5.10.206 -> 5.10.207 ``                                      |
| [`cf21b93e`](https://github.com/NixOS/nixpkgs/commit/cf21b93edfaa39d325f0f087d27b8356808be1af) | `` python311Packages.peaqevcore: 19.6.5 -> 19.6.6 ``                        |
| [`9784ec38`](https://github.com/NixOS/nixpkgs/commit/9784ec382ee42d2ebebcccf0bd4e5a2cb09d55e0) | `` python311Packages.govee-ble: 0.27.2 -> 0.27.3 ``                         |
| [`2de745f1`](https://github.com/NixOS/nixpkgs/commit/2de745f11dbc413e747d5c2f41445db4d282e9a1) | `` mesa: 23.3.2 -> 23.3.3 ``                                                |
| [`13a6f426`](https://github.com/NixOS/nixpkgs/commit/13a6f4268742c16273ca8db92780a3fb504a4639) | `` virtualbox: fix build with libxml 2.12 + gcc 13 ``                       |
| [`e770463c`](https://github.com/NixOS/nixpkgs/commit/e770463c187f2de8f3f3cb12cf85668b7b62e608) | `` just: 1.22.1 -> 1.23.0 ``                                                |
| [`5ff3603f`](https://github.com/NixOS/nixpkgs/commit/5ff3603f6e08db86a29329372dc2a0569775369b) | `` linuxKernel.kernels.linux_lqx: 6.6.10-lqx1 -> 6.6.11-lqx1 ``             |
| [`563d2c4d`](https://github.com/NixOS/nixpkgs/commit/563d2c4dec4c553812594b0a36717be932e11030) | `` linuxKernel.kernels.linux_zen: 6.7-zen1 -> 6.7-zen2 ``                   |
| [`1aacf47e`](https://github.com/NixOS/nixpkgs/commit/1aacf47e18a0a5808cdcad28cccf158f4dd88da9) | `` cpp-jwt: fix build with `strictDeps = true;` ``                          |
| [`2c3dd4a4`](https://github.com/NixOS/nixpkgs/commit/2c3dd4a4f03ff284c0b5d3c5dc345d8ead745b1c) | `` mommy: 1.2.6 -> 1.3.0 ``                                                 |
| [`28330aa2`](https://github.com/NixOS/nixpkgs/commit/28330aa2040cb412315ea884f2864b17cade222e) | `` keep-sorted: init at 0.2.0 ``                                            |
| [`3bcb0ed7`](https://github.com/NixOS/nixpkgs/commit/3bcb0ed710d3864482ca14848861eea5030157b6) | `` mos: init at 3.4.1 ``                                                    |
| [`b8f55513`](https://github.com/NixOS/nixpkgs/commit/b8f55513c7fe494760f2c631c30f9f00975e8b02) | `` tbls: 1.72.0 -> 1.72.1 ``                                                |
| [`c36ba0e4`](https://github.com/NixOS/nixpkgs/commit/c36ba0e449548d092a19f03e23665e2bc1605eb9) | `` pegasus: unstable-2023-05-22 -> unstable-2023-12-05 ``                   |
| [`dbc598a3`](https://github.com/NixOS/nixpkgs/commit/dbc598a3c83383f2508f05cd349585cbe33b917c) | `` python311Packages.pysmi-lextudio: init at 1.1.13 ``                      |
| [`77e5fa5e`](https://github.com/NixOS/nixpkgs/commit/77e5fa5ea6f11617e5852eb82dfd39b4f2df8a94) | `` nixos/libvirtd: support out-of-tree vhost-user drivers ``                |
| [`62c8b51c`](https://github.com/NixOS/nixpkgs/commit/62c8b51c2720b31c76dda52626b6d914597b18d9) | `` virtiofsd: include vhost-user configuration file ``                      |
| [`52c3d54b`](https://github.com/NixOS/nixpkgs/commit/52c3d54be78d9d9e15326ab24e41a216e50450a5) | `` mod_tile: 0.6.1+unstable=2023-03-09 -> 0.7.0 ``                          |
| [`280b6d8d`](https://github.com/NixOS/nixpkgs/commit/280b6d8d65f4d5aaaa82c0c23925a309118fff57) | `` cartridges: 2.3 -> 2.7.2 ``                                              |
| [`6a5ee95e`](https://github.com/NixOS/nixpkgs/commit/6a5ee95e7899b7e7bcf76014998c388d75130461) | `` garmin-plugin: remove ``                                                 |
| [`ab22a877`](https://github.com/NixOS/nixpkgs/commit/ab22a877c47acc6933c83653c5bacec8cbcd2e65) | `` docker-buildx: 0.12.0 -> 0.12.1 ``                                       |
| [`ad8c1af7`](https://github.com/NixOS/nixpkgs/commit/ad8c1af79d8e1834b37b8be773d220ddc43c1e16) | `` python311Packages.pyenphase: 1.16.0 -> 1.17.0 ``                         |
| [`476e51ad`](https://github.com/NixOS/nixpkgs/commit/476e51ad719b4f7bfe883af2878334bf5ce14800) | `` cozette: 1.23.1 -> 1.23.2 ``                                             |
| [`84f7b9a1`](https://github.com/NixOS/nixpkgs/commit/84f7b9a1ee339d2e33cb3f3818203020ec1470c5) | `` python311Packages.nexia: refactor ``                                     |
| [`0bb124f6`](https://github.com/NixOS/nixpkgs/commit/0bb124f696034ae3df0831ab203597018564a24c) | `` python311Packages.nexia: 2.0.7 -> 2.0.8 ``                               |
| [`6dcc1d2d`](https://github.com/NixOS/nixpkgs/commit/6dcc1d2df3b8c2add09576a4754c4419ed76635c) | `` python311Packages.jsonpath-ng: 1.6.0 -> 1.6.1 ``                         |
| [`eaafddbc`](https://github.com/NixOS/nixpkgs/commit/eaafddbc1460792869a28a3204c2331d934b619f) | `` python311Packages.elastic-apm: 6.19.0 -> 6.20.0 ``                       |
| [`a9a99b39`](https://github.com/NixOS/nixpkgs/commit/a9a99b390550ab481a769cae2e5f05d5e624aa89) | `` astc-encoder: 4.6.1 -> 4.7.0 ``                                          |
| [`d1236a45`](https://github.com/NixOS/nixpkgs/commit/d1236a45f1ff171bb42e2acb6ad0adac26da910f) | `` tailwindcss-language-server: 0.0.14 -> 0.0.16 ``                         |
| [`d690f454`](https://github.com/NixOS/nixpkgs/commit/d690f4546e9b9902fa9737e4bcb6c6f83eaeef65) | `` tailwindcss: 3.4.0 -> 3.4.1 ``                                           |
| [`09aa366e`](https://github.com/NixOS/nixpkgs/commit/09aa366e5616ccbbb127021379d4ffa90aa39db4) | `` cosmic-settings: unstable-2023-10-26 -> unstable-2024-01-09 ``           |
| [`ff1232cf`](https://github.com/NixOS/nixpkgs/commit/ff1232cf6302a9f7c488946b90997b9c108bc41e) | `` python3Packages.tensorflow: pin the older gcc ``                         |
| [`497f6119`](https://github.com/NixOS/nixpkgs/commit/497f6119e2ccb87aa2a66170f7a980333a6e0b2d) | `` cudaPackages.backendStdenv: switch to stdenvAdapters.useLibsFrom ``      |
| [`e6e27991`](https://github.com/NixOS/nixpkgs/commit/e6e279913c70268c149dbee9f20ffc215fcb037c) | `` stdenvAdapters.useLibsFrom: init ``                                      |
| [`c45e1b64`](https://github.com/NixOS/nixpkgs/commit/c45e1b6459b90142c78c38cdc44b7e865cf4dcec) | `` cudaPackages.cuda_nvcc: use gcc from pkgsHostTarget ``                   |
| [`8eda4c36`](https://github.com/NixOS/nixpkgs/commit/8eda4c36a50dab64377fe3d73a0e8dadb3eaac0e) | `` cc-wrapper: cxxStdlib: expose solib and package separately ``            |
| [`210ce384`](https://github.com/NixOS/nixpkgs/commit/210ce3840807a87b7e407fed6ce8ec04e6e318bc) | `` cudaPackages.backendStdenv: use gccForLibs ``                            |
| [`290ea236`](https://github.com/NixOS/nixpkgs/commit/290ea23649ef663eab7de48992de87c647316044) | `` cc-wrapper: expose the c++ std library being used ``                     |
| [`223283c6`](https://github.com/NixOS/nixpkgs/commit/223283c66b431a937dc41c760f08067336c9c113) | `` cudaPackages: drop dangling cudatoolkit/extension.nix ``                 |
| [`aabf6422`](https://github.com/NixOS/nixpkgs/commit/aabf642251f0f5db3ba4680af8ab1e61815c5e01) | `` cosmic-files: init at unstable-2024-01-12 ``                             |
| [`f86a8266`](https://github.com/NixOS/nixpkgs/commit/f86a8266a2ac4dc497c532f45a78bc85d0ef1ab1) | `` svd2rust: 0.31.4 -> 0.31.5 ``                                            |
| [`e5472720`](https://github.com/NixOS/nixpkgs/commit/e5472720170f41d24394cde7fe10396bd33e35f4) | `` apx: 2.1.2 -> 2.2.0 ``                                                   |
| [`577cf0f8`](https://github.com/NixOS/nixpkgs/commit/577cf0f895fbb5c27c7b626fbdb10b9b8faf7e1a) | `` multipass: 1.12.2 -> 1.13.0 ``                                           |
| [`8b5217b6`](https://github.com/NixOS/nixpkgs/commit/8b5217b6deabc37b0114552cfce8c445e7567cc5) | `` iortcw: add rjpcasalino as maintainer ``                                 |
| [`4e614fa1`](https://github.com/NixOS/nixpkgs/commit/4e614fa1be54962bf83c143b4d642ff9cb7c73f4) | `` dnf-plugins-core: 4.4.3 -> 4.4.4 ``                                      |
| [`b28200aa`](https://github.com/NixOS/nixpkgs/commit/b28200aa23db05fe6ac29e8828b8119e6a4cd6ff) | `` texlive: document LuaLaTeX font cache (#280080) ``                       |
| [`ea423335`](https://github.com/NixOS/nixpkgs/commit/ea42333590a909ced8a58febf584b75788fa7d75) | `` sssd: 2.9.3 -> 2.9.4 ``                                                  |
| [`391d29cb`](https://github.com/NixOS/nixpkgs/commit/391d29cb04fe2ca9a4744c10d6b8a7783f6b0f6d) | `` nixos/tests/installer: fix eval ``                                       |
| [`8c947d17`](https://github.com/NixOS/nixpkgs/commit/8c947d1782e6a8905b950ce61eedc738c51d6c59) | `` i2p: enable aarch64-linux platform ``                                    |
| [`07f2cd9a`](https://github.com/NixOS/nixpkgs/commit/07f2cd9ac2e5a5596c6ada00b9eabcc915f414bb) | `` linux_zen, linux_lqx: add missing top-level attributes. ``               |
| [`b3b4f77d`](https://github.com/NixOS/nixpkgs/commit/b3b4f77dbb2ff41661f3d786fd7f65cd6e1dad19) | `` obs-studio-plugins.obs-ndi: 4.10.0 -> 4.13.0 ``                          |
| [`68bfb1d2`](https://github.com/NixOS/nixpkgs/commit/68bfb1d2e5965df8f355bf6fbbe238b8925827d1) | `` maintainers: add rjpcasalino. ``                                         |
| [`72525b80`](https://github.com/NixOS/nixpkgs/commit/72525b80be362f78d25ca651e4283e2d0e1db3d7) | `` crosvm: 119.0 -> 120.0 ``                                                |
| [`47e473ac`](https://github.com/NixOS/nixpkgs/commit/47e473acca92717d3eb44358ed8298e9115a49ec) | `` java-service-wrapper: enable aarch64-linux platform ``                   |
| [`b1eff5ae`](https://github.com/NixOS/nixpkgs/commit/b1eff5aeabf2466e005eb55b8458dea966f6dc9f) | `` snac2: 2.43 -> 2.44 ``                                                   |
| [`293fe1cf`](https://github.com/NixOS/nixpkgs/commit/293fe1cf1ad57f79d851bdf04f2ac81430143363) | `` smbmap: 1.9.2 -> 1.10.2 ``                                               |
| [`adb78d94`](https://github.com/NixOS/nixpkgs/commit/adb78d94434065c684e2d1817ed5fcb01c82fede) | `` nix-lib-nmd: init at 0.5.0 ``                                            |
| [`1a502c91`](https://github.com/NixOS/nixpkgs/commit/1a502c91a77e0c8bbc379f5b4097e31b9507ef59) | `` nix-lib-nmt: init at 0.5.0 ``                                            |
| [`cc22b678`](https://github.com/NixOS/nixpkgs/commit/cc22b678b14bf008b10e973c8d48ff4fad326022) | `` skytemple: 1.6.0 -> 1.6.3 ``                                             |
| [`182eac4c`](https://github.com/NixOS/nixpkgs/commit/182eac4c19488a830f87327b536b480bde0ddd09) | `` remnote: 1.13.0 -> 1.13.34 ``                                            |
| [`dc237ef7`](https://github.com/NixOS/nixpkgs/commit/dc237ef7f577bada0022109bed5727d7f74effa6) | `` dftd4: enable shared builds on !isStatic platforms ``                    |
| [`00713edc`](https://github.com/NixOS/nixpkgs/commit/00713edc7bc763a268a6b5b39df202bdfca258e0) | `` mstore: enable shared builds on !isStatic platforms ``                   |
| [`0138d805`](https://github.com/NixOS/nixpkgs/commit/0138d805ddce32a6327e562d132236a4310423e9) | `` multicharge: enable shared builds on !isStatic platforms ``              |
| [`66317989`](https://github.com/NixOS/nixpkgs/commit/6631798926b430943266bf844a8ae5a27f7d7e69) | `` simple-dftd3: enable shared builds on !isStatic platforms ``             |
| [`a3f4b8c7`](https://github.com/NixOS/nixpkgs/commit/a3f4b8c7da2b8707205041f9144024a983886e98) | `` tblite: enable shared builds on !isStatic platforms ``                   |
| [`9250befb`](https://github.com/NixOS/nixpkgs/commit/9250befb66367bb67cca3101f7464d7ded05e953) | `` toml-f: enable shared builds on !isStatic platforms ``                   |
| [`71e47e8a`](https://github.com/NixOS/nixpkgs/commit/71e47e8a232fc3a4fd1817d33028194ada8d3554) | `` mctc-lib: enable shared builds on !isStatic platforms ``                 |