### PR TITLE
chore(flake/spicetify-nix): `b30c6fe8` -> `1de18dc5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -703,11 +703,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705551028,
-        "narHash": "sha256-Rkb+B7mbk3kH48vF1tpYc1W4bf6NBrDwmJ3O+js1NlA=",
+        "lastModified": 1705723846,
+        "narHash": "sha256-CixVZZgPB1U3TgYAj79NnpPKtkdqS7kXuqjG9MMZwjM=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "b30c6fe8825b9a2b6a60509cdc0d57ba3323776f",
+        "rev": "1de18dc5d6a103f07fdf2f2e0d1dc0f549686eab",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`1de18dc5`](https://github.com/Gerg-L/spicetify-nix/commit/1de18dc5d6a103f07fdf2f2e0d1dc0f549686eab) | `` CI update 2024-01-20 (#49) `` |
| [`b50bfb3e`](https://github.com/Gerg-L/spicetify-nix/commit/b50bfb3efc1b0de2254676b956c10cdfabcb4af8) | `` CI update 2024-01-19 (#48) `` |