### PR TITLE
chore(flake/nixpkgs): `5223d1f8` -> `cefcf19e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -590,11 +590,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1705384131,
-        "narHash": "sha256-VD8Zi21JtIKMCCqwHmef6g+chhT5PROZ3HXAlm/o7PA=",
+        "lastModified": 1705556346,
+        "narHash": "sha256-2+ZUEFCKlctTsut81S84xkCccMsZLLX7DA/U3xZ3BqY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5223d1f86aab688bf05c6069b87be5f662d84eac",
+        "rev": "cefcf19e1c6d4255b2aede5535d04064f6917e9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`3d6a5ad6`](https://github.com/NixOS/nixpkgs/commit/3d6a5ad6049b9c55488b501b2a3b439586d7dd5e) | `` systemd-lib: fix automount generation after 9fbf82d9cb48 ``                    |
| [`2fba629f`](https://github.com/NixOS/nixpkgs/commit/2fba629f59f3de8cf773ad5fcac782e62a934faa) | `` coqPackages.QuickChick: 2.0.1 → 2.0.2 ``                                       |
| [`8a9a8c61`](https://github.com/NixOS/nixpkgs/commit/8a9a8c6104fbcb08840433f25dbf4ecdaabbbf0f) | `` chromium: 120.0.6099.216 -> 120.0.6099.224 ``                                  |
| [`6dbaf744`](https://github.com/NixOS/nixpkgs/commit/6dbaf744d62e1fb19cc360f0cebbf850f32b5e3f) | `` legendary-gl: add main program ``                                              |
| [`697b3ed0`](https://github.com/NixOS/nixpkgs/commit/697b3ed06f9df7a356d02047516c459c7d435d84) | `` python311Packages.pyasyncore: fix license ``                                   |
| [`b66442b2`](https://github.com/NixOS/nixpkgs/commit/b66442b2f997fbee70f983c6866477b72ce446a9) | `` drawio: 22.1.16 -> 22.1.18 ``                                                  |
| [`69834c39`](https://github.com/NixOS/nixpkgs/commit/69834c39c1aa3e8c4cb5d9b3d3c63d5fc4f39c74) | `` vimPlugins.sniprun: 1.3.10 -> 1.3.11 ``                                        |
| [`5c5c0fba`](https://github.com/NixOS/nixpkgs/commit/5c5c0fba212f0936e9a53b9b2e9a11ed04df33f6) | `` solana-validator: 1.10 -> 1.16 ``                                              |
| [`25649226`](https://github.com/NixOS/nixpkgs/commit/25649226651bd2451baaacc9c97be2602065f20a) | `` python311Packages.open-interpreter: init at 0.2.0 ``                           |
| [`543fb704`](https://github.com/NixOS/nixpkgs/commit/543fb70434ba0e7f1eaa700972001ca3230c004a) | `` python311Packages.moderngl-window: relax pillow dependency; fix build ``       |
| [`1516b35a`](https://github.com/NixOS/nixpkgs/commit/1516b35afa9dca43d40a605292098bd24543009a) | `` check-by-name: Remove legacy CI script ``                                      |
| [`8cf3cd91`](https://github.com/NixOS/nixpkgs/commit/8cf3cd91b2b6052f99fbe78f80141e57fcc02230) | `` check-by-name: Update contributor docs ``                                      |
| [`50d57f62`](https://github.com/NixOS/nixpkgs/commit/50d57f623671afd2ecd4180b928a4e44cbabe399) | `` check-by-name: Fix CI ``                                                       |
| [`7f5dd771`](https://github.com/NixOS/nixpkgs/commit/7f5dd771e582bfac76af797356b77d808e5e97ae) | `` open-interpreter: 0.1.11 -> 0.2.0 ``                                           |
| [`45b34474`](https://github.com/NixOS/nixpkgs/commit/45b34474978c64a29795e0200f7150385531088c) | `` python311Packages.tokentrim: unstable-2023-09-07 -> 0.1.13 ``                  |
| [`c593183b`](https://github.com/NixOS/nixpkgs/commit/c593183b1b5bc13dd6ffad5882495efa49ff2cfc) | `` junction: 1.6 → 1.7 ``                                                         |
| [`53250e9f`](https://github.com/NixOS/nixpkgs/commit/53250e9fe6f0816d1d1b59b1813f8c60ff80b961) | `` vaultwarden.webvault: 2024.1.0 -> 2024.1.1 ``                                  |
| [`754418d8`](https://github.com/NixOS/nixpkgs/commit/754418d8701580c444ad36d0ddc6d1342cd80ec6) | `` python311Packages.mpd2: refactor ``                                            |
| [`0d565b02`](https://github.com/NixOS/nixpkgs/commit/0d565b02fa3ce0e1cee03a94f7ced06b15ba2fee) | `` speakersafetyd: init at 0.1.9 (#281305) ``                                     |
| [`3ff0cd72`](https://github.com/NixOS/nixpkgs/commit/3ff0cd726331b8b4b01606e1fb87e3609d9be72a) | `` hare: embedd paths for cross-compilation toolchains ``                         |
| [`6f0376f2`](https://github.com/NixOS/nixpkgs/commit/6f0376f222780aca254ec0e82d26caee510e2c30) | `` teams-for-linux: 1.4.2 -> 1.4.4 ``                                             |
| [`9065dc97`](https://github.com/NixOS/nixpkgs/commit/9065dc97a6cf8786f3671f0b8b99b76cc033981e) | `` ldtk: 1.5.2 -> 1.5.3 ``                                                        |
| [`bed725db`](https://github.com/NixOS/nixpkgs/commit/bed725db88c8163b9c5cd2186f34bed79e1add42) | `` cudaPackages_11_4.nsight_systems: clean up the deprecation comments ``         |
| [`30af0cda`](https://github.com/NixOS/nixpkgs/commit/30af0cdab6de6a0b12f4ab35b2539fe9773db307) | `` tests.nixpkgs-check-by-name: Test non-Nix invalid symlinks instead ``          |
| [`cf90aa9a`](https://github.com/NixOS/nixpkgs/commit/cf90aa9a86e5edf4e8c991904ce04183fc10c99c) | `` tests.nixpkgs-check-by-name: Don't test invalid Nix files ``                   |
| [`2c7c5603`](https://github.com/NixOS/nixpkgs/commit/2c7c560330ee7b4089d27887f66ef0fe249bf866) | `` coqPackages.mathcomp: 2.1.0 -> 2.2.0 ``                                        |
| [`d0c71af8`](https://github.com/NixOS/nixpkgs/commit/d0c71af81f4eced8a5e89716ed0a0311f91c5593) | `` python3Packages.xarray-einstats: 0.6.0 -> 0.7.0, support updated xarray ``     |
| [`7d758e35`](https://github.com/NixOS/nixpkgs/commit/7d758e356c089b84f66e213eefc4b34d9f25c0c3) | `` cosmic-session: init at 0-unstable-2024-01-17 ``                               |
| [`35c015ff`](https://github.com/NixOS/nixpkgs/commit/35c015ff9165125cb2090b721b41228085fd2cb8) | `` nixos/ntpd-rs: fix metrics service ``                                          |
| [`5026f746`](https://github.com/NixOS/nixpkgs/commit/5026f74653024e4d8e4fcf681b82a52cffbced40) | `` laurel: 0.5.5 -> 0.5.6 ``                                                      |
| [`47b64d03`](https://github.com/NixOS/nixpkgs/commit/47b64d03d1933ff30d4ef4ba549396438fbc3768) | `` dune_3: 3.12.2 -> 3.13.0 ``                                                    |
| [`33860c4f`](https://github.com/NixOS/nixpkgs/commit/33860c4ffef6e26d57ac281f4cfb1e0b8fdb351f) | `` ocamlPackages.luv: 0.5.11 -> 0.5.12 (#226435) ``                               |
| [`82b2fd1f`](https://github.com/NixOS/nixpkgs/commit/82b2fd1ffa8402bbf92708a36beeb6629ec1557f) | `` emacs.pkgs.ghc-mod: fixup ``                                                   |
| [`4fb8db4b`](https://github.com/NixOS/nixpkgs/commit/4fb8db4b03e4999dd8aa1b99f107b32caf6b1d8b) | `` advcpmv: 0.9-9.3 -> 0.9-9.4 ``                                                 |
| [`a13bc9c0`](https://github.com/NixOS/nixpkgs/commit/a13bc9c0a0c47cee393f75583e54d8ba1ecdd7fe) | `` advcpmv: init at 0.9-9.3 ``                                                    |
| [`cbf15cbb`](https://github.com/NixOS/nixpkgs/commit/cbf15cbb9d95c51c1229ef0073d28002924a5336) | `` lagrange-tui: 1.17.5 -> 1.17.6 ``                                              |
| [`0a195ccc`](https://github.com/NixOS/nixpkgs/commit/0a195cccbf50ac65ed80166faa9b7983b0988fcc) | `` androidStudioPackages.canary: 2023.3.1.3 -> 2023.3.1.4 ``                      |
| [`e862ac6b`](https://github.com/NixOS/nixpkgs/commit/e862ac6b5ca280d3e41db71467f129839e47ee45) | `` element-{web,desktop}: 1.11.53 -> 1.11.54 (#281458) ``                         |
| [`181faf91`](https://github.com/NixOS/nixpkgs/commit/181faf917635d545607ef02295e01661337ce2e7) | `` python311Packages.meilisearch: refactor ``                                     |
| [`1050d94b`](https://github.com/NixOS/nixpkgs/commit/1050d94b82d809428a05842015dded0907e25d69) | `` python311Packages.meilisearch: 0.28.4 -> 0.29.0 ``                             |
| [`fb8b20d9`](https://github.com/NixOS/nixpkgs/commit/fb8b20d90e69d93b6886a4cb80039ca185b73b89) | `` acpid: Disable network access ``                                               |
| [`98f34cd0`](https://github.com/NixOS/nixpkgs/commit/98f34cd01c9b469a6f2a85c72325f45c256830aa) | `` tfsec: 1.28.4 -> 1.28.5 ``                                                     |
| [`17d3654e`](https://github.com/NixOS/nixpkgs/commit/17d3654e118ac11c3e18745624ece51dc0885cea) | `` trufflehog: 3.63.9 -> 3.63.10 ``                                               |
| [`d378b0cc`](https://github.com/NixOS/nixpkgs/commit/d378b0ccc75680ee759a24eb8accc3b0e141da3e) | `` trufflehog: 3.63.8 -> 3.63.9 ``                                                |
| [`f3f055e8`](https://github.com/NixOS/nixpkgs/commit/f3f055e8b04ff311b83c1c8b4dceb981b3f70cf8) | `` checkov: 3.1.62 -> 3.1.63 ``                                                   |
| [`aa4baefc`](https://github.com/NixOS/nixpkgs/commit/aa4baefc630013c1f3f69a4ae7f876e84f00c946) | `` ksmbd-tools: install systemd unit ``                                           |
| [`2ba9c098`](https://github.com/NixOS/nixpkgs/commit/2ba9c098d41a671d6b1054cc456488f11554e6ee) | `` ignite-cli: 28.1.0 -> 28.1.1 ``                                                |
| [`00595927`](https://github.com/NixOS/nixpkgs/commit/0059592746e0129edc9dbcc303cb7fa17f29487f) | `` python311Packages.meshtastic: refactor ``                                      |
| [`750025d1`](https://github.com/NixOS/nixpkgs/commit/750025d10470395814c234713ac07c341b401b84) | `` python311Packages.meshtastic: 2.2.17 -> 2.2.18 ``                              |
| [`18ea65b9`](https://github.com/NixOS/nixpkgs/commit/18ea65b9b7615b7044d8ce9cd86ac2df66ffa64e) | `` python311Packages.haversine: refactor ``                                       |
| [`5f758a69`](https://github.com/NixOS/nixpkgs/commit/5f758a692e686b3861d04cb9afb1ce614ce3489e) | `` python311Packages.haversine: 2.8.0 -> 2.8.1 ``                                 |
| [`5c772265`](https://github.com/NixOS/nixpkgs/commit/5c772265964101ee1c38ad96aa8ad22df8f7b634) | `` python311Packages.botocore-stubs: 1.34.19 -> 1.34.20 ``                        |
| [`fb1976a8`](https://github.com/NixOS/nixpkgs/commit/fb1976a8fddde5fc4178008b92b46b01fb698665) | `` python311Packages.boto3-stubs: 1.34.19 -> 1.34.20 ``                           |
| [`01acbe0f`](https://github.com/NixOS/nixpkgs/commit/01acbe0fba4d0c5fb52fa6b86538750fa58e86fa) | `` libphonenumber: fix reproducible builds patch ``                               |
| [`c7f615d8`](https://github.com/NixOS/nixpkgs/commit/c7f615d8ab15c23961fd885123201f01321273f6) | `` prevo: adjust wrapper, loosen platforms ``                                     |
| [`6c900ea1`](https://github.com/NixOS/nixpkgs/commit/6c900ea19a74aad802cadc1941a5fc907f36a645) | `` prevo*: move to pkgs/by-name ``                                                |
| [`8373e306`](https://github.com/NixOS/nixpkgs/commit/8373e306ffe3fa83cd64ef8e5084b368a2494368) | `` gh: 2.41.0 -> 2.42.1 ``                                                        |
| [`aba7e02e`](https://github.com/NixOS/nixpkgs/commit/aba7e02e1c504760e95e760939ec4995822c18b7) | `` tests.nixpkgs-check-by-name: Minor README.md update ``                         |
| [`28c4666e`](https://github.com/NixOS/nixpkgs/commit/28c4666e8b94ad87c8bc1801b7bf2441fca95e0c) | `` tests.nixpkgs-check-by-name: added test that fails multiple validity checks `` |
| [`9da57b5b`](https://github.com/NixOS/nixpkgs/commit/9da57b5bd370a90e979453694e715975a38eb966) | `` check-by-name/run-local.sh: Make it usable for non-CI platforms ``             |
| [`2dd7f0e8`](https://github.com/NixOS/nixpkgs/commit/2dd7f0e8b9959326104d1ce5a808743cd9d6aa61) | `` tests.nixpkgs-check-by-name: Use NIX_PATH for extra test files ``              |
| [`64ad8b68`](https://github.com/NixOS/nixpkgs/commit/64ad8b683643e31f490c59930300b57bb86c434f) | `` tests.nixpkgs-check-by-name: Limit source files ``                             |
| [`57a19d87`](https://github.com/NixOS/nixpkgs/commit/57a19d87d0968a29ab050bb8e3caba089af269d1) | `` python311Packages.unique-log-filter: init at 0.1.0 ``                          |
| [`9ad30c21`](https://github.com/NixOS/nixpkgs/commit/9ad30c213af6a9f5bc1741370e28e1b85034705a) | `` gdown: 4.7.1 -> 4.7.3 ``                                                       |
| [`a96f30df`](https://github.com/NixOS/nixpkgs/commit/a96f30df2d40f44b227b8ee01c010467139fdade) | `` bookstack: 23.08.3 -> 23.12.1 ``                                               |
| [`527feea2`](https://github.com/NixOS/nixpkgs/commit/527feea2a3c4f15c7a2ed8dbd1c59959d7024a2b) | `` wofi-emoji: fix paths in shell script ``                                       |
| [`f11eff08`](https://github.com/NixOS/nixpkgs/commit/f11eff088e0780ba76697b1a30268f188441fac6) | `` wofi-emoji: 2023-06-19 -> 2023-12-22 ``                                        |
| [`21d257ee`](https://github.com/NixOS/nixpkgs/commit/21d257ee5be8b736f944cfc60dea5ff7ce8360b1) | `` jetbrains.{idea,pycharm}-community-src: 2023.2.2 -> 2023.3.2 ``                |
| [`7ec60593`](https://github.com/NixOS/nixpkgs/commit/7ec605930b289b9ca75817afe386103df7fe3a92) | `` pkgsMusl.systemd: fix build (#281323) ``                                       |
| [`7ecfd267`](https://github.com/NixOS/nixpkgs/commit/7ecfd267753bd00b2aa021360c1a9c316153f67d) | `` pdm: 2.10.4 -> 2.12.1, fix build ``                                            |
| [`7be7fc50`](https://github.com/NixOS/nixpkgs/commit/7be7fc508cfb3f1bbfc73131ff83a49d467e1114) | `` python3Packages.dep-logic: init at 0.0.4 ``                                    |
| [`d3942104`](https://github.com/NixOS/nixpkgs/commit/d394210497bf5aecb3af2e3c9e7924b276fdbced) | `` keep-sorted: 0.2.0 -> 0.3.0 ``                                                 |
| [`8c08a3b8`](https://github.com/NixOS/nixpkgs/commit/8c08a3b85f546a87056e545efe0480218ccbf72b) | `` focuswriter: 1.8.5 -> 1.8.6 ``                                                 |
| [`2dca255f`](https://github.com/NixOS/nixpkgs/commit/2dca255f5e7cc4d4640b9f7b9186be1dba2bf5b5) | `` ocamlPackages.cmarkit: 0.2.0 -> 0.3.0 ``                                       |
| [`41f6cde5`](https://github.com/NixOS/nixpkgs/commit/41f6cde5a5a167aba99de1b375e8da66b74bfb23) | `` oha: 1.0.0 -> 1.1.0 ``                                                         |
| [`509fa455`](https://github.com/NixOS/nixpkgs/commit/509fa4552c92ef77491c92d1a96cb796fc94ee5b) | `` python311Packages.icalevents: relax deps ``                                    |
| [`4745b5ed`](https://github.com/NixOS/nixpkgs/commit/4745b5edf3b7f9d20169586634e12dbe9ecc76c8) | `` simulide: init at 0.4.15-SR10 ``                                               |
| [`023a55f8`](https://github.com/NixOS/nixpkgs/commit/023a55f825a38a1bd939b4d8300c4b86a3f3c7fa) | `` yazi: 0.1.5 -> 0.2.1 ``                                                        |
| [`148cff9b`](https://github.com/NixOS/nixpkgs/commit/148cff9bff0f859b46ad5622d157ebaa95a1737d) | `` slskd: 0.18.2 -> 0.19.5 ``                                                     |
| [`053e365c`](https://github.com/NixOS/nixpkgs/commit/053e365c0b4da1be7aa32632073438b1f886ccdc) | `` aws-sso-cli: 1.14.2 -> 1.14.3 ``                                               |
| [`0f2fa7fb`](https://github.com/NixOS/nixpkgs/commit/0f2fa7fbc3d9d923a56248bb777a07ce658f3383) | `` terraform-ls: 0.32.4 -> 0.32.5 ``                                              |
| [`11d4757b`](https://github.com/NixOS/nixpkgs/commit/11d4757b11b1f4ffdaa6140dff38f9b707f05f61) | `` docker-slim: 1.40.8 -> 1.40.9 ``                                               |
| [`8c58c6ca`](https://github.com/NixOS/nixpkgs/commit/8c58c6cac1e0c21a15b9e8fc9a70a2b5aad000ba) | `` quicktype: 23.0.80 -> 23.0.81 ``                                               |
| [`bf7bff0c`](https://github.com/NixOS/nixpkgs/commit/bf7bff0c188789f5224488f40e6186ea5f755462) | `` python311Packages.getjump: 2.4.1 -> 2.4.2 ``                                   |
| [`32c00dc3`](https://github.com/NixOS/nixpkgs/commit/32c00dc37042934c79041116383e27f04ad84710) | `` nodejs_21: 21.5.0 -> 21.6.0 ``                                                 |
| [`a6566ad1`](https://github.com/NixOS/nixpkgs/commit/a6566ad1e9b077bece728e19d49571d0ddf506f4) | `` vale: 3.0.3 -> 3.0.5 ``                                                        |
| [`7c3ecbdc`](https://github.com/NixOS/nixpkgs/commit/7c3ecbdce9e5f054e32e5d58c86399d5f2375a6b) | `` nixos/invoiceplane: add nginx as a webserver option for invoiceplane ``        |
| [`e49368bd`](https://github.com/NixOS/nixpkgs/commit/e49368bdb2dd3ffc8b0ed046277868d86146384c) | `` maintainers: add CarlosCraveiro ``                                             |
| [`d09e4541`](https://github.com/NixOS/nixpkgs/commit/d09e454114b2930f847ea9337f7e0b12a8103fdf) | `` fix: tmux-plugins binary path ``                                               |
| [`d9097c0a`](https://github.com/NixOS/nixpkgs/commit/d9097c0a2b8dc510901ff7428868fb6ebeebdbc1) | `` typst-preview: 0.9.2 -> 0.10.5 ``                                              |
| [`ffe76ea5`](https://github.com/NixOS/nixpkgs/commit/ffe76ea5e23e80c4ea79cf8beba6e59fae975f5b) | `` likwid: init at 5.3.0 ``                                                       |
| [`41e8aec8`](https://github.com/NixOS/nixpkgs/commit/41e8aec89a58b40014d52486c1000bf576765bfa) | `` clusterctl: 1.6.0 -> 1.6.1 ``                                                  |
| [`05b06094`](https://github.com/NixOS/nixpkgs/commit/05b060948bb846e2c6be0e98d5bed3c5cfed801d) | `` python311Packages.pyatag: exclude from bulk updates ``                         |
| [`66212da3`](https://github.com/NixOS/nixpkgs/commit/66212da3485b344f9c781b86bfdd207e94d832ec) | `` python311Packages.starline: exclude from bulk updates ``                       |
| [`ae1ee608`](https://github.com/NixOS/nixpkgs/commit/ae1ee608c0a3e953c6fc33ae72939058b4f2de66) | `` Revert "python3Packages.starline: 0.1.5 -> 0.2.0" ``                           |
| [`68f4ce77`](https://github.com/NixOS/nixpkgs/commit/68f4ce778f2fe7596a3bc43d6b1bde19f47f6aeb) | `` mir: Disable pre-compiled headers ``                                           |
| [`290031a5`](https://github.com/NixOS/nixpkgs/commit/290031a530772b607395237b340802681ace5a5a) | `` komikku: 1.33.0 -> 1.35.0 ``                                                   |
| [`0f70deed`](https://github.com/NixOS/nixpkgs/commit/0f70deed1cb54683a76363862ffd1fc7ea5dfa54) | `` cudaPackages: update the release notes with the major version bump ``          |
| [`8ddc8e33`](https://github.com/NixOS/nixpkgs/commit/8ddc8e335530af3d1394fe323838ade3b0a7d2f6) | `` cudaPackages_12.nsight_systems: unbreak ``                                     |
| [`b16942df`](https://github.com/NixOS/nixpkgs/commit/b16942dfa8287ed5a4c24b18e5036c09687387d4) | `` cudaPackages.cuda_cudart: a separate output for stub ``                        |
| [`cd51c704`](https://github.com/NixOS/nixpkgs/commit/cd51c7049c15c6f3c36b504d6a4391b049536188) | `` suitesparse: fix the cuda12 variant ``                                         |
| [`1620cc6e`](https://github.com/NixOS/nixpkgs/commit/1620cc6e9ad6672ebaf2201cbde7a90152ebbef7) | `` cudaPackages: 11.8 -> 12.2 ``                                                  |
| [`7d161de7`](https://github.com/NixOS/nixpkgs/commit/7d161de78111dead45620ab77f7f97d99d044659) | `` cudaPackages_12: 12.0 -> 12.2 ``                                               |
| [`253325ea`](https://github.com/NixOS/nixpkgs/commit/253325ea8684a42ce44f08b297195638e2b166cf) | `` xq: 0.2.44 -> 0.2.45 ``                                                        |
| [`d7a396b3`](https://github.com/NixOS/nixpkgs/commit/d7a396b3c4f805bbb498a9cbffeac1d7eb833a88) | `` python311Packages.securetar: refactor ``                                       |
| [`d34e1df8`](https://github.com/NixOS/nixpkgs/commit/d34e1df8e83c956340d5aae372b7ce77a09f790b) | `` python311Packages.securetar: 2023.3.0 -> 2023.12.0 ``                          |
| [`29da62e4`](https://github.com/NixOS/nixpkgs/commit/29da62e4e2b4b95d890e5cdaf3b522ccaa6b6a23) | `` bees: 0.9.3 -> 0.10 ``                                                         |