### PR TITLE
chore(flake/flake-parts): `07f63952` -> `60c61400`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -175,11 +175,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704982712,
-        "narHash": "sha256-2Ptt+9h8dczgle2Oo6z5ni5rt/uLMG47UFTR1ry/wgg=",
+        "lastModified": 1706569497,
+        "narHash": "sha256-oixb0IDb5eZYw6BaVr/R/1pSoMh4rfJHkVnlgeRIeZs=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "07f6395285469419cf9d078f59b5b49993198c00",
+        "rev": "60c614008eed1d0383d21daac177a3e036192ed8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                                          |
| -------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`b60b914a`](https://github.com/hercules-ci/flake-parts/commit/b60b914ac6f706bdb6e55c0eadeffa732a60bd16) | `` dev: Make the test slightly more sensible ``  |
| [`14114c56`](https://github.com/hercules-ci/flake-parts/commit/14114c563acab4cee2828aa8dad9036d617e1ea2) | `` templates: make flake-parts input explicit `` |
| [`238b0dc9`](https://github.com/hercules-ci/flake-parts/commit/238b0dc94b068a32530e8675425d22753d4af343) | `` apps: Add polyfill ``                         |
| [`562a6b5e`](https://github.com/hercules-ci/flake-parts/commit/562a6b5e54193e32c9819903c166cf211072e46c) | `` dev: Test apps ``                             |
| [`acd542d1`](https://github.com/hercules-ci/flake-parts/commit/acd542d16b086b2aeb823c090bf6121e7a1af12b) | `` apps: use lib.getExe to find executable ``    |