### PR TITLE
chore(flake/home-manager): `b84191db` -> `9b378afa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -287,11 +287,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705535278,
-        "narHash": "sha256-V5+XKfNbiY0bLKLQlH+AXyhHttEL7XcZBH9iSbxxexA=",
+        "lastModified": 1705794055,
+        "narHash": "sha256-mv/KrxEAZNhpPJcDqdQ709If9p2DTEYIDPo2r9xchlg=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b84191db127c16a92cbdf7f7b9969d58bb456699",
+        "rev": "9b378afae72cb07471e19aefc30e8e05ef2d7a61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`9b378afa`](https://github.com/nix-community/home-manager/commit/9b378afae72cb07471e19aefc30e8e05ef2d7a61) | `` hyprland: change plugins settings generation ``                  |
| [`ce4b88c4`](https://github.com/nix-community/home-manager/commit/ce4b88c465d928f4f8b75d0920f1788d5b65ca94) | `` mcfly: add mcfly-fzf integration ``                              |
| [`2064348e`](https://github.com/nix-community/home-manager/commit/2064348e555b6aa963da6372a8f14e6acb80a176) | `` hyprland: do not override existing plugins settings in config `` |
| [`d6185e83`](https://github.com/nix-community/home-manager/commit/d6185e83d864a4a73d5e6655ab7410c074c0657c) | `` docs, tests: revert to fetchTarball for nmd and nmt ``           |