### PR TITLE
chore(flake/nur): `c39b293f` -> `8452fbba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -606,11 +606,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1705794259,
-        "narHash": "sha256-Zrd20rPA+DsvLyU3JWXVCRt07o0wN4riKfeJv9wXAXE=",
+        "lastModified": 1706014755,
+        "narHash": "sha256-RjiYDLlqM509x3NpuRgHjkT8nXq+P0v+VJzjm8RKqeE=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "c39b293ff897568c488372823230ec46b5b1b841",
+        "rev": "8452fbba02b789b9046356a9546db1a312a04804",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8452fbba`](https://github.com/nix-community/NUR/commit/8452fbba02b789b9046356a9546db1a312a04804) | `` automatic update `` |
| [`084c9e5a`](https://github.com/nix-community/NUR/commit/084c9e5ac47b1da166bb485fe1ade830eb525f07) | `` automatic update `` |
| [`dbda804c`](https://github.com/nix-community/NUR/commit/dbda804cf36a64d698b1ef4df35ecabfa45442a6) | `` automatic update `` |
| [`1d21e45d`](https://github.com/nix-community/NUR/commit/1d21e45d0a555e48e3800dfae234c330361bfc08) | `` automatic update `` |
| [`ca9d5533`](https://github.com/nix-community/NUR/commit/ca9d55332782e1ac0ac263596cd4d48b4a429dab) | `` automatic update `` |
| [`0069433d`](https://github.com/nix-community/NUR/commit/0069433daa260b20302ee5b501888828ba4e4dbc) | `` automatic update `` |
| [`7fa73649`](https://github.com/nix-community/NUR/commit/7fa73649f77307a61836cbd5a0b95703223a9a86) | `` automatic update `` |
| [`42cf459f`](https://github.com/nix-community/NUR/commit/42cf459f61ab038beadd4da7867c46203cb941c9) | `` automatic update `` |
| [`21151d82`](https://github.com/nix-community/NUR/commit/21151d82b1c2156080bb453b935ecc61dab134b4) | `` automatic update `` |
| [`15cecdfa`](https://github.com/nix-community/NUR/commit/15cecdfaa9c56d0e3460a80e2672fe9789b94302) | `` automatic update `` |
| [`d6c5b607`](https://github.com/nix-community/NUR/commit/d6c5b6079d730f1b4588ea22b0ed008c245cb818) | `` automatic update `` |
| [`68c68e53`](https://github.com/nix-community/NUR/commit/68c68e53ba4095644cb111d310a9daedb2dbf7fa) | `` automatic update `` |
| [`d70c2a18`](https://github.com/nix-community/NUR/commit/d70c2a18ef5df36804bb87537063b2d15baf9292) | `` automatic update `` |
| [`ad710d13`](https://github.com/nix-community/NUR/commit/ad710d139b3d033144386445e1dcdbe833fa0f04) | `` automatic update `` |
| [`0d0d7dbf`](https://github.com/nix-community/NUR/commit/0d0d7dbf9317a4e2aaee94c1bd098387262c3256) | `` automatic update `` |
| [`0d37a32e`](https://github.com/nix-community/NUR/commit/0d37a32ebadba95810740b3a44f4dd96eae41587) | `` automatic update `` |
| [`2482e298`](https://github.com/nix-community/NUR/commit/2482e298332a435100483a35e17d50bcbd9a5325) | `` automatic update `` |
| [`1a834468`](https://github.com/nix-community/NUR/commit/1a83446861b58ce409f485016bf66a8d66957e2c) | `` automatic update `` |
| [`5efd4d39`](https://github.com/nix-community/NUR/commit/5efd4d39154107ae73b27e917666707ae940f104) | `` automatic update `` |
| [`a29c6f71`](https://github.com/nix-community/NUR/commit/a29c6f71063d0ce903e927fa7885651c00abd33b) | `` automatic update `` |
| [`3b71df0e`](https://github.com/nix-community/NUR/commit/3b71df0e3e90c32554154d608db507c4f6d6fd13) | `` automatic update `` |
| [`6e301223`](https://github.com/nix-community/NUR/commit/6e3012237f99313423d356e18ac6dfda289d8cfb) | `` automatic update `` |
| [`49dc0fef`](https://github.com/nix-community/NUR/commit/49dc0fef1a407cfb96daad2c0609a009496cc2df) | `` automatic update `` |
| [`d1821b6a`](https://github.com/nix-community/NUR/commit/d1821b6a0206e931d42c22da4654162abebcf4d9) | `` automatic update `` |
| [`b69cb83b`](https://github.com/nix-community/NUR/commit/b69cb83b2bbf8ff89384718258da18f3a6a3c024) | `` automatic update `` |
| [`384ac71f`](https://github.com/nix-community/NUR/commit/384ac71f725e53d3e2acf3a86cdd8d25ca7e2ae4) | `` automatic update `` |
| [`53b9b646`](https://github.com/nix-community/NUR/commit/53b9b646124543179ff2f63117551599801bf103) | `` automatic update `` |
| [`5e5d9934`](https://github.com/nix-community/NUR/commit/5e5d9934a13055949729770476e640d3e1a1a612) | `` automatic update `` |
| [`7d8494cb`](https://github.com/nix-community/NUR/commit/7d8494cbcbcc26d90d87e77a0f3a62459fbbf05c) | `` automatic update `` |
| [`f0a4f546`](https://github.com/nix-community/NUR/commit/f0a4f546d8aaa4ee0ccf9e907ee12ce9121fffc4) | `` automatic update `` |
| [`1b6ca600`](https://github.com/nix-community/NUR/commit/1b6ca600ff9357fa500a9e636bb15e59b2599e5f) | `` automatic update `` |
| [`2072630f`](https://github.com/nix-community/NUR/commit/2072630fec40fe24c905f508f7b8a2cf27b3f277) | `` automatic update `` |
| [`43740fb4`](https://github.com/nix-community/NUR/commit/43740fb42099d9814c6d290c15722feedc2f9ce1) | `` automatic update `` |
| [`906a8697`](https://github.com/nix-community/NUR/commit/906a86978c205e6043a1ad11692f9766c2774880) | `` automatic update `` |
| [`15971653`](https://github.com/nix-community/NUR/commit/15971653a2e5ed1d67c01d0c00c4e3e3b84bea0c) | `` automatic update `` |
| [`2b4a30cd`](https://github.com/nix-community/NUR/commit/2b4a30cde35eb5b7813c731aa26fc475a27c723e) | `` automatic update `` |
| [`bfd7ae8f`](https://github.com/nix-community/NUR/commit/bfd7ae8fd550bbae107547934fdb9d3dd04bb592) | `` automatic update `` |
| [`2fe90f24`](https://github.com/nix-community/NUR/commit/2fe90f24673e65191c8c9c7f5207a7d936decf51) | `` automatic update `` |
| [`6364d3aa`](https://github.com/nix-community/NUR/commit/6364d3aa72c8f16787a187a0a3967cd83911dd76) | `` automatic update `` |
| [`0f826a07`](https://github.com/nix-community/NUR/commit/0f826a07b9f2b7110fd811d334357461734df579) | `` automatic update `` |
| [`d798727f`](https://github.com/nix-community/NUR/commit/d798727f69dd62b67b17dc99d35691f9c6b44b96) | `` automatic update `` |
| [`035838c4`](https://github.com/nix-community/NUR/commit/035838c4b3844d36c399df306b7d537f905cfda4) | `` automatic update `` |
| [`246a0315`](https://github.com/nix-community/NUR/commit/246a031505b2c9043e82fcabd551f5dcded77c2d) | `` automatic update `` |
| [`907ca905`](https://github.com/nix-community/NUR/commit/907ca905eab246a08be6f652cb94e2e7ef81e9d0) | `` automatic update `` |
| [`caa9ee7b`](https://github.com/nix-community/NUR/commit/caa9ee7ba5c583ad1e46199ebcaad0ff57ed3992) | `` automatic update `` |
| [`ff6497ef`](https://github.com/nix-community/NUR/commit/ff6497ef576a1d88ef7ecb7e40e3a7cd9a410b2b) | `` automatic update `` |
| [`3c0ac654`](https://github.com/nix-community/NUR/commit/3c0ac654b9ef21a3dc6960cd2b311e458ff9b48d) | `` automatic update `` |