### PR TITLE
chore(flake/hyprland): `4d403dac` -> `791e1b96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -311,11 +311,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1705782792,
-        "narHash": "sha256-AnNvfQK3BQtri7JUmTsaAWAOBzCxEf5t3VaGm0Kezjk=",
+        "lastModified": 1705973554,
+        "narHash": "sha256-ZvzkhQA0iaUEkyCxBItps5qcSX509vpxpku1NVaiLRQ=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "4d403dac3244aab217fb9bf17a68e9a009fcadd8",
+        "rev": "791e1b96b3cd12d56648b3ce7ffb0832eba2b37d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                           |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
| [`791e1b96`](https://github.com/hyprwm/Hyprland/commit/791e1b96b3cd12d56648b3ce7ffb0832eba2b37d) | `` internal: minor header cleanup ``              |
| [`02b4a9bd`](https://github.com/hyprwm/Hyprland/commit/02b4a9bdede8ab0336e2e7ac52b39cab36208bb4) | `` compositor: clarify common errors at launch `` |