### PR TITLE
chore(flake/chaotic): `18e8728c` -> `59ccbc5c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1705789286,
-        "narHash": "sha256-34LxkYfTCbv7qbEBq3y48JkJia9/KtZi1QMqVrnApj0=",
+        "lastModified": 1706010186,
+        "narHash": "sha256-HrTA0Wl+1SB1WTMNGhgXvNYr9RV2WgPcYmjP7R8weeI=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "18e8728c4bd5a227d65f6dbe90715d0234d30b4a",
+        "rev": "59ccbc5c133947d988d416c54add6ee62b10cccc",
         "type": "github"
       },
       "original": {
@@ -513,12 +513,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705677747,
-        "narHash": "sha256-eyM3okYtMgYDgmYukoUzrmuoY4xl4FUujnsv/P6I/zI=",
-        "rev": "bbe7d8f876fbbe7c959c90ba2ae2852220573261",
-        "revCount": 573276,
+        "lastModified": 1705856552,
+        "narHash": "sha256-JXfnuEf5Yd6bhMs/uvM67/joxYKoysyE3M2k6T3eWbg=",
+        "rev": "612f97239e2cc474c13c9dafa0df378058c5ad8d",
+        "revCount": 574351,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.573276%2Brev-bbe7d8f876fbbe7c959c90ba2ae2852220573261/018d28dc-8ce1-71b2-b752-28895ab7bbcb/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.574351%2Brev-612f97239e2cc474c13c9dafa0df378058c5ad8d/018d3085-aff0-7a0b-ab80-1a9c414de8cd/source.tar.gz"
       },
       "original": {
         "type": "tarball",


### PR DESCRIPTION
| Commit                                                                                          | Message                         |
| ----------------------------------------------------------------------------------------------- | ------------------------------- |
| [`59ccbc5c`](https://github.com/chaotic-cx/nyx/commit/59ccbc5c133947d988d416c54add6ee62b10cccc) | `` Bump 20240123-1 (#558) ``    |
| [`faad4691`](https://github.com/chaotic-cx/nyx/commit/faad469131e78f786e8a8f5aaf94ed5c91457933) | `` Bump 20240122-1 (#557) ``    |
| [`85687e4e`](https://github.com/chaotic-cx/nyx/commit/85687e4ec7deb6e0aa2a7af1564d14dcb73b35aa) | `` failures: update ``          |
| [`b31ec348`](https://github.com/chaotic-cx/nyx/commit/b31ec348c7ee639a2e5765a35f78247c5e63dee2) | `` nixpkgs: bump to 20240122 `` |