### PR TITLE
chore(flake/emacs-overlay): `e2953343` -> `d8b97372`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706000038,
-        "narHash": "sha256-QytIgkH0wEV2SlW0qttfINEyXPuD7o22W6ZzUceT6z4=",
+        "lastModified": 1706375167,
+        "narHash": "sha256-ScJ/hSeivguoMOos/rsbuvY1bekMffPID53ShqFTp0Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e2953343aa80377bb1f486f46ef5553b5570753e",
+        "rev": "d8b97372ee6f5024ef715da603e40a62cc1f9703",
         "type": "github"
       },
       "original": {
@@ -558,11 +558,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1705774713,
-        "narHash": "sha256-j6ADaDH9XiumUzkTPlFyCBcoWYhO83lfgiSqEJF2zcs=",
+        "lastModified": 1706098335,
+        "narHash": "sha256-r3dWjT8P9/Ah5m5ul4WqIWD8muj5F+/gbCdjiNVBKmU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1b64fc1287991a9cce717a01c1973ef86cb1af0b",
+        "rev": "a77ab169a83a4175169d78684ddd2e54486ac651",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                        |
| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
| [`d8b97372`](https://github.com/nix-community/emacs-overlay/commit/d8b97372ee6f5024ef715da603e40a62cc1f9703) | `` Updated emacs ``                                                            |
| [`f33d4946`](https://github.com/nix-community/emacs-overlay/commit/f33d4946fa34a82e9c0580ab95813445b6659da3) | `` Updated elpa ``                                                             |
| [`44a03f57`](https://github.com/nix-community/emacs-overlay/commit/44a03f57c31e3fb4323410988389278a4f2f7999) | `` Updated emacs ``                                                            |
| [`e0252ec4`](https://github.com/nix-community/emacs-overlay/commit/e0252ec480bc1e09b95f0fd044921972dfca45aa) | `` Updated emacs ``                                                            |
| [`27805cce`](https://github.com/nix-community/emacs-overlay/commit/27805ccec0cd57b4dd2e6768f9df769d3e62ca77) | `` Updated elpa ``                                                             |
| [`77ab1e5b`](https://github.com/nix-community/emacs-overlay/commit/77ab1e5b58f46c48b78e47bcd3d727459740cb57) | `` Updated flake inputs ``                                                     |
| [`89ef4839`](https://github.com/nix-community/emacs-overlay/commit/89ef483952c2f5d1a4d8e52be846a6c20fd6be64) | `` Updated emacs ``                                                            |
| [`fe9774e2`](https://github.com/nix-community/emacs-overlay/commit/fe9774e2308a9efbfb83c1f1c0b69d9db3581649) | `` Updated elpa ``                                                             |
| [`babae500`](https://github.com/nix-community/emacs-overlay/commit/babae500c2bca610eb38e17a1ef1bf0f70beb29e) | `` Updated emacs ``                                                            |
| [`6d9de841`](https://github.com/nix-community/emacs-overlay/commit/6d9de8417bab707a31f75a9c7a633e581c387385) | `` Updated emacs ``                                                            |
| [`a05080ae`](https://github.com/nix-community/emacs-overlay/commit/a05080ae009d2725536f028bc1ac47aedd2344b0) | `` Updated melpa ``                                                            |
| [`fc034627`](https://github.com/nix-community/emacs-overlay/commit/fc0346276e0e2a5abd5bbb9535d96f4ba4d4482c) | `` Updated elpa ``                                                             |
| [`f955f653`](https://github.com/nix-community/emacs-overlay/commit/f955f65318caf28da81fe80f5437c6446dbfa7a3) | `` Updated emacs ``                                                            |
| [`ac7a6bb9`](https://github.com/nix-community/emacs-overlay/commit/ac7a6bb962205862337d8034b04c98d6059f604d) | `` Updated elpa ``                                                             |
| [`b141adfd`](https://github.com/nix-community/emacs-overlay/commit/b141adfd12559af3a9fb73f9ba6a70703e4abc25) | `` Updated flake inputs ``                                                     |
| [`1da43661`](https://github.com/nix-community/emacs-overlay/commit/1da43661dec36a276fbae4c4c78f79c3a084328d) | `` Revert "repos/emacs: Only instantiate derivations on update, dont build" `` |
| [`f551c97d`](https://github.com/nix-community/emacs-overlay/commit/f551c97d8bb48bd7fe95bc6819f64e8aada4d76e) | `` Revert "repos/emacs: And also remove no-out-link" ``                        |
| [`dd5d758f`](https://github.com/nix-community/emacs-overlay/commit/dd5d758f69dd1ae6d0399763aa73ca34974ce9e3) | `` Updated emacs ``                                                            |
| [`cefc21a7`](https://github.com/nix-community/emacs-overlay/commit/cefc21a743a96cf996c4f09e141317e74e7ae794) | `` Updated melpa ``                                                            |
| [`fdd86a5e`](https://github.com/nix-community/emacs-overlay/commit/fdd86a5eb908203d3bac9f694960508a8182b601) | `` Updated elpa ``                                                             |
| [`5b427ea1`](https://github.com/nix-community/emacs-overlay/commit/5b427ea16e8c0e9510d1afcd98bb1e7f51ef8f07) | `` Updated emacs ``                                                            |
| [`fca275c0`](https://github.com/nix-community/emacs-overlay/commit/fca275c0dad55e519073df9552ccb34dd1fc08fc) | `` Updated nongnu ``                                                           |
| [`697e5806`](https://github.com/nix-community/emacs-overlay/commit/697e580696334fa0d85276b98f484e03fa88dc83) | `` Updated melpa ``                                                            |
| [`e3b7bb7f`](https://github.com/nix-community/emacs-overlay/commit/e3b7bb7fffddec090d20fc805aa9717a550b7d5a) | `` Updated elpa ``                                                             |
| [`0d6e23e8`](https://github.com/nix-community/emacs-overlay/commit/0d6e23e87da95a64b1f4aa871bddd1640708c767) | `` Updated emacs ``                                                            |
| [`46d30fde`](https://github.com/nix-community/emacs-overlay/commit/46d30fdef02008e5f1856d4039a0b48d20a3bca6) | `` Updated melpa ``                                                            |
| [`3cdb6ec1`](https://github.com/nix-community/emacs-overlay/commit/3cdb6ec1b4c537b72395f9f09f5a573f80315166) | `` Updated emacs ``                                                            |
| [`24b4024a`](https://github.com/nix-community/emacs-overlay/commit/24b4024af8327b64067d97dd9d98e635ffd9beca) | `` Updated melpa ``                                                            |
| [`71b38b13`](https://github.com/nix-community/emacs-overlay/commit/71b38b1324939cd53b0b3c31d4a82aec238ae1af) | `` Updated elpa ``                                                             |
| [`0c3c8702`](https://github.com/nix-community/emacs-overlay/commit/0c3c87020fcca200978143698e85d5846a47bb2c) | `` Updated emacs ``                                                            |
| [`ea1f9f60`](https://github.com/nix-community/emacs-overlay/commit/ea1f9f60b6530698e2340c7798229355500bbfb2) | `` Revert "Try removing the bytecomp-revert.patch" ``                          |
| [`d6772c6c`](https://github.com/nix-community/emacs-overlay/commit/d6772c6c105d28dcd1f7763aa507b9cdddee249c) | `` Try removing the bytecomp-revert.patch ``                                   |
| [`b47e82db`](https://github.com/nix-community/emacs-overlay/commit/b47e82dbcfdfa4b6ce844565707b51fde1b58988) | `` Updated melpa ``                                                            |
| [`1060b97c`](https://github.com/nix-community/emacs-overlay/commit/1060b97c199bf5abff50bf09c7983250e749d884) | `` Updated elpa ``                                                             |
| [`cfbcb6f4`](https://github.com/nix-community/emacs-overlay/commit/cfbcb6f4cdf4a206bc3bf51abb6b5c7f27700932) | `` Updated emacs ``                                                            |
| [`667d22e0`](https://github.com/nix-community/emacs-overlay/commit/667d22e0dd361093efa024dfe30fd1b3334676b3) | `` Updated flake inputs ``                                                     |