### PR TITLE
chore(flake/home-manager): `9b378afa` -> `3df2a80f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -287,11 +287,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705794055,
-        "narHash": "sha256-mv/KrxEAZNhpPJcDqdQ709If9p2DTEYIDPo2r9xchlg=",
+        "lastModified": 1706001011,
+        "narHash": "sha256-J7Bs9LHdZubgNHZ6+eE/7C18lZ1P6S5/zdJSdXFItI4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9b378afae72cb07471e19aefc30e8e05ef2d7a61",
+        "rev": "3df2a80f3f85f91ea06e5e91071fa74ba92e5084",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                    |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
| [`3df2a80f`](https://github.com/nix-community/home-manager/commit/3df2a80f3f85f91ea06e5e91071fa74ba92e5084) | `` zoxide: fix nushell 0.89 deprecation `` |
| [`3d0dc78e`](https://github.com/nix-community/home-manager/commit/3d0dc78e80031731240c979d87eed8e090d35439) | `` bemenu: allow floats in settings ``     |
| [`2d47379a`](https://github.com/nix-community/home-manager/commit/2d47379ad591bcb14ca95a90b6964b8305f6c913) | `` flake.lock: Update ``                   |
| [`4af6720f`](https://github.com/nix-community/home-manager/commit/4af6720fff6cdc6188ccd4533365a202f6adeccc) | `` k9s: fix unnecessary test dependency `` |
| [`020399c2`](https://github.com/nix-community/home-manager/commit/020399c287afa853136b8089c315e238bf4b161d) | `` k9s: v0.29/v0.30 compatibility ``       |
| [`0021558d`](https://github.com/nix-community/home-manager/commit/0021558dba313b6f494cd16362dcd4071f407535) | `` mise: fix test ``                       |
| [`928f2528`](https://github.com/nix-community/home-manager/commit/928f2528f9ee952ba0a47bbb1ece8d93ed66e784) | `` mise: add module ``                     |