### PR TITLE
chore(flake/chaotic): `7bf8c1a4` -> `d2a46921`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1705428451,
-        "narHash": "sha256-cemZ4ZJ/oAQR8DayqRXQBnQSXrAE+ivAUXX0gpo0yEo=",
+        "lastModified": 1705493531,
+        "narHash": "sha256-o9rj1FkiURtwQfiYsF8ra+wc/BLHIrBVnEc7Gr2jTBM=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "7bf8c1a486fa7c8603a077203efa2255cc9b0aff",
+        "rev": "d2a46921c9f290ece5fa8faf9b9bf8bc6227f1ac",
         "type": "github"
       },
       "original": {
@@ -513,12 +513,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705133751,
-        "narHash": "sha256-rCIsyE80jgiOU78gCWN3A0wE0tR2GI5nH6MlS+HaaSQ=",
-        "rev": "9b19f5e77dd906cb52dade0b7bd280339d2a1f3d",
-        "revCount": 571036,
+        "lastModified": 1705316053,
+        "narHash": "sha256-J2Ey5mPFT8gdfL2XC0JTZvKaBw/b2pnyudEXFvl+dQM=",
+        "rev": "c3e128f3c0ecc1fb04aef9f72b3dcc2f6cecf370",
+        "revCount": 571714,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.571036%2Brev-9b19f5e77dd906cb52dade0b7bd280339d2a1f3d/018d072b-1039-7cf8-a8f8-968a0abfe96e/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.571714%2Brev-c3e128f3c0ecc1fb04aef9f72b3dcc2f6cecf370/018d13d4-6560-744b-8254-c10a7ef5adef/source.tar.gz"
       },
       "original": {
         "type": "tarball",


### PR DESCRIPTION
| Commit                                                                                          | Message                         |
| ----------------------------------------------------------------------------------------------- | ------------------------------- |
| [`d2a46921`](https://github.com/chaotic-cx/nyx/commit/d2a46921c9f290ece5fa8faf9b9bf8bc6227f1ac) | `` Bump 20240117-1 (#550) ``    |
| [`35518e29`](https://github.com/chaotic-cx/nyx/commit/35518e2947b9b640ee8a272404917d87dc8e087c) | `` nixpkgs: bump to 20240116 `` |