### PR TITLE
chore(flake/home-manager): `3df2a80f` -> `b2f56952`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -287,11 +287,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706001011,
-        "narHash": "sha256-J7Bs9LHdZubgNHZ6+eE/7C18lZ1P6S5/zdJSdXFItI4=",
+        "lastModified": 1706306660,
+        "narHash": "sha256-lZvgkHtVeduGByPb0Tz9LpAi4olfkEm8XPgv0o7GRsk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3df2a80f3f85f91ea06e5e91071fa74ba92e5084",
+        "rev": "b2f56952074cb46e93902ecaabfb04dd93733434",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`b2f56952`](https://github.com/nix-community/home-manager/commit/b2f56952074cb46e93902ecaabfb04dd93733434) | `` network-manager-applet: add XDG data directory ``         |
| [`690764d2`](https://github.com/nix-community/home-manager/commit/690764d2dcfccf01ddfc9f19220c88182339f40f) | `` firefox: Reimplement FF native messaging ``               |
| [`c7ce343d`](https://github.com/nix-community/home-manager/commit/c7ce343d9bf1a329056a4dd5b32ea8cc43b55e15) | `` home-manager: add extendModules attribute ``              |
| [`c82e52b0`](https://github.com/nix-community/home-manager/commit/c82e52b0d96eb9f1c8334add871dce8e837d043b) | `` flake.lock: Update ``                                     |
| [`03958aff`](https://github.com/nix-community/home-manager/commit/03958aff4415a5278d0ea462db370e9d770e904e) | `` firefox: add default containers ``                        |
| [`70688f19`](https://github.com/nix-community/home-manager/commit/70688f195a294a09d31d6bfe339bb090d443e949) | `` keepassx: remove module ``                                |
| [`6359d40f`](https://github.com/nix-community/home-manager/commit/6359d40f6ec0b72a38e02b333f343c3d4929ec10) | `` firefox: implement native messaging hosts ``              |
| [`e8481103`](https://github.com/nix-community/home-manager/commit/e84811035d7c8ec79ed6c687a97e19e2a22123c1) | `` treewide: deprecate `VERBOSE_ECHO` ``                     |
| [`190c6f46`](https://github.com/nix-community/home-manager/commit/190c6f46090a62ad025828bd8e16799d8fcdab1e) | `` home-manager: avoid running empty `nix profile remove` `` |
| [`42567290`](https://github.com/nix-community/home-manager/commit/425672900691a16a897fc47b4d5c3013d2a822a0) | `` treewide: deprecate `DRY_RUN_CMD` and `DRY_RUN_NULL` ``   |
| [`6b28ab2d`](https://github.com/nix-community/home-manager/commit/6b28ab2d798c1c84e24053d95f4ee1dd9d81e2fb) | `` tealdeer: add cache update activation script ``           |