### PR TITLE
chore(flake/nur): `679d0b5b` -> `4e695604`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -606,11 +606,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705427061,
-        "narHash": "sha256-YK0y1fuk4P8cjnWIGUVpjkVtcdJBos+GdAYaqm0gHLs=",
+        "lastModified": 1705582191,
+        "narHash": "sha256-BcAqtHPHmbhomwodH3kA2PM2TiEwZBU8VOX3SNFphpg=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "679d0b5b18df44613a322347ff117eb0276c4514",
+        "rev": "4e69560402130d4ab721feac2eab1df26767359c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4e695604`](https://github.com/nix-community/NUR/commit/4e69560402130d4ab721feac2eab1df26767359c) | `` automatic update `` |
| [`a72a322d`](https://github.com/nix-community/NUR/commit/a72a322d545b162fc45a3668db442356cf39503b) | `` automatic update `` |
| [`9a4b285d`](https://github.com/nix-community/NUR/commit/9a4b285d2da183fad6a7fefa5cd54dc68a20adf0) | `` automatic update `` |
| [`e312882c`](https://github.com/nix-community/NUR/commit/e312882c07d2cbc289e5c60c34a23b2a8cd1c880) | `` automatic update `` |
| [`516c74d4`](https://github.com/nix-community/NUR/commit/516c74d45d21debcb58ee3da0570d80d68278ab4) | `` automatic update `` |
| [`3bc7e5ff`](https://github.com/nix-community/NUR/commit/3bc7e5ff2c0eaf2c20bf91bedb1b32683c58582c) | `` automatic update `` |
| [`51ae7d4b`](https://github.com/nix-community/NUR/commit/51ae7d4b33927abfde437cf08f125bb2e26e891d) | `` automatic update `` |
| [`2a8b3d0f`](https://github.com/nix-community/NUR/commit/2a8b3d0f05e087ab9c38165d826946a97ab45c5e) | `` automatic update `` |
| [`45fe6e3a`](https://github.com/nix-community/NUR/commit/45fe6e3a6888a1a7666936038ded021ce1206325) | `` automatic update `` |
| [`208f26d4`](https://github.com/nix-community/NUR/commit/208f26d4d1c4b8e951a51357e20190a24cd3f304) | `` automatic update `` |
| [`691d245e`](https://github.com/nix-community/NUR/commit/691d245e369dfc04c1a60e3b98f564503758e098) | `` automatic update `` |
| [`f9922340`](https://github.com/nix-community/NUR/commit/f99223402ec756b3f9f54666029c87edb78b2502) | `` automatic update `` |
| [`5d4a5a69`](https://github.com/nix-community/NUR/commit/5d4a5a69aefe71df9860948364143f6b41171ddc) | `` automatic update `` |
| [`cc3f814b`](https://github.com/nix-community/NUR/commit/cc3f814b1ed18c0763ed781b48f0ccd59ac2e8e6) | `` automatic update `` |
| [`20d8d3c3`](https://github.com/nix-community/NUR/commit/20d8d3c30b4440dd5bbf0ac328ba2bf5cba1fc3d) | `` automatic update `` |
| [`04601475`](https://github.com/nix-community/NUR/commit/04601475300f553c98c6768bbba456d63840d044) | `` automatic update `` |
| [`6076a79b`](https://github.com/nix-community/NUR/commit/6076a79b8d26bc47091fe635760d958bc313fd94) | `` automatic update `` |
| [`3c773fa3`](https://github.com/nix-community/NUR/commit/3c773fa3b438b5b06261f69167b609543caa8701) | `` automatic update `` |
| [`076de536`](https://github.com/nix-community/NUR/commit/076de53609ecd728684bde3c0a1d719669a9866c) | `` automatic update `` |
| [`c050a429`](https://github.com/nix-community/NUR/commit/c050a4297f2025516c9dbd6603bab1b218e80764) | `` automatic update `` |
| [`2cb8b307`](https://github.com/nix-community/NUR/commit/2cb8b307e3cd085aacbb4f2c59590e7bdb3f25ae) | `` automatic update `` |
| [`58f1c69c`](https://github.com/nix-community/NUR/commit/58f1c69c63adcaa2fb02697a0f8f3ca9eccca528) | `` automatic update `` |
| [`6bb00660`](https://github.com/nix-community/NUR/commit/6bb00660bdcce465f1d83346dec6d12b20c60477) | `` automatic update `` |
| [`3547553f`](https://github.com/nix-community/NUR/commit/3547553f591c4dcde285805e4d262be2aec7459a) | `` automatic update `` |
| [`94e443e3`](https://github.com/nix-community/NUR/commit/94e443e3b7a9f1c84848420a6518a01b849865ef) | `` automatic update `` |
| [`5095f759`](https://github.com/nix-community/NUR/commit/5095f759261809f4e5eaec878e767a673b922184) | `` automatic update `` |
| [`76b08c50`](https://github.com/nix-community/NUR/commit/76b08c50a95288f4100ebabc9f4d3a825a35ee68) | `` automatic update `` |
| [`1b54a4c3`](https://github.com/nix-community/NUR/commit/1b54a4c32111f486ae0e39771eab7f40f1f1d51a) | `` automatic update `` |
| [`a77498e0`](https://github.com/nix-community/NUR/commit/a77498e0017ac7512002828b7e02337cf6928e1c) | `` automatic update `` |
| [`01dcdf77`](https://github.com/nix-community/NUR/commit/01dcdf771e537fc34d531e639fb85d958fb7ce02) | `` automatic update `` |
| [`0482c9db`](https://github.com/nix-community/NUR/commit/0482c9dbc4e0f18340a6efe2c52b77800435fc68) | `` automatic update `` |
| [`2afd51ec`](https://github.com/nix-community/NUR/commit/2afd51ec110a41d646272a548fe5a2913f33a918) | `` automatic update `` |
| [`e5a47250`](https://github.com/nix-community/NUR/commit/e5a47250972eb972d108f003fe71babba5b5913c) | `` automatic update `` |
| [`cb8b51f3`](https://github.com/nix-community/NUR/commit/cb8b51f32f9587369857ee5cb6331b3fca0fb10b) | `` automatic update `` |
| [`61c58aa4`](https://github.com/nix-community/NUR/commit/61c58aa4fe5ec33003a9fe51de7799539fac1473) | `` automatic update `` |
| [`8d1c62ba`](https://github.com/nix-community/NUR/commit/8d1c62baf47e465e0732ebf7336d2443add7e3ec) | `` automatic update `` |
| [`d8cb8b7b`](https://github.com/nix-community/NUR/commit/d8cb8b7bc09cf704831caa4cec54d2ab6e5756cd) | `` automatic update `` |
| [`5124d9b9`](https://github.com/nix-community/NUR/commit/5124d9b94d3ffd632864d07c1a31bf0d2e568c42) | `` automatic update `` |
| [`b574577f`](https://github.com/nix-community/NUR/commit/b574577f6d3c5b9fab849ddacc0ad7d05cc08847) | `` automatic update `` |
| [`e6ef947a`](https://github.com/nix-community/NUR/commit/e6ef947a377d529b33796a9e05c1e9138f3bc192) | `` automatic update `` |
| [`1566b4e1`](https://github.com/nix-community/NUR/commit/1566b4e117d0cc8b9336f2dd6fade51089b9453b) | `` automatic update `` |
| [`fc514e83`](https://github.com/nix-community/NUR/commit/fc514e835def8cf67e63eb8a4f06eb6c52e05cb8) | `` automatic update `` |
| [`f28bee7b`](https://github.com/nix-community/NUR/commit/f28bee7b100aa6b96631eb433f0fcb7f2653be40) | `` automatic update `` |
| [`48c3d556`](https://github.com/nix-community/NUR/commit/48c3d5565365dbaac5d2919d9f7cb754da79f8cc) | `` automatic update `` |
| [`36cb0efe`](https://github.com/nix-community/NUR/commit/36cb0efea3adab06eff2639babdbb24d0c059630) | `` automatic update `` |
| [`579de42a`](https://github.com/nix-community/NUR/commit/579de42a9893e57bc5020dbdddf35473c9cda15a) | `` automatic update `` |
| [`49ee80a3`](https://github.com/nix-community/NUR/commit/49ee80a37d8a3a75b501e077de2115a062af0701) | `` automatic update `` |
| [`30dcc214`](https://github.com/nix-community/NUR/commit/30dcc214b3ca38fb769b289399cc6b486921457b) | `` automatic update `` |
| [`b7672ac6`](https://github.com/nix-community/NUR/commit/b7672ac60e52dc5804d07079eaca31dc4a0854eb) | `` automatic update `` |
| [`bc9055dd`](https://github.com/nix-community/NUR/commit/bc9055dd280a5c8c1e9a8e0b7f10608cf3915b0b) | `` automatic update `` |
| [`a519fb76`](https://github.com/nix-community/NUR/commit/a519fb76da9fed5f8afd734c2d0eb676b6942795) | `` automatic update `` |
| [`e624e8d1`](https://github.com/nix-community/NUR/commit/e624e8d167a7376b1ea715cf218c547d11bb4d28) | `` automatic update `` |
| [`69bb2258`](https://github.com/nix-community/NUR/commit/69bb22580340859ff3b1fcb477010f7c5ab755cb) | `` automatic update `` |
| [`d903efee`](https://github.com/nix-community/NUR/commit/d903efee82490af2b5307eb0717f9de623a53195) | `` automatic update `` |