### PR TITLE
chore(flake/emacs-overlay): `0272f041` -> `4baba64e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705423993,
-        "narHash": "sha256-kZtmuGdBzKT6vFbzVZqe9vm7ckkowSQz1Ln1ItvU3+A=",
+        "lastModified": 1705579015,
+        "narHash": "sha256-osKcl4saYzbcVUJLdunSyfEBz2OODLckhBuhp4wf4P0=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "0272f04189d187055b300c77178cce855382cc55",
+        "rev": "4baba64e8088c2cdbde661d6697d1fff3ba59f6d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                               |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------- |
| [`4baba64e`](https://github.com/nix-community/emacs-overlay/commit/4baba64e8088c2cdbde661d6697d1fff3ba59f6d) | `` Manually update emacs-unstable for 29.2 release `` |
| [`39f23b18`](https://github.com/nix-community/emacs-overlay/commit/39f23b184ca4b191fbef420ba3f6f63a0895d68b) | `` Updated melpa ``                                   |
| [`9aaefc4e`](https://github.com/nix-community/emacs-overlay/commit/9aaefc4e713561e39a642e2a645777528b40fbdb) | `` Updated melpa ``                                   |
| [`686f6c59`](https://github.com/nix-community/emacs-overlay/commit/686f6c59c4db2ff550f48ff9b767d6d53e8ca0cd) | `` Updated elpa ``                                    |
| [`70164fbf`](https://github.com/nix-community/emacs-overlay/commit/70164fbf83cdcd4d3772db6193a5b402716271e5) | `` Updated melpa ``                                   |
| [`5ae3690b`](https://github.com/nix-community/emacs-overlay/commit/5ae3690b9a643950743bc5890f778b31a5d76c00) | `` Updated elpa ``                                    |
| [`7e2ecc36`](https://github.com/nix-community/emacs-overlay/commit/7e2ecc3654c3daa74a1f72826cac9b8fd13a7f06) | `` Updated melpa ``                                   |
| [`ed25d979`](https://github.com/nix-community/emacs-overlay/commit/ed25d9799f2251666a0e8749a15f4301ebf37a1b) | `` Updated melpa ``                                   |
| [`d2a68273`](https://github.com/nix-community/emacs-overlay/commit/d2a68273c0a309d78c6e654602bf5c087f401d61) | `` Updated elpa ``                                    |
| [`9ad02597`](https://github.com/nix-community/emacs-overlay/commit/9ad0259722fd75ed4402d5e8cf1393ddf94a4928) | `` Updated flake inputs ``                            |