### PR TITLE
chore(flake/emacs-overlay): `4baba64e` -> `3566704a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705579015,
-        "narHash": "sha256-osKcl4saYzbcVUJLdunSyfEBz2OODLckhBuhp4wf4P0=",
+        "lastModified": 1705783124,
+        "narHash": "sha256-OK9WJGd/b4VSZ/d5v3xm9E2YoVwJx/PDN26EHrQv5Ic=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4baba64e8088c2cdbde661d6697d1fff3ba59f6d",
+        "rev": "3566704a6769341e5a84c49a28b545b26759e23f",
         "type": "github"
       },
       "original": {
@@ -558,11 +558,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1705331948,
-        "narHash": "sha256-qjQXfvrAT1/RKDFAMdl8Hw3m4tLVvMCc8fMqzJv0pP4=",
+        "lastModified": 1705641746,
+        "narHash": "sha256-D6c2aH8HQbWc7ZWSV0BUpFpd94ImFyCP8jFIsKQ4Slg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b8dd8be3c790215716e7c12b247f45ca525867e2",
+        "rev": "d2003f2223cbb8cd95134e4a0541beea215c1073",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                       |
| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
| [`d3944caa`](https://github.com/nix-community/emacs-overlay/commit/d3944caa140aa7ee67b0238ec3a19a910e4a4050) | `` Updated emacs ``                                                           |
| [`e574b56c`](https://github.com/nix-community/emacs-overlay/commit/e574b56c87d7894f1cb14dacf38ff5c4a5082431) | `` elisp: Tangle org-mode files when used with defaultInitFile ``             |
| [`2db8934d`](https://github.com/nix-community/emacs-overlay/commit/2db8934d6ec0a50effad0cf4dfbcdd496d0d2fdc) | `` Update emacs ``                                                            |
| [`7744578a`](https://github.com/nix-community/emacs-overlay/commit/7744578ae998127cef9002949f84778e6775a2c8) | `` Revert "Revert "Revert "Revert "fixup! Update bytecomp-revert.patch"""" `` |
| [`ceacea3b`](https://github.com/nix-community/emacs-overlay/commit/ceacea3bc70890c816cd616ec2a7af5ff93d6f4c) | `` Revert "Revert "Revert "Revert "Update bytecomp-revert.patch"""" ``        |
| [`90dfac9d`](https://github.com/nix-community/emacs-overlay/commit/90dfac9d46c86246b7fac16c689b5e5492bf9b2c) | `` Revert "Temporarily disable "emacs" update" ``                             |
| [`fd04cba8`](https://github.com/nix-community/emacs-overlay/commit/fd04cba897ffc741d08eceee8cb4d4058177eb5d) | `` Updated melpa ``                                                           |
| [`fcc7bd71`](https://github.com/nix-community/emacs-overlay/commit/fcc7bd71eadb8041dab9e97c237ae12873be627a) | `` Updated melpa ``                                                           |
| [`2876e264`](https://github.com/nix-community/emacs-overlay/commit/2876e264544034fa2f8ac06faec09b87a9a6c916) | `` Updated elpa ``                                                            |
| [`fd002eb7`](https://github.com/nix-community/emacs-overlay/commit/fd002eb789e61b5c213c531f0e5973d98c0a2688) | `` Updated flake inputs ``                                                    |
| [`e812fbf7`](https://github.com/nix-community/emacs-overlay/commit/e812fbf7ec5c1e9fa44fb74a3f456cdf68fb7a4f) | `` Updated melpa ``                                                           |
| [`ad687a09`](https://github.com/nix-community/emacs-overlay/commit/ad687a09864a19b45a00d02ee8cebd13760113ef) | `` Updated elpa ``                                                            |
| [`dc3dafe4`](https://github.com/nix-community/emacs-overlay/commit/dc3dafe421095791e2dacf2b03e1686365160d35) | `` Updated melpa ``                                                           |
| [`397f91d9`](https://github.com/nix-community/emacs-overlay/commit/397f91d98f2bd0d81ce54b15ad6bf457a8dc536a) | `` Updated melpa ``                                                           |
| [`eaf998b4`](https://github.com/nix-community/emacs-overlay/commit/eaf998b4ab1397000afeeced036fcb55e61750dd) | `` Updated elpa ``                                                            |
| [`eeb8da16`](https://github.com/nix-community/emacs-overlay/commit/eeb8da168b6882e54d66b960a2ee9490663b6a7d) | `` Updated flake inputs ``                                                    |
| [`68ce1f4f`](https://github.com/nix-community/emacs-overlay/commit/68ce1f4f6c8d1c0fc9ee3d9febac9fd62e527647) | `` Updated melpa ``                                                           |
| [`4e2567af`](https://github.com/nix-community/emacs-overlay/commit/4e2567af3a540d4c9e5512b3f70589b9d7ec181b) | `` Updated elpa ``                                                            |
| [`10ebdcc9`](https://github.com/nix-community/emacs-overlay/commit/10ebdcc9777f3accf780ff2a66da3052445a05b6) | `` Updated flake inputs ``                                                    |