### PR TITLE
chore(flake/hyprland): `c4365f20` -> `4d403dac`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1705503680,
-        "narHash": "sha256-e+ou1KvZeZp104yeCgvgTTp5G+DB380CUZuUkijZxAc=",
+        "lastModified": 1705782792,
+        "narHash": "sha256-AnNvfQK3BQtri7JUmTsaAWAOBzCxEf5t3VaGm0Kezjk=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "c4365f20ed8ff0dd480b7ed7cf1bfff1a0b6911a",
+        "rev": "4d403dac3244aab217fb9bf17a68e9a009fcadd8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                               |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
| [`4d403dac`](https://github.com/hyprwm/Hyprland/commit/4d403dac3244aab217fb9bf17a68e9a009fcadd8) | `` build: protocols: require wayland-protocols >= 1.32 ``             |
| [`f40e382f`](https://github.com/hyprwm/Hyprland/commit/f40e382fc6208d4fe2e53581ea27510cb62417dd) | `` crashreporter: skip first possibly cut off line in log tail ``     |
| [`b86ed02d`](https://github.com/hyprwm/Hyprland/commit/b86ed02d8ae7c955e1f42cc27a19fe18d82c50b7) | `` keybinds: avoid duplicated held keys, only use last, remove all `` |
| [`17339e0a`](https://github.com/hyprwm/Hyprland/commit/17339e0ae9ad01dcfdede76e8dfaf516a8cbb924) | `` input: track exclusive LSes ``                                     |
| [`5eeec886`](https://github.com/hyprwm/Hyprland/commit/5eeec8860e2dc8ff80dda26243778b5ecc923ca2) | `` core: improve cleanup logic ``                                     |
| [`9f20a159`](https://github.com/hyprwm/Hyprland/commit/9f20a15955697b0f52740c1e0180acdafa071f79) | `` input: remove animate checks on resize limiter (#4480) ``          |