### PR TITLE
chore(flake/treefmt-nix): `8cd95da6` -> `9d458726`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -783,11 +783,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705659004,
-        "narHash": "sha256-XQsZudrb9u5Pw631U0tFYZkjq49CcwF24XT01vz2jPk=",
+        "lastModified": 1705910240,
+        "narHash": "sha256-Mt29QigQALm2YODaidHHokyNew1TxcRVpBBPV3HifKk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "8cd95da6c30852adb2a06c4b6bdacfe8b64a0a35",
+        "rev": "9d458726fed1cc00e48031bb7214dfa3c16b7a0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                    |
| ---------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
| [`9d458726`](https://github.com/numtide/treefmt-nix/commit/9d458726fed1cc00e48031bb7214dfa3c16b7a0f) | `` readme: document how to use custom formatters (#151) `` |