### PR TITLE
chore(flake/treefmt-nix): `04f25d7b` -> `8cd95da6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -783,11 +783,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704649711,
-        "narHash": "sha256-+qxqJrZwvZGilGiLQj3QbYssPdYCwl7ejwMImgH7VBQ=",
+        "lastModified": 1705659004,
+        "narHash": "sha256-XQsZudrb9u5Pw631U0tFYZkjq49CcwF24XT01vz2jPk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "04f25d7bec9fb29d2c3bacaa48a3304840000d36",
+        "rev": "8cd95da6c30852adb2a06c4b6bdacfe8b64a0a35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                   |
| ---------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`8cd95da6`](https://github.com/numtide/treefmt-nix/commit/8cd95da6c30852adb2a06c4b6bdacfe8b64a0a35) | `` keep-sorted: init (#150) ``            |
| [`5861b733`](https://github.com/numtide/treefmt-nix/commit/5861b733f22ae4c192c7d207bae515d3bb77a6c0) | `` just: add as formatter ``              |
| [`093ad41d`](https://github.com/numtide/treefmt-nix/commit/093ad41d747c58bb5f6d2f649078febaf05b780c) | `` flake.lock: Update ``                  |
| [`84ec04bd`](https://github.com/numtide/treefmt-nix/commit/84ec04bd6aaec92b00954bd58be8e2ffe310dd18) | `` readme: update contributing section `` |