### PR TITLE
chore(flake/emacs-overlay): `3566704a` -> `e2953343`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1705783124,
-        "narHash": "sha256-OK9WJGd/b4VSZ/d5v3xm9E2YoVwJx/PDN26EHrQv5Ic=",
+        "lastModified": 1706000038,
+        "narHash": "sha256-QytIgkH0wEV2SlW0qttfINEyXPuD7o22W6ZzUceT6z4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3566704a6769341e5a84c49a28b545b26759e23f",
+        "rev": "e2953343aa80377bb1f486f46ef5553b5570753e",
         "type": "github"
       },
       "original": {
@@ -558,11 +558,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1705641746,
-        "narHash": "sha256-D6c2aH8HQbWc7ZWSV0BUpFpd94ImFyCP8jFIsKQ4Slg=",
+        "lastModified": 1705774713,
+        "narHash": "sha256-j6ADaDH9XiumUzkTPlFyCBcoWYhO83lfgiSqEJF2zcs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2003f2223cbb8cd95134e4a0541beea215c1073",
+        "rev": "1b64fc1287991a9cce717a01c1973ef86cb1af0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`e2953343`](https://github.com/nix-community/emacs-overlay/commit/e2953343aa80377bb1f486f46ef5553b5570753e) | `` Updated melpa ``        |
| [`0ba82576`](https://github.com/nix-community/emacs-overlay/commit/0ba825768579730f1db48b74245e9948df3875db) | `` Updated emacs ``        |
| [`7f898abe`](https://github.com/nix-community/emacs-overlay/commit/7f898abe4a56b56b9f5b13dec1af0132b1950642) | `` Updated melpa ``        |
| [`e58b822a`](https://github.com/nix-community/emacs-overlay/commit/e58b822a7c3de3e2445982da0630eb5dbd58e72d) | `` Updated elpa ``         |
| [`d87c4688`](https://github.com/nix-community/emacs-overlay/commit/d87c4688208b04e4c1d49090ce19a46eb6031209) | `` Updated emacs ``        |
| [`f2304fe5`](https://github.com/nix-community/emacs-overlay/commit/f2304fe5b19fd1554a977eaf905cd82bd6186f0e) | `` Updated nongnu ``       |
| [`6474bb55`](https://github.com/nix-community/emacs-overlay/commit/6474bb55cdc31790ce7911a501689b3099985c09) | `` Updated melpa ``        |
| [`90b1750b`](https://github.com/nix-community/emacs-overlay/commit/90b1750b38194c49eb99a9074b6fc7f24956fd4b) | `` Updated emacs ``        |
| [`207d3343`](https://github.com/nix-community/emacs-overlay/commit/207d3343f36c098cefab8c920a67309e436b3243) | `` Updated elpa ``         |
| [`7906c257`](https://github.com/nix-community/emacs-overlay/commit/7906c2578426d2f0dfc42d4a585896f38f5f8731) | `` Updated flake inputs `` |
| [`83731bc2`](https://github.com/nix-community/emacs-overlay/commit/83731bc2f68f485e843534da607f374f75b4f0bd) | `` Updated melpa ``        |
| [`48fa5dcf`](https://github.com/nix-community/emacs-overlay/commit/48fa5dcf1a3b3d412aad5fb54440d01c357c5265) | `` Updated emacs ``        |
| [`ee992c3b`](https://github.com/nix-community/emacs-overlay/commit/ee992c3b9fac56c40e79c958e5241250feccd336) | `` Updated melpa ``        |
| [`7ead5922`](https://github.com/nix-community/emacs-overlay/commit/7ead5922cd7e28b488040ae600ab079578220b3e) | `` Updated elpa ``         |
| [`8f9a6e38`](https://github.com/nix-community/emacs-overlay/commit/8f9a6e38cb3c57dad69656722474f38dd301d898) | `` Updated emacs ``        |
| [`cfc3478a`](https://github.com/nix-community/emacs-overlay/commit/cfc3478a947fd0296e9d834269bb77f9814d9de3) | `` Updated flake inputs `` |
| [`3135b0f4`](https://github.com/nix-community/emacs-overlay/commit/3135b0f49fab65ff105d0a6f6eeceae184b335cb) | `` Updated elpa ``         |
| [`79e0d240`](https://github.com/nix-community/emacs-overlay/commit/79e0d24045abb888a0c1e039c5c8c7349162bc28) | `` Updated melpa ``        |
| [`2595ca99`](https://github.com/nix-community/emacs-overlay/commit/2595ca99db800f3be0759aae85d0cf44a231732c) | `` Updated emacs ``        |
| [`340aa2c0`](https://github.com/nix-community/emacs-overlay/commit/340aa2c0aa86961ed4cc818885e245660d6bc611) | `` Updated melpa ``        |
| [`eb1e63bf`](https://github.com/nix-community/emacs-overlay/commit/eb1e63bfb52352f35edc63d39b70ad4a186e132c) | `` Updated elpa ``         |
| [`19aeab9b`](https://github.com/nix-community/emacs-overlay/commit/19aeab9b06a80467836db74d673421027f29bf3f) | `` Updated emacs ``        |
| [`446a8bee`](https://github.com/nix-community/emacs-overlay/commit/446a8bee5f191ec899ba7eb33c507a3187146d2a) | `` Updated nongnu ``       |
| [`c4615217`](https://github.com/nix-community/emacs-overlay/commit/c4615217bce56ec45cff6be1a91bba17ac4b4de0) | `` Updated flake inputs `` |