### PR TITLE
chore(flake/spicetify-nix): `61d83fc5` -> `f842a134`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -703,11 +703,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705983050,
-        "narHash": "sha256-rfb3kCoJFpD6rU7ZrYV6fUalaurvw+oowV5fwpLo26w=",
+        "lastModified": 1706328557,
+        "narHash": "sha256-kpoSI9Y1KNsFLC6lBZG4isU9HHpCrKoAT5oBtO6ycRU=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "61d83fc5ab4c982e45c823d60069a1c49b1b2a38",
+        "rev": "f842a1348f7f04e2a93d22bfec81f49923b9b0ec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`f842a134`](https://github.com/Gerg-L/spicetify-nix/commit/f842a1348f7f04e2a93d22bfec81f49923b9b0ec) | `` CI update 2024-01-27 (#56) `` |
| [`9ae31ca7`](https://github.com/Gerg-L/spicetify-nix/commit/9ae31ca7136965be977333b2ada37fb108951993) | `` CI update 2024-01-26 (#55) `` |
| [`c7db5485`](https://github.com/Gerg-L/spicetify-nix/commit/c7db5485125f8138fd3f22f001aeceb77fcca937) | `` CI update 2024-01-25 (#54) `` |
| [`3b33eeb0`](https://github.com/Gerg-L/spicetify-nix/commit/3b33eeb07c539e1bf39cb814187a1539a745ccd8) | `` CI update 2024-01-24 (#53) `` |