### PR TITLE
chore(flake/hyprland): `3c964a9f` -> `c4365f20`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1705332646,
-        "narHash": "sha256-D/7HUGGYBZHn8Zjs8Agf2i8mL64uqksKEjXz1QAd80c=",
+        "lastModified": 1705503680,
+        "narHash": "sha256-e+ou1KvZeZp104yeCgvgTTp5G+DB380CUZuUkijZxAc=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "3c964a9fdc220250a85b1c498e5b6fad9390272f",
+        "rev": "c4365f20ed8ff0dd480b7ed7cf1bfff1a0b6911a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                     |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
| [`c4365f20`](https://github.com/hyprwm/Hyprland/commit/c4365f20ed8ff0dd480b7ed7cf1bfff1a0b6911a) | `` damage: use buffer_damage instead of effective_damage `` |
| [`307dd8f5`](https://github.com/hyprwm/Hyprland/commit/307dd8f511ab51dbf0900d16f29d66db8b619158) | `` input: partially revert #4401 ``                         |
| [`8342bac6`](https://github.com/hyprwm/Hyprland/commit/8342bac697b7abf036ec1c005af695fb8ab99b13) | `` Nix: disable fortify for devshell (#4463) ``             |