### PR TITLE
chore(flake/spicetify-nix): `1de18dc5` -> `61d83fc5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -703,11 +703,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705723846,
-        "narHash": "sha256-CixVZZgPB1U3TgYAj79NnpPKtkdqS7kXuqjG9MMZwjM=",
+        "lastModified": 1705983050,
+        "narHash": "sha256-rfb3kCoJFpD6rU7ZrYV6fUalaurvw+oowV5fwpLo26w=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "1de18dc5d6a103f07fdf2f2e0d1dc0f549686eab",
+        "rev": "61d83fc5ab4c982e45c823d60069a1c49b1b2a38",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`61d83fc5`](https://github.com/Gerg-L/spicetify-nix/commit/61d83fc5ab4c982e45c823d60069a1c49b1b2a38) | `` CI update 2024-01-23 (#52) `` |
| [`47cc7ad8`](https://github.com/Gerg-L/spicetify-nix/commit/47cc7ad8f0db7883af86dc180e9456a392b80428) | `` CI update 2024-01-22 (#51) `` |
| [`7af165ab`](https://github.com/Gerg-L/spicetify-nix/commit/7af165abeefa0a36fe4da13c74bc9a57554cf292) | `` CI update 2024-01-21 (#50) `` |