### PR TITLE
chore(flake/nix-index-database): `49aaeecf` -> `f8e04fbc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -474,11 +474,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705282324,
-        "narHash": "sha256-LnURMA7yCM5t7et9O2+2YfGQh0FKAfE5GyahNDDzJVM=",
+        "lastModified": 1705806513,
+        "narHash": "sha256-FcOmNjhHFfPz2udZbRpZ1sfyhVMr+C2O8kOxPj+HDDk=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "49aaeecf41ae0a0944e2c627cb515bcde428a1d1",
+        "rev": "f8e04fbcebcc24cebc91989981bd45f69b963ed7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`f8e04fbc`](https://github.com/nix-community/nix-index-database/commit/f8e04fbcebcc24cebc91989981bd45f69b963ed7) | `` update packages.nix to release 2024-01-21-030727 `` |
| [`244811b8`](https://github.com/nix-community/nix-index-database/commit/244811b8aaf7bd25d7e48bb300daf07eca9a9c96) | `` flake.lock: Update ``                               |