### PR TITLE
chore(flake/nixpkgs): `0e0b1629` -> `7ac72b3e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -590,11 +590,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1705978183,
-        "narHash": "sha256-p8M+ifmGRApkMG5M3t2OFJF38+FJq8VElZtEQm1utP4=",
+        "lastModified": 1706275741,
+        "narHash": "sha256-53O2JHFdDTWHzTfLkZRAZVAk9ntChFhcTTnAtj6bJKE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0e0b16295676114d2994db7f620b52d7958dc33c",
+        "rev": "7ac72b3ee2af9bab80d66addd9b237277cc975c5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                   |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
| [`07e7fcc4`](https://github.com/NixOS/nixpkgs/commit/07e7fcc46fcedf1f63c68c33a3b68ef521ebe2cf) | `` nixos/test-driver: black ``                                                            |
| [`c251abe9`](https://github.com/NixOS/nixpkgs/commit/c251abe9b45ec5d7883472586d4ca8d54ed28fb0) | `` virtualbox: Edit description ``                                                        |
| [`ad38e641`](https://github.com/NixOS/nixpkgs/commit/ad38e641cdd25bcbe37a1b01ebe65973b2457ef0) | `` yubioath-flutter: 6.2.0 -> 6.3.1 ``                                                    |
| [`deaea6d2`](https://github.com/NixOS/nixpkgs/commit/deaea6d218e0be563c5cdb762b5dd3b1ffaee8e8) | `` yubioath-flutter: fix double wrapping ``                                               |
| [`1f4fea5a`](https://github.com/NixOS/nixpkgs/commit/1f4fea5a41f481b09db119955502f67557ece5ea) | `` python311Packages.dissect: add new modules ``                                          |
| [`cd309fd2`](https://github.com/NixOS/nixpkgs/commit/cd309fd2321ec01c96f7675097891048bba8f6d4) | `` python311Packages.dissect-clfs: 1.1 -> 1.6 ``                                          |
| [`5d9974aa`](https://github.com/NixOS/nixpkgs/commit/5d9974aafe8d52eee0d14316990ff12f36abe8c3) | `` python312Packages.dissect-jffs: init at 1.0 ``                                         |
| [`c0c961fe`](https://github.com/NixOS/nixpkgs/commit/c0c961fe5152b81a0ab67575169ae64876593d32) | `` python312Packages.dissect-btrfs: init at 1.1 ``                                        |
| [`c659d365`](https://github.com/NixOS/nixpkgs/commit/c659d3651676c4b170b3151143d3b1d139e0776e) | `` mawk: 1.3.4-20230525 -> 1.3.4-20240123 ``                                              |
| [`f873eed3`](https://github.com/NixOS/nixpkgs/commit/f873eed3b0b9e46c7bb4f3dc03703282acb4d696) | `` tclx: 8.6.2 -> 8.6.3 ``                                                                |
| [`9e1cdfac`](https://github.com/NixOS/nixpkgs/commit/9e1cdfac659bbe1c244e679d7e57c6c541894929) | `` python312Packages.python-lzo: 1.15 -> 1.16 ``                                          |
| [`7c59d70b`](https://github.com/NixOS/nixpkgs/commit/7c59d70ba0ac200954412131335ffbd481ef7c8b) | `` vscode-extensions.quicktype.quicktype: init at 12.0.46 ``                              |
| [`64a3677e`](https://github.com/NixOS/nixpkgs/commit/64a3677ed036ebbf8b48c018077da6e7a44392fe) | `` python311Packages.dissect-target: relax flow-record ``                                 |
| [`9a050d1f`](https://github.com/NixOS/nixpkgs/commit/9a050d1f392fe5d994a67b68ebe41f9018df2c3c) | `` gotestwaf: refactor ``                                                                 |
| [`0c8e9eab`](https://github.com/NixOS/nixpkgs/commit/0c8e9eabb1c5334104cc62c0f9f391f0da8d7fdd) | `` geoserver: 2.24.1 -> 2.24.2 ``                                                         |
| [`3f97f7af`](https://github.com/NixOS/nixpkgs/commit/3f97f7afedcd2dc83056a2693f8e25c0c9e9890f) | `` ocamlPackages.type_eq: init at 0.0.1 ``                                                |
| [`2d2dfe7e`](https://github.com/NixOS/nixpkgs/commit/2d2dfe7e7bd51b8dfff995eaffef33a599722c0d) | `` gotestwaf: 0.4.9 -> 0.4.10 ``                                                          |
| [`ddb85af9`](https://github.com/NixOS/nixpkgs/commit/ddb85af914f9664c85fecdc5adffa2207031d665) | `` python311Packages.yara-python: 4.3.1 -> 4.4.0 ``                                       |
| [`0f51210d`](https://github.com/NixOS/nixpkgs/commit/0f51210defe4e6c0f56f9fe52737ca04507cd208) | `` cargo-fuzz: use hash instead of sha256 ``                                              |
| [`837e599d`](https://github.com/NixOS/nixpkgs/commit/837e599dfa28465431400b5797e39a1b9934b13d) | `` minijinja: init at 1.0.12 ``                                                           |
| [`69031a7a`](https://github.com/NixOS/nixpkgs/commit/69031a7a04687b8efb34c279bd9dde1f65067fd7) | `` cargo-fuzz: 0.11.3 -> 0.11.4 ``                                                        |
| [`af1f72b0`](https://github.com/NixOS/nixpkgs/commit/af1f72b0fb09a603f35d7b2b50db53bf1047b38d) | `` timg: 1.5.3 -> 1.6.0 ``                                                                |
| [`35e9b830`](https://github.com/NixOS/nixpkgs/commit/35e9b830cd5ba282ddb2f1a81cdab61f80142463) | `` gitlab: 16.7.2 -> 16.7.4 ``                                                            |
| [`13764a1a`](https://github.com/NixOS/nixpkgs/commit/13764a1a1659309f5371daf3db007cf3388de6fd) | `` python311Packages.geometric: 1.0.1 -> 1.0.2 ``                                         |
| [`e264cdc3`](https://github.com/NixOS/nixpkgs/commit/e264cdc38b2fc9e110054d5598fbc11bc6d65da3) | `` linux_6_1: 6.1.74 -> 6.1.75 ``                                                         |
| [`f8f2cdd2`](https://github.com/NixOS/nixpkgs/commit/f8f2cdd2c7a9f9dd779b6e79d2bfcb09d863185c) | `` linux_6_6: 6.6.13 -> 6.6.14 ``                                                         |
| [`02c63fa7`](https://github.com/NixOS/nixpkgs/commit/02c63fa701bcf043bc5bdd166b5229857d1ffbee) | `` linux_6_7: 6.7.1 -> 6.7.2 ``                                                           |
| [`d5e11b7d`](https://github.com/NixOS/nixpkgs/commit/d5e11b7d9a8303fe2e49e2ef042791e7db7ae823) | `` f3d: 2.2.1 -> 2.3.0 ``                                                                 |
| [`ce77b53f`](https://github.com/NixOS/nixpkgs/commit/ce77b53f1a812aca689056e8c25a58479fdd0cb7) | `` f3d.meta.maintainers: add pbsds ``                                                     |
| [`e5970be7`](https://github.com/NixOS/nixpkgs/commit/e5970be7e321f05c34dacf62353c26e27f93955d) | `` f3d: build manpage ``                                                                  |
| [`eaf845cf`](https://github.com/NixOS/nixpkgs/commit/eaf845cf05cbbda06bc94866feb3db4e053638fd) | `` f3d: unbreak with autoPatchelfHook ``                                                  |
| [`8f2a52aa`](https://github.com/NixOS/nixpkgs/commit/8f2a52aaf681eb66cd20beb1d648c9f1a9fddf9f) | `` zarf: 0.32.1 -> 0.32.2 ``                                                              |
| [`f61c0114`](https://github.com/NixOS/nixpkgs/commit/f61c0114078e09d9c2955232b627263c25f28c9f) | `` ants: 2.5.0 -> 2.5.1 ``                                                                |
| [`62d3ddff`](https://github.com/NixOS/nixpkgs/commit/62d3ddffaf4ce3f9c28cf66ccd0e67c8cd986c6d) | `` kn: 1.12.0 -> 1.13.0 ``                                                                |
| [`48c6ae52`](https://github.com/NixOS/nixpkgs/commit/48c6ae52914242b1244f4d22cd499adf2479f719) | `` sentry-cli: 2.25.2 -> 2.26.0 ``                                                        |
| [`40df2c36`](https://github.com/NixOS/nixpkgs/commit/40df2c36fe82e9f9b4c1a65acd3132d78f54b3a1) | `` xpipe: 1.7.14 -> 1.7.16 ``                                                             |
| [`914bb49f`](https://github.com/NixOS/nixpkgs/commit/914bb49f4ef2f66c8a4644aaf075ae4150481178) | `` bpftrace: 0.19.1 -> 0.20.0 ``                                                          |
| [`249fef32`](https://github.com/NixOS/nixpkgs/commit/249fef32c42e19fb3f2a914a7688fe45bf9b664c) | `` linux_5_15: 5.15.147 -> 5.15.148 ``                                                    |
| [`bf749233`](https://github.com/NixOS/nixpkgs/commit/bf749233db2d4292d41b0f56287eebd799962cd8) | `` linux_4_19: 4.19.305 -> 4.19.306 ``                                                    |
| [`214ce1fd`](https://github.com/NixOS/nixpkgs/commit/214ce1fd7a1e1271361b7efd8c7252606148e7f9) | `` linux_5_4: 5.4.267 -> 5.4.268 ``                                                       |
| [`749faf66`](https://github.com/NixOS/nixpkgs/commit/749faf660911f685822a2eeaee948fc32e41b025) | `` linux_5_10: 5.10.208 -> 5.10.209 ``                                                    |
| [`058d77ca`](https://github.com/NixOS/nixpkgs/commit/058d77caf3e0305023417982c3fbd4246b95282f) | `` python311Packages.tabcmd: refactor ``                                                  |
| [`9eec2753`](https://github.com/NixOS/nixpkgs/commit/9eec27532dad203e079c26aaa52ae86e09a314cf) | `` python311Packages.tableauserverclient: 0.29 -> 0.30 ``                                 |
| [`5baf8c43`](https://github.com/NixOS/nixpkgs/commit/5baf8c431d238af817d0609f0c4629d00e76c41e) | `` python311Packages.tableauserverclient: fix issue with versioneer ``                    |
| [`aa09da2c`](https://github.com/NixOS/nixpkgs/commit/aa09da2cf552037b7957a22752aba706d3a3c486) | `` python311Packages.crontab: init at 0.23.0 ``                                           |
| [`60c32585`](https://github.com/NixOS/nixpkgs/commit/60c32585c5ea0e9f330577a4f62afcdb89f14a20) | `` python311Packages.gitlike-commands: add patch to replace distutils ``                  |
| [`02c9c3cc`](https://github.com/NixOS/nixpkgs/commit/02c9c3ccbd9fafd3d1d24536cab196a365c7b365) | `` tippecanoe: 2.41.0 -> 2.41.2 ``                                                        |
| [`ecfba593`](https://github.com/NixOS/nixpkgs/commit/ecfba593f23e06a96d6e2cf7d6df8d1012c46eb4) | `` blender: unpin llvmPackages_10 ``                                                      |
| [`fdd7755f`](https://github.com/NixOS/nixpkgs/commit/fdd7755f9373f15856a3582596bed0d9a028fb41) | `` nominatim: Add pyosmium to the dependencies ``                                         |
| [`e6b1cb3c`](https://github.com/NixOS/nixpkgs/commit/e6b1cb3cd0e442da35b6d44b7658bd75fbbb44d3) | `` python311Packages.ed25519-blake2b: 1.4 -> 1.4.1 ``                                     |
| [`adac00ce`](https://github.com/NixOS/nixpkgs/commit/adac00cee24ff2e97a4a12293cdaf6fb2147e9b5) | `` python311Packages.ed25519-blake2b: refactor ``                                         |
| [`b911a567`](https://github.com/NixOS/nixpkgs/commit/b911a5675f99edc46b61bc797ce93c678526494b) | `` python311Packages.dvc-data: 3.8.0 -> 3.9.0 ``                                          |
| [`0d85bf0e`](https://github.com/NixOS/nixpkgs/commit/0d85bf0efed41a37feb2f61a702a15a83427f348) | `` nixos/systemd: Temporarily bring back multi-user -> network-online ``                  |
| [`01038b59`](https://github.com/NixOS/nixpkgs/commit/01038b59a3995167341f031e92faff555b8992b2) | `` python311Packages.azure-mgmt-security: 5.0.0 -> 6.0.0 ``                               |
| [`b2c535cd`](https://github.com/NixOS/nixpkgs/commit/b2c535cdba428d9648c29f3d7c921f213f4a6ff7) | `` python311Packages.azure-mgmt-recoveryservicesbackup: 7.0.0 -> 9.0.0 ``                 |
| [`2bc361cc`](https://github.com/NixOS/nixpkgs/commit/2bc361ccfb9093991fba56313ebde96f6a844a5e) | `` python311Packages.azure-mgmt-containerservice: 28.0.0 -> 29.0.0 ``                     |
| [`f67b36ba`](https://github.com/NixOS/nixpkgs/commit/f67b36bad67f1cf683a61cf6ac98e12d3b5a6532) | `` Revert "patchelf_0_13: init at 0.13.1" ``                                              |
| [`f84fc976`](https://github.com/NixOS/nixpkgs/commit/f84fc97618ee022326c7b9778e78372aecb45574) | `` Revert "patchelf: use 0.13.x on aarch64+musl" ``                                       |
| [`26a9e8a0`](https://github.com/NixOS/nixpkgs/commit/26a9e8a0c6846475eae6817a7f16157b59d1ff21) | `` Revert "pkgsMusl.coreutils: fix build on aarch64" ``                                   |
| [`7554724a`](https://github.com/NixOS/nixpkgs/commit/7554724a36f9ea5b067526880b994ef1ab1df075) | `` Revert "diffutils: disable tests on aarch64 musl" ``                                   |
| [`cea1ed8e`](https://github.com/NixOS/nixpkgs/commit/cea1ed8e8e8497a07af1f8ecf474b1dd8be0b5bc) | `` python311Packages.authheaders: 0.15.3 -> 0.16.2 ``                                     |
| [`2780b940`](https://github.com/NixOS/nixpkgs/commit/2780b940dcd11770e95689b53a9447a855ccc763) | `` python311Packages.aiosql: 9.2 -> 9.3 ``                                                |
| [`14f4f21b`](https://github.com/NixOS/nixpkgs/commit/14f4f21bd93dc0af7dab8d60c220b07979be420f) | `` python311Packages.aiocomelit: 0.7.4 -> 0.8.2 ``                                        |
| [`bf718f60`](https://github.com/NixOS/nixpkgs/commit/bf718f6081d4771e1cd6ca20f0b035be713c3087) | `` python311Packages.python-kasa: 0.6.0.1 -> 0.6.1 ``                                     |
| [`940f2ca5`](https://github.com/NixOS/nixpkgs/commit/940f2ca565ee138558cbaca51e107b44c0b25e94) | `` python311Packages.types-docutils: 0.20.0.20240106 -> 0.20.0.20240125 ``                |
| [`2aac3fb6`](https://github.com/NixOS/nixpkgs/commit/2aac3fb65c3814ab1914e9b33cbd3f312940b9e7) | `` qpdfview: Use lrelease to create translations ``                                       |
| [`55b2ed34`](https://github.com/NixOS/nixpkgs/commit/55b2ed34383c45e6f50762f419093e861ec2d1ca) | `` python311Packages.twilio: 8.11.1 -> 8.12.0 ``                                          |
| [`aba6645d`](https://github.com/NixOS/nixpkgs/commit/aba6645ddba04320ba24ca12c50f14c32c18dde8) | `` python311Packages.pyswitchbot: 0.44.0 -> 0.44.1 ``                                     |
| [`80208b4e`](https://github.com/NixOS/nixpkgs/commit/80208b4ef28d79b14046e8de4f95f29589209d7e) | `` python311Packages.publicsuffixlist: 0.10.0.20240124 -> 0.10.0.20240125 ``              |
| [`631a401e`](https://github.com/NixOS/nixpkgs/commit/631a401eea7ebaa1f9e2d4c06bd579db8bdf99a8) | `` cnspec: 10.0.1 -> 10.0.2 ``                                                            |
| [`cdec3bbb`](https://github.com/NixOS/nixpkgs/commit/cdec3bbbefe6a15422626e26ab697fa5ce871586) | `` python312Packages.botocore-stubs: 1.34.26 -> 1.34.27 ``                                |
| [`5eede924`](https://github.com/NixOS/nixpkgs/commit/5eede924b246e159b38ff52e37efe2253531e23c) | `` python312Packages.boto3-stubs: 1.34.25 -> 1.34.27 ``                                   |
| [`1196ae6e`](https://github.com/NixOS/nixpkgs/commit/1196ae6e6bdc3070402fd0875f8f5b69cb4c4a12) | `` nixos/lib/test-driver: add `wait_for_qmp_event` ``                                     |
| [`f2153c07`](https://github.com/NixOS/nixpkgs/commit/f2153c0774202b1c65f0dcc65ac14455b64dc3af) | `` checkov: 3.1.69 -> 3.1.70 ``                                                           |
| [`ebde9f93`](https://github.com/NixOS/nixpkgs/commit/ebde9f932113ac20bb3526d644e4d3d04a96e9d6) | `` faustlive: unpin llvm, fix build, fix runtime ``                                       |
| [`02cc697a`](https://github.com/NixOS/nixpkgs/commit/02cc697a7c89237ee3d3f4ae0cec116cbff202be) | `` faustlive: reformat ``                                                                 |
| [`43fcbbff`](https://github.com/NixOS/nixpkgs/commit/43fcbbff73af19fb915c3a16682b597e800433bb) | `` nextcloud27: 27.1.5 -> 27.1.6, nextcloud26: 26.0.10 -> 26.0.11 ``                      |
| [`aeda6661`](https://github.com/NixOS/nixpkgs/commit/aeda66611bf84e72e8b5c435455f9f14cd8f761a) | `` Revert "mdevctl: 1.2.0 -> 1.3.0" ``                                                    |
| [`f788080e`](https://github.com/NixOS/nixpkgs/commit/f788080e0481f0df90c1592f4b973d786afd3335) | `` jdt-language-server: Call installlPhase hooks ``                                       |
| [`a3c9b3b6`](https://github.com/NixOS/nixpkgs/commit/a3c9b3b67892f434b65866b358fe7d2fb880ccfb) | `` sage: import scipy 1.12 upgrade patch ``                                               |
| [`c789a320`](https://github.com/NixOS/nixpkgs/commit/c789a3204080c01e5f03df82395745cba1258afb) | `` linuxPackages.nvidiaPackages.vulkan_beta: 535.43.22 -> 535.43.23 ``                    |
| [`f522af71`](https://github.com/NixOS/nixpkgs/commit/f522af717445843162d808c00f8106bdc7d78d31) | `` nixos/release-notes: mention dnsdist DNSCrypt options ``                               |
| [`78bc60b8`](https://github.com/NixOS/nixpkgs/commit/78bc60b8a4c0ffdd7f6161d51f12da231f05483c) | `` nixos/hebbot: init ``                                                                  |
| [`a41bd090`](https://github.com/NixOS/nixpkgs/commit/a41bd09059230be65d4eb767084b87192501f3fe) | `` nixos/tests/dnsdist: test dnscrypt support ``                                          |
| [`1a1b91b3`](https://github.com/NixOS/nixpkgs/commit/1a1b91b3b98cf23a5c30b8383d1b1c0427c0f3eb) | `` nixos/dnsdist: add options for dnscrypt ``                                             |
| [`cc9de162`](https://github.com/NixOS/nixpkgs/commit/cc9de1626bec0e963ea9a5e942449834139fb67d) | `` nixos/tests/dnsdist: use runTest ``                                                    |
| [`ea67e455`](https://github.com/NixOS/nixpkgs/commit/ea67e455d3d59fd80c20169051475f5b84193b8d) | `` stdenvBootstrapTools: update aarch64 musl ``                                           |
| [`fc5879c0`](https://github.com/NixOS/nixpkgs/commit/fc5879c08d4b5017c0d5448511e0fe7d5a4c288a) | `` genimage: 16 -> 17 ``                                                                  |
| [`bbc22ad1`](https://github.com/NixOS/nixpkgs/commit/bbc22ad117e1a55536ee19a6d3b72c743286dba4) | `` supabase-cli: 1.131.2 -> 1.137.2 ``                                                    |
| [`1b7626ec`](https://github.com/NixOS/nixpkgs/commit/1b7626ec30700dcd71c8c2cff9761b8001f537ee) | `` kubecolor: 0.2.0 -> 0.2.2 ``                                                           |
| [`c2d822e6`](https://github.com/NixOS/nixpkgs/commit/c2d822e6b02a7f20c82d22457f3b09ff305001e3) | `` nixos/netbird: Allow running multiple netbird networks in parallel ``                  |
| [`82355260`](https://github.com/NixOS/nixpkgs/commit/8235526030af3b32bbc79d96c45960350b6316a7) | `` maintainers: add applejag ``                                                           |
| [`3cb78237`](https://github.com/NixOS/nixpkgs/commit/3cb78237388c3fa9559458a2b00af7beb57c446b) | `` nixos/mail/dovecot2: warn about potential collision due to structured configuration `` |
| [`cd457d02`](https://github.com/NixOS/nixpkgs/commit/cd457d02e591e9cb20075dbce22ff3d9d3bb13ae) | `` vimPlugins.nvim-treesitter: update grammars ``                                         |
| [`5b38636d`](https://github.com/NixOS/nixpkgs/commit/5b38636d4dd778a1f494824eac354a73fea4756e) | `` vimPlugins: update on 2024-01-25 ``                                                    |
| [`f8e4c856`](https://github.com/NixOS/nixpkgs/commit/f8e4c856bc401cc6bc8be09f29381ad70ea5f13b) | `` python311Packages.litellm: 1.18.3 -> 1.19.0 ``                                         |
| [`e08482a6`](https://github.com/NixOS/nixpkgs/commit/e08482a6017dab669c81b35c1be4dcef19eae19d) | `` doc: update dockerTools.pullImage content and use doc conventions ``                   |
| [`64e86afe`](https://github.com/NixOS/nixpkgs/commit/64e86afe8330bc64f9b7f3a428d72ca202b73b76) | `` python311Packages.pytedee-async: 0.2.11 -> 0.2.12 ``                                   |
| [`a63b9c15`](https://github.com/NixOS/nixpkgs/commit/a63b9c15c9d81cebb9cedc0c7fe767e3ce9589ae) | `` doc: Update manuals bespoke syntax ``                                                  |
| [`f5e1c3b2`](https://github.com/NixOS/nixpkgs/commit/f5e1c3b2da79cef44355cda96c35b77503bf843b) | `` python311Packages.anthropic: 0.7.8 -> 0.11.0 ``                                        |
| [`a731d0cb`](https://github.com/NixOS/nixpkgs/commit/a731d0cb71c58f56895f71a5b02eda2962a46746) | `` doc: update conventions with repl examples and function (in|out)puts ``                |
| [`ad99ac93`](https://github.com/NixOS/nixpkgs/commit/ad99ac9356a875b3e2afbf020a4a7d58f03417dd) | `` doc: Note on how to use shadowSetup with buildLayeredImage (#267220) ``                |
| [`1cbd2ac8`](https://github.com/NixOS/nixpkgs/commit/1cbd2ac8f8174b90c1a4aa12230f59a6eb7c3690) | `` doc: Fix typo in dotnet.section.md (#282685) ``                                        |
| [`848f5183`](https://github.com/NixOS/nixpkgs/commit/848f518363131449752a53d191276f661e22b5ee) | `` doc: add types to template (#281220) ``                                                |
| [`c1e253de`](https://github.com/NixOS/nixpkgs/commit/c1e253de2279a6881b2d9d24b61decf7165c5a7a) | `` eza: 0.17.2 -> 0.17.3 ``                                                               |
| [`9afc0c14`](https://github.com/NixOS/nixpkgs/commit/9afc0c14cb6da107c46aba61ffbb81c0b05dfd0a) | `` naev: 0.11.2 -> 0.11.3 ``                                                              |
| [`65fc44c3`](https://github.com/NixOS/nixpkgs/commit/65fc44c341f5b438260a198b6ee2cf6e50bd2e4c) | `` haskell.compiler.ghc8102Binary: remove at 8.10.2 ``                                    |
| [`e94d6f86`](https://github.com/NixOS/nixpkgs/commit/e94d6f865ddc7adf75c1a7781946114415d77f3a) | `` await: init at 0.999 ``                                                                |
| [`d7d7e123`](https://github.com/NixOS/nixpkgs/commit/d7d7e123b332b4da5008fdcc56253c437e1387ff) | `` nodePackages.volar: add meta.mainProgram ``                                            |
| [`354d2267`](https://github.com/NixOS/nixpkgs/commit/354d2267d2d84d88ae4ecf17b4c155f905523c10) | `` terraform: 1.7.0 -> 1.7.1 (#283693) ``                                                 |