### PR TITLE
chore(flake/nixpkgs): `b4ee3c3c` -> `0e0b1629`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -590,11 +590,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1705692095,
-        "narHash": "sha256-iJazHf0FQjuIplTEvDHMkByxQD1kyCp4Cm78krkf3N8=",
+        "lastModified": 1705978183,
+        "narHash": "sha256-p8M+ifmGRApkMG5M3t2OFJF38+FJq8VElZtEQm1utP4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b4ee3c3cc4b63315702e09858f6b517bdd249b3f",
+        "rev": "0e0b16295676114d2994db7f620b52d7958dc33c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                                                                                                     |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| [`9a3de614`](https://github.com/NixOS/nixpkgs/commit/9a3de614d10160f7a726028b04e3319186b6722d) | `` python311Packages.snakemake-interface-executor-plugins: 8.1.3 -> 8.2.0 ``                                                                                                                |
| [`87dc5782`](https://github.com/NixOS/nixpkgs/commit/87dc5782747be7f21a3cee89b452dd78d929480d) | `` python311Packages.scikit-hep-testdata: 0.4.35 -> 0.4.37 ``                                                                                                                               |
| [`651865ce`](https://github.com/NixOS/nixpkgs/commit/651865ce9432f7050c0e62edee6d5a375ff06bd1) | `` assemblyscript: 0.27.22 -> 0.27.23 ``                                                                                                                                                    |
| [`de87abd7`](https://github.com/NixOS/nixpkgs/commit/de87abd74ba2e318c49762863cf2ab63f9bccb63) | `` changed dlib to actually use cuda properly and switched back to default blas and added lapack to make it easier to override, removed fftw because dlib hasn't supported it since 2015 `` |
| [`a0f64838`](https://github.com/NixOS/nixpkgs/commit/a0f64838742007baf781df782593a2477df3f33b) | `` python311Packages.posthog: 3.3.1 -> 3.3.2 ``                                                                                                                                             |
| [`9b892673`](https://github.com/NixOS/nixpkgs/commit/9b89267338b9616aeb6b8b421f1680d5b143ab37) | `` python310Packages.pyradios: 2.0.0 -> 2.1.0 ``                                                                                                                                            |
| [`242faeff`](https://github.com/NixOS/nixpkgs/commit/242faeffee2b2baad68c18b472d7999a13d52701) | `` iotop-c: add meta.mainProgram ``                                                                                                                                                         |
| [`5a3295ae`](https://github.com/NixOS/nixpkgs/commit/5a3295ae4deb3e7d7fff83649b6d93b211f48441) | `` python311Packages.requests-download: rename from requests_download ``                                                                                                                    |
| [`65342bb7`](https://github.com/NixOS/nixpkgs/commit/65342bb7a0d1031c28024f59acd1bde71bf32134) | `` python311Packages.readme-renderer: rename from readme_renderer (#279385) ``                                                                                                              |
| [`ccfd5465`](https://github.com/NixOS/nixpkgs/commit/ccfd5465e68b18387efb47cf4f9be5a04120e71d) | `` hydra_unstable: drop patch ``                                                                                                                                                            |
| [`08c95629`](https://github.com/NixOS/nixpkgs/commit/08c95629950342c4d2185b82a59aec2226f38b96) | `` keepalived: add myself as a maintainer ``                                                                                                                                                |
| [`52792a13`](https://github.com/NixOS/nixpkgs/commit/52792a13e0c399530ef2a39049b013ef05459c81) | `` python311Packages.cantools: 39.4.2 -> 39.4.3 ``                                                                                                                                          |
| [`101c590b`](https://github.com/NixOS/nixpkgs/commit/101c590b9c8d12af368d313fce6dcfea8662ecf5) | `` minio-client: 2024-01-05T05-04-32Z -> 2024-01-18T07-03-39Z ``                                                                                                                            |
| [`f0c83f6c`](https://github.com/NixOS/nixpkgs/commit/f0c83f6c52d23189db562096fda16e379ec26b7c) | `` cargo-zigbuild: 0.18.1 -> 0.18.2 ``                                                                                                                                                      |
| [`5ff0ef51`](https://github.com/NixOS/nixpkgs/commit/5ff0ef514f4a5f69213f933b54474bc83f231bd6) | `` foxotron: fetch assimp patches to fix build ``                                                                                                                                           |
| [`a11aeadf`](https://github.com/NixOS/nixpkgs/commit/a11aeadf0aed0434bfd58123a5a54e4561c1ffa8) | `` norminette: 3.3.54 -> 3.3.55 ``                                                                                                                                                          |
| [`95ca2cc0`](https://github.com/NixOS/nixpkgs/commit/95ca2cc04ead0607fecfee46f5f0f5ca8ae3dd74) | `` ugrep: 4.5.1 -> 4.5.2 ``                                                                                                                                                                 |
| [`c1191815`](https://github.com/NixOS/nixpkgs/commit/c11918156df91996f1f6693414e205e6d882309a) | `` prometheus-pushgateway: 1.6.2 -> 1.7.0 (#282708) ``                                                                                                                                      |
| [`522c89c3`](https://github.com/NixOS/nixpkgs/commit/522c89c3705be4fde6be9a60d483b83078fdcf77) | `` melonDS: 0.9.5 -> 0.9.5-unstable-2024-01-17 (#282620) ``                                                                                                                                 |
| [`177fddd4`](https://github.com/NixOS/nixpkgs/commit/177fddd4e9ce761d184f47501777a37f0eb22583) | `` esphome: 2023.12.5 -> 2023.12.8 ``                                                                                                                                                       |
| [`d6fc2bf1`](https://github.com/NixOS/nixpkgs/commit/d6fc2bf14900ab4a625fbd85e5eed8d7e7c3236f) | `` linux/hardened/patches/6.6: 6.6.12-hardened1 -> 6.6.13-hardened1 ``                                                                                                                      |
| [`c909e231`](https://github.com/NixOS/nixpkgs/commit/c909e231a284bdf8788636aa4177dc6de407cfb5) | `` linux/hardened/patches/6.1: 6.1.73-hardened1 -> 6.1.74-hardened1 ``                                                                                                                      |
| [`34076dea`](https://github.com/NixOS/nixpkgs/commit/34076dea4272ef0ef6fea0e862a0981142133f22) | `` linux_testing: 6.7 -> 6.8-rc1 ``                                                                                                                                                         |
| [`bc39fabc`](https://github.com/NixOS/nixpkgs/commit/bc39fabc394be072cffec2b9fd9e1a4e506bdea9) | `` protolint: 0.47.4 -> 0.47.5 ``                                                                                                                                                           |
| [`a687b236`](https://github.com/NixOS/nixpkgs/commit/a687b236ebf98d3be3a58b7727a2b4d84fad3f72) | `` python311Packages.willow: 1.7.0 -> 1.8.0 ``                                                                                                                                              |
| [`1ed8d340`](https://github.com/NixOS/nixpkgs/commit/1ed8d34097074e3a38c672c6f6fe20d1b5b42662) | `` shopware-cli: 0.4.5 -> 0.4.13 ``                                                                                                                                                         |
| [`e21414ed`](https://github.com/NixOS/nixpkgs/commit/e21414ed30ed545b9a396dd9264cc8dfa51b7af9) | `` innernet: 1.6.0 -> 1.6.1 ``                                                                                                                                                              |
| [`08358891`](https://github.com/NixOS/nixpkgs/commit/08358891f524ad1a38f1d0e103339bdd15821427) | `` boxed-cpp: 1.1.0 -> 1.2.0 ``                                                                                                                                                             |
| [`6de0d929`](https://github.com/NixOS/nixpkgs/commit/6de0d9293e441dd05bda7346c0daaa856f1a341f) | `` Revert "Dovecot: Do not include empty sieve_extensions and sieve_global_extensions" ``                                                                                                   |
| [`62204e05`](https://github.com/NixOS/nixpkgs/commit/62204e05fa53a0c567baf10d1c009e6b26874b2e) | `` simulide_1_1_0: use corrected upstream source ``                                                                                                                                         |
| [`f23f877f`](https://github.com/NixOS/nixpkgs/commit/f23f877ff5304685e3b42bf139984e8a212a4327) | `` pypi-mirror: 5.0.2 -> 5.2.0 ``                                                                                                                                                           |
| [`da00cc3e`](https://github.com/NixOS/nixpkgs/commit/da00cc3e65a4603739aab5bc42d7739b0b5fbad6) | `` go-containerregistry: 0.17.0 -> 0.18.0 ``                                                                                                                                                |
| [`9d353905`](https://github.com/NixOS/nixpkgs/commit/9d353905ea94632d19b88c08086234231a8a1879) | `` build-graalvm-native-image: pass whole environment ``                                                                                                                                    |
| [`b1e25837`](https://github.com/NixOS/nixpkgs/commit/b1e25837c231d24b7ba3a0d798ccb4f6c19a0a38) | `` dracula-theme: unstable-2024-01-08 -> unstable-2024-01-16 ``                                                                                                                             |
| [`ea0ae5d2`](https://github.com/NixOS/nixpkgs/commit/ea0ae5d2bc321935cca9997896a5a0eea0560265) | `` tuifimanager: 3.3.1 -> 3.3.5 ``                                                                                                                                                          |
| [`97b2b445`](https://github.com/NixOS/nixpkgs/commit/97b2b4452e5139c21af21daa8140d9bb78d8e750) | `` microsoft-edge: 120.0.2210.77 -> 120.0.2210.144 ``                                                                                                                                       |
| [`c69e1af8`](https://github.com/NixOS/nixpkgs/commit/c69e1af8bf7bd14e8be07621765b0f02bfc96791) | `` cirrus-cli: 0.108.2 -> 0.108.5 ``                                                                                                                                                        |
| [`456b4e4f`](https://github.com/NixOS/nixpkgs/commit/456b4e4faf5e51d7eed5dd557eabff6b42d01295) | `` er-patcher: 1.10-1 -> 1.10.1-1 ``                                                                                                                                                        |
| [`637f9c7a`](https://github.com/NixOS/nixpkgs/commit/637f9c7a1a98004af91ebd01bea549d6ca237dd9) | `` yazi: 0.2.1 -> 0.2.2 ``                                                                                                                                                                  |
| [`80b9bb0f`](https://github.com/NixOS/nixpkgs/commit/80b9bb0f366173837ba8db1c395d81a6983f52fd) | `` matrix-sliding-sync: 0.99.14 -> 0.99.15 ``                                                                                                                                               |
| [`da3587e8`](https://github.com/NixOS/nixpkgs/commit/da3587e8eac8c6f840737832de7c07e3c9238e07) | `` nixos/rl-2405: document NetBox breaking change ``                                                                                                                                        |
| [`02f6897b`](https://github.com/NixOS/nixpkgs/commit/02f6897b88ffe1bdf251234b4cd6eff4ea213eea) | `` netbox_3_6: mark as EOL ``                                                                                                                                                               |
| [`5d2370f8`](https://github.com/NixOS/nixpkgs/commit/5d2370f800bbcb7bf61ab1e71023634cf8ffe48e) | `` netbox_3_5: remove ``                                                                                                                                                                    |
| [`163fed29`](https://github.com/NixOS/nixpkgs/commit/163fed297ed65a24241f190d8e954ce1877f9020) | `` netbox: 3.6.9 -> 3.7.1 ``                                                                                                                                                                |
| [`3628e2ab`](https://github.com/NixOS/nixpkgs/commit/3628e2abece651c5fff73d9bed8c638360c21feb) | `` python311Packages.homeassistant-stubs: 2024.1.3 -> 2024.1.5 ``                                                                                                                           |
| [`b5a67fce`](https://github.com/NixOS/nixpkgs/commit/b5a67fce9e61519754540aedeca5468b91f7c3e8) | `` home-assistant: 2024.1.3 -> 2024.1.5 ``                                                                                                                                                  |
| [`9e77e78f`](https://github.com/NixOS/nixpkgs/commit/9e77e78f342f3358c28810c7dd1642956effa9b8) | `` python311Packages.snakemake-interface-common: 1.15.0 -> 1.15.1 ``                                                                                                                        |
| [`7e5ed397`](https://github.com/NixOS/nixpkgs/commit/7e5ed397206fe7675321f1bb2341050ca528e5a7) | `` cargo-deny: 0.14.3 -> 0.14.7 ``                                                                                                                                                          |
| [`11e38137`](https://github.com/NixOS/nixpkgs/commit/11e38137294143580e55eb609c261617fba7acb6) | `` eigenmath: unstable-2023-12-31 -> unstable-2024-01-22 ``                                                                                                                                 |
| [`cd424a3d`](https://github.com/NixOS/nixpkgs/commit/cd424a3df3f6d3404e920acd9a3517fa3bc1eb69) | `` dcnnt: 0.9.0 -> 0.9.2 ``                                                                                                                                                                 |
| [`905fa507`](https://github.com/NixOS/nixpkgs/commit/905fa5072a90ca1818b5ad0fe131eb053188f10c) | `` vscodium: 1.85.1.23348 -> 1.85.2.24019 ``                                                                                                                                                |
| [`34bef506`](https://github.com/NixOS/nixpkgs/commit/34bef506f14784779eb9413b6d9f5d0234a8dabc) | `` vals: 0.32.0 -> 0.33.0 ``                                                                                                                                                                |
| [`9ad625fd`](https://github.com/NixOS/nixpkgs/commit/9ad625fdfaa022f0fd0f20c30a928757a489a11b) | `` openmolcas: fix pyparsing >= 3.11 compatibility ``                                                                                                                                       |
| [`cf3391dc`](https://github.com/NixOS/nixpkgs/commit/cf3391dc01a777532e24bac97f8027dcc570ceeb) | `` ncncd: unstable-2023-10-26 -> unstable-2024-01-16 ``                                                                                                                                     |
| [`4e6a53c6`](https://github.com/NixOS/nixpkgs/commit/4e6a53c699384e5780995cf9354440e450fb10fc) | `` element-{web,desktop}: 1.11.54 -> 1.11.55 ``                                                                                                                                             |
| [`bfcffb6b`](https://github.com/NixOS/nixpkgs/commit/bfcffb6b189dc6a7c6f418b4147672a2a156ba94) | `` cinnamon.mint-artwork: 1.7.9 -> 1.8.0 ``                                                                                                                                                 |
| [`90edbf1d`](https://github.com/NixOS/nixpkgs/commit/90edbf1dd4f7fc3f9e4a55f60801e053e739cd16) | `` fstl: 0.9.4 -> 0.10.0 (#264257) ``                                                                                                                                                       |
| [`b21f8d16`](https://github.com/NixOS/nixpkgs/commit/b21f8d1640b707b8b8f9344a5b2fed2aa79ad6f8) | `` circt: 1.62.0 -> 1.63.0 ``                                                                                                                                                               |
| [`a157371e`](https://github.com/NixOS/nixpkgs/commit/a157371e70d10250b8ccacb7b204ad9cc307a585) | `` python312Packages.ipwhois: add patch to fix assertEquals usage ``                                                                                                                        |
| [`3cc1080a`](https://github.com/NixOS/nixpkgs/commit/3cc1080ae795ffcb0ee87146703aed2ecb65aa07) | `` files-cli: 2.12.22 -> 2.12.24 ``                                                                                                                                                         |
| [`7e5c58c2`](https://github.com/NixOS/nixpkgs/commit/7e5c58c2aa2c71f2f39d96361d396dde72fcc329) | `` sd-local: 1.0.51 -> 1.0.52 ``                                                                                                                                                            |
| [`015e8591`](https://github.com/NixOS/nixpkgs/commit/015e8591162994deff934bae8066988d8404795d) | `` nats-server: 2.10.7 -> 2.10.9 ``                                                                                                                                                         |
| [`1b7e4347`](https://github.com/NixOS/nixpkgs/commit/1b7e43471ff88438d84aedf0f37bd71f5e909920) | `` doc: remove misleading kernel.features explanation ``                                                                                                                                    |
| [`35812652`](https://github.com/NixOS/nixpkgs/commit/35812652598f54e8b151a7e514efc28654ff55e5) | `` linux: remove unused features ``                                                                                                                                                         |
| [`ae517a39`](https://github.com/NixOS/nixpkgs/commit/ae517a39412aba963b7e67134e6e14f49a6b3450) | `` mailmanPackages.python3.pkgs.redis: 4.5.4 -> 4.6.0 ``                                                                                                                                    |
| [`a5d263af`](https://github.com/NixOS/nixpkgs/commit/a5d263af016a25e2af980b9b07ef1df95b1008c7) | `` mailman-web: 0.0.6 -> 0.0.8 ``                                                                                                                                                           |
| [`7d1649fc`](https://github.com/NixOS/nixpkgs/commit/7d1649fca82fa043f2dcc131e9f6989c2a4913f6) | `` mailmanPackages.postorius: 1.3.8 -> 1.3.10 ``                                                                                                                                            |
| [`f5804016`](https://github.com/NixOS/nixpkgs/commit/f5804016bb9594e407a251b23c0b0a4787b0960a) | `` mailman: 3.3.8 -> 3.3.9 ``                                                                                                                                                               |
| [`78b9406b`](https://github.com/NixOS/nixpkgs/commit/78b9406b417a39ddb726dd4727bf085eca910a5d) | `` mailmanPackages.hyperkitty: 1.3.7 -> 1.3.8 ``                                                                                                                                            |
| [`c3b2d5e5`](https://github.com/NixOS/nixpkgs/commit/c3b2d5e5dbece88527804ad7c211fa34e336f88b) | `` mailman: remove obsolete substitution ``                                                                                                                                                 |
| [`7016fa45`](https://github.com/NixOS/nixpkgs/commit/7016fa4559aa71b6ede2b680bc18b2491b187f85) | `` mailmanPackages.hyperkitty: remove obsolete patches ``                                                                                                                                   |
| [`633473f6`](https://github.com/NixOS/nixpkgs/commit/633473f6cb25de9061163bc005f0967d659b9c2c) | `` b4: 0.12.3 -> 0.12.4 ``                                                                                                                                                                  |
| [`7e525278`](https://github.com/NixOS/nixpkgs/commit/7e5252786a3682aa186e6bfc13724a0bd0ef901d) | `` patatt: 0.6.2 -> 0.6.3 ``                                                                                                                                                                |
| [`372513f6`](https://github.com/NixOS/nixpkgs/commit/372513f630ee8ecdc8e91ecb9e35c42f739fb773) | `` nixos/buildbot: don't require network-online.target ``                                                                                                                                   |
| [`ce241ad1`](https://github.com/NixOS/nixpkgs/commit/ce241ad18fc328e8dba4a9164803ba67d19c929f) | `` balena-cli: 17.4.11 -> 17.4.12 ``                                                                                                                                                        |
| [`91ea2e05`](https://github.com/NixOS/nixpkgs/commit/91ea2e05abf7ef7d660f439fd1a97fd81677e408) | `` homepage-dashboard: 0.8.4 -> 0.8.6 ``                                                                                                                                                    |
| [`2f6981d6`](https://github.com/NixOS/nixpkgs/commit/2f6981d6e155129a5f9963e789e04a4b20b5ce58) | `` build-graalvm-native-image: do not use NATIVE_IMAGE_DEPRECATED_BUILDER_SANITATION ``                                                                                                     |
| [`acde56f5`](https://github.com/NixOS/nixpkgs/commit/acde56f5eb5354ab3467f7cd848d91a92de35c04) | `` node-manta: 5.4.1 -> 5.4.2 ``                                                                                                                                                            |
| [`54221e26`](https://github.com/NixOS/nixpkgs/commit/54221e26f9627eb05446347110eaac7a363b820c) | `` seaweedfs: 3.61 -> 3.62 ``                                                                                                                                                               |
| [`4eead0f5`](https://github.com/NixOS/nixpkgs/commit/4eead0f5ef488b1b2b60ec6fe3d7384983c42789) | `` bsnes-hd: pull upstream `gcc-13` fix ``                                                                                                                                                  |
| [`5e38bc96`](https://github.com/NixOS/nixpkgs/commit/5e38bc968c769269fcc3ef07665ddf7a26a25d12) | `` jackett: 0.21.1510 -> 0.21.1588 ``                                                                                                                                                       |
| [`81681c8d`](https://github.com/NixOS/nixpkgs/commit/81681c8d404c1dc059d1b2428f52dd9f09649197) | `` pg_activity: 3.0.3 -> 3.4.2 ``                                                                                                                                                           |
| [`53456b8d`](https://github.com/NixOS/nixpkgs/commit/53456b8d047c8f3d362e145a926453992a86ea9f) | `` tuba: 0.6.1 -> 0.6.2 ``                                                                                                                                                                  |
| [`4cfdbc7b`](https://github.com/NixOS/nixpkgs/commit/4cfdbc7b72c177f5c5a044da10c5483be374bb50) | `` postfix: 3.8.4 -> 3.8.5 ``                                                                                                                                                               |
| [`85c32658`](https://github.com/NixOS/nixpkgs/commit/85c32658d9b1311159b1c9996a0fbd07da1da438) | `` xe-guest-utilities: 8.3.1 -> 8.4.0 ``                                                                                                                                                    |
| [`16168763`](https://github.com/NixOS/nixpkgs/commit/1616876309f28777b155ce079684179000d35466) | `` zsh-prezto: unstable-2023-11-30 -> unstable-2024-01-18 ``                                                                                                                                |
| [`e576ff79`](https://github.com/NixOS/nixpkgs/commit/e576ff796702664005f05c5bf89b0ff679d7f3d0) | `` percollate: 4.0.4 -> 4.0.5 ``                                                                                                                                                            |
| [`b06aeee2`](https://github.com/NixOS/nixpkgs/commit/b06aeee2a088d84f1ff3e9d2f12bdc77bcacf069) | `` babashka: 1.3.186 -> 1.3.188 ``                                                                                                                                                          |
| [`7d317c0b`](https://github.com/NixOS/nixpkgs/commit/7d317c0b75ccf69620e61320b44a0f29d1699f1e) | `` goflow2: 2.1.1 -> 2.1.2 (#282835) ``                                                                                                                                                     |
| [`fb2e3625`](https://github.com/NixOS/nixpkgs/commit/fb2e36252a37c9d3ab324a7e80ba0def895b10e1) | `` python311Packages.githubkit: 0.10.7 -> 0.11.0 ``                                                                                                                                         |
| [`bea4776f`](https://github.com/NixOS/nixpkgs/commit/bea4776f99cd8ac57c12bd0327b2063bd69353e9) | `` elixir-ls: 0.18.1 -> 0.19.0 ``                                                                                                                                                           |
| [`4d6fbe11`](https://github.com/NixOS/nixpkgs/commit/4d6fbe110203104afb3a799af41c88cdb55e3381) | `` fuc: 1.1.10 -> 2.0.0 ``                                                                                                                                                                  |