### PR TITLE
chore(flake/treefmt-nix): `9d458726` -> `fbef7c77`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -783,11 +783,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705910240,
-        "narHash": "sha256-Mt29QigQALm2YODaidHHokyNew1TxcRVpBBPV3HifKk=",
+        "lastModified": 1706285206,
+        "narHash": "sha256-3WWX6fckgMsFFOmYCuCRJqnLKFB2L3rS2EF6amD+Fp8=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "9d458726fed1cc00e48031bb7214dfa3c16b7a0f",
+        "rev": "fbef7c773be115ed33f37e97256a9e8f6312b925",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                   |
| ---------------------------------------------------------------------------------------------------- | ------------------------- |
| [`dfb3d0ef`](https://github.com/numtide/treefmt-nix/commit/dfb3d0efb0e141b28edd7182613c7ff5a9f87bae) | `` formatjson5: init ``   |
| [`e3282e0b`](https://github.com/numtide/treefmt-nix/commit/e3282e0b197d229a04c2ac1861c0a32c69d0bf83) | `` flake.lock: Update ``  |
| [`3139f18e`](https://github.com/numtide/treefmt-nix/commit/3139f18ee5cf16ea2b291a717c06f1e66df3e908) | `` add fourmolu (#153) `` |
| [`23f601bf`](https://github.com/numtide/treefmt-nix/commit/23f601bfdef75e21fe8854e24a043bb642201794) | `` add cljfmt (#152) ``   |