### PR TITLE
chore(flake/nur): `4e695604` -> `c39b293f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -606,11 +606,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705582191,
-        "narHash": "sha256-BcAqtHPHmbhomwodH3kA2PM2TiEwZBU8VOX3SNFphpg=",
+        "lastModified": 1705794259,
+        "narHash": "sha256-Zrd20rPA+DsvLyU3JWXVCRt07o0wN4riKfeJv9wXAXE=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "4e69560402130d4ab721feac2eab1df26767359c",
+        "rev": "c39b293ff897568c488372823230ec46b5b1b841",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                              |
| -------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`c39b293f`](https://github.com/nix-community/NUR/commit/c39b293ff897568c488372823230ec46b5b1b841) | `` automatic update ``               |
| [`26884905`](https://github.com/nix-community/NUR/commit/26884905e6e16577275d60f3985861eec185afa4) | `` automatic update ``               |
| [`65380eec`](https://github.com/nix-community/NUR/commit/65380eec6e39c81a064b44d43d706599c9d8320d) | `` automatic update ``               |
| [`eee17bb6`](https://github.com/nix-community/NUR/commit/eee17bb61f9a6dff151a595cbc2d75e6918768fe) | `` automatic update ``               |
| [`09a43e5c`](https://github.com/nix-community/NUR/commit/09a43e5cb3c252dccd2ef00e7f3607a9573f4d05) | `` automatic update ``               |
| [`93a3c398`](https://github.com/nix-community/NUR/commit/93a3c3987677fc28e66b8876f9e5a2712d79b918) | `` automatic update ``               |
| [`8cf1886e`](https://github.com/nix-community/NUR/commit/8cf1886e854410b982ace2f2263cf570d5f6b730) | `` automatic update ``               |
| [`4a37f776`](https://github.com/nix-community/NUR/commit/4a37f7768e7c0d2a1a6bb21bb1568f1fe4c7c66a) | `` automatic update ``               |
| [`313c3c10`](https://github.com/nix-community/NUR/commit/313c3c1063318216b51b9691902fc285f5b1b7ae) | `` automatic update ``               |
| [`5600a7b7`](https://github.com/nix-community/NUR/commit/5600a7b720cc0ba8134d64c88d132d94fcc3ae78) | `` automatic update ``               |
| [`43c32d3b`](https://github.com/nix-community/NUR/commit/43c32d3bc27361bbdba050977fe6a40dc7fce128) | `` automatic update ``               |
| [`ce4b47f0`](https://github.com/nix-community/NUR/commit/ce4b47f0d290e2f5b8f088a82a9b810cbe90afa3) | `` automatic update ``               |
| [`d57a0ad1`](https://github.com/nix-community/NUR/commit/d57a0ad143f0f42883a1ff824344a06995157c9f) | `` automatic update ``               |
| [`883f061d`](https://github.com/nix-community/NUR/commit/883f061dd30e40bb06f1ed490ab073cb18c41a41) | `` automatic update ``               |
| [`238f73f6`](https://github.com/nix-community/NUR/commit/238f73f63e2c0a0fd894d95ebeb09c3daddc5801) | `` automatic update ``               |
| [`eca40357`](https://github.com/nix-community/NUR/commit/eca403570fcf05edcbcfd6142d25d4f7a5f55e32) | `` automatic update ``               |
| [`74f84f4b`](https://github.com/nix-community/NUR/commit/74f84f4bb3b36de03f205a75609eca91fe7332e2) | `` automatic update ``               |
| [`f8acdb36`](https://github.com/nix-community/NUR/commit/f8acdb369de0846742840c1b19026f81df6af24b) | `` automatic update ``               |
| [`5ee948b8`](https://github.com/nix-community/NUR/commit/5ee948b8a5f654ad91a1d6db22ab2f89e928ae1e) | `` automatic update ``               |
| [`48b3de8c`](https://github.com/nix-community/NUR/commit/48b3de8c458d1b144b183cace158edfae75391c6) | `` automatic update ``               |
| [`4a497e24`](https://github.com/nix-community/NUR/commit/4a497e248db739c85191bed691acd969db1cb881) | `` automatic update ``               |
| [`c821534e`](https://github.com/nix-community/NUR/commit/c821534eb6202e0a2af60ddf47dc1e487db03b0a) | `` automatic update ``               |
| [`a4f012ac`](https://github.com/nix-community/NUR/commit/a4f012ac71386b639a8e1a15dc1679ca0c49ff3e) | `` automatic update ``               |
| [`de4ee222`](https://github.com/nix-community/NUR/commit/de4ee22210e14df8bc1c91cb517701a1e91aa92c) | `` automatic update ``               |
| [`d1f5ecf8`](https://github.com/nix-community/NUR/commit/d1f5ecf8f123124af3977d3010a2d4bcc42af18b) | `` automatic update ``               |
| [`868aa9b5`](https://github.com/nix-community/NUR/commit/868aa9b52241ad7c8cb89cdd207f8d0149ebf95b) | `` automatic update ``               |
| [`fa77eaf6`](https://github.com/nix-community/NUR/commit/fa77eaf6c407aa48ce8da0212ea0c752189bf87d) | `` automatic update ``               |
| [`9270a293`](https://github.com/nix-community/NUR/commit/9270a293f01ae7748ec42b903c7b92123cb24ec0) | `` automatic update ``               |
| [`750734b3`](https://github.com/nix-community/NUR/commit/750734b35cbc48450a8bfa04586fbe3610e2f2c3) | `` automatic update ``               |
| [`b68b7cf3`](https://github.com/nix-community/NUR/commit/b68b7cf37a4d34c12c4b7d76d8ac6cedca6817ed) | `` automatic update ``               |
| [`a00a6151`](https://github.com/nix-community/NUR/commit/a00a61515a07be0cb55e76c981ef3fbfe875fbe0) | `` automatic update ``               |
| [`43df15e3`](https://github.com/nix-community/NUR/commit/43df15e3feb5ef80aa41d49876fbf5bd860b355a) | `` automatic update ``               |
| [`0297e17e`](https://github.com/nix-community/NUR/commit/0297e17e7a1c5246cd1fba75c0353c8dae24ad7b) | `` automatic update ``               |
| [`4fb9a66e`](https://github.com/nix-community/NUR/commit/4fb9a66e564c5d0b8e2393473e225a2827579bcf) | `` automatic update ``               |
| [`54adff74`](https://github.com/nix-community/NUR/commit/54adff742c899c6f7c61420171eb7e5050b21a1f) | `` automatic update ``               |
| [`e004fc4f`](https://github.com/nix-community/NUR/commit/e004fc4f6dc5a3016f624e714c6d99460bc84c41) | `` automatic update ``               |
| [`fbdc1ba8`](https://github.com/nix-community/NUR/commit/fbdc1ba81e9a5121386e64f54a1eff41dc47e8bc) | `` automatic update ``               |
| [`45e99e80`](https://github.com/nix-community/NUR/commit/45e99e80a0f25e50905f9da6153048136c4c7f64) | `` automatic update ``               |
| [`d94a031e`](https://github.com/nix-community/NUR/commit/d94a031eb1ca4d4aa34eb49b4916f8d0e82dd089) | `` automatic update ``               |
| [`67bd5c7e`](https://github.com/nix-community/NUR/commit/67bd5c7e6189cbc8134756754b6ec8a19222cde2) | `` automatic update ``               |
| [`66c3aec5`](https://github.com/nix-community/NUR/commit/66c3aec51e9d40381a053798de41b5e477d4b665) | `` automatic update ``               |
| [`b417bdc5`](https://github.com/nix-community/NUR/commit/b417bdc500787ba21935e34c676f0eb009b7a9a3) | `` automatic update ``               |
| [`ec2cb59e`](https://github.com/nix-community/NUR/commit/ec2cb59e4d9da7c7c4cb0882de698ba7633fc539) | `` added Ex-32 repo to repos.json `` |
| [`56e9a4c0`](https://github.com/nix-community/NUR/commit/56e9a4c0e034499dbf48ef58a9555fc4b0d5333f) | `` automatic update ``               |
| [`ac0ade06`](https://github.com/nix-community/NUR/commit/ac0ade06f6ef7b095567c58b2a62c62837358480) | `` automatic update ``               |