### PR TITLE
chore(flake/chaotic): `59ccbc5c` -> `05858851`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1706010186,
-        "narHash": "sha256-HrTA0Wl+1SB1WTMNGhgXvNYr9RV2WgPcYmjP7R8weeI=",
+        "lastModified": 1706278412,
+        "narHash": "sha256-qdbKtbEHpnBgrdP6gCG97bHJv5rpVLwcwpI4eSJgm3k=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "59ccbc5c133947d988d416c54add6ee62b10cccc",
+        "rev": "05858851fcf6b687534c4a15d735b87309687cbd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                           |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
| [`05858851`](https://github.com/chaotic-cx/nyx/commit/05858851fcf6b687534c4a15d735b87309687cbd) | `` Bump 20240126-1 (#563) ``                                      |
| [`5c1df573`](https://github.com/chaotic-cx/nyx/commit/5c1df57391b39bf0880e7b3b9209e4f37e19fcde) | `` Bump 20240125-1 (#562) ``                                      |
| [`c6b611eb`](https://github.com/chaotic-cx/nyx/commit/c6b611eb70016efec73ec1d669089b8d5b331da1) | `` firefox_nightly: apply branding to binary and desktop unity `` |
| [`a2f122f1`](https://github.com/chaotic-cx/nyx/commit/a2f122f12a6408731e39c89fe053983b2f888a75) | `` Bump 20240124-2 (#561) ``                                      |
| [`4109ba5d`](https://github.com/chaotic-cx/nyx/commit/4109ba5d4ae58687d010d39bd37415c5f27a836e) | `` ci: prevent docs failures from deploying ``                    |
| [`e6f42a03`](https://github.com/chaotic-cx/nyx/commit/e6f42a03d44c9bee8ef288bc02913879441f61c3) | `` docs: fix eval ``                                              |
| [`447f04a7`](https://github.com/chaotic-cx/nyx/commit/447f04a76daef41c4b0933e95514d393d44ac5d0) | `` Bump 20240124-1 (#560) ``                                      |
| [`2c9c7f43`](https://github.com/chaotic-cx/nyx/commit/2c9c7f43fc292dbdea1f0982b7ee1bfad5282ba9) | `` Bump 20240123-2 (#559) ``                                      |