### PR TITLE
chore(flake/home-manager): `b2f56952` -> `d634c3ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -287,11 +287,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706306660,
-        "narHash": "sha256-lZvgkHtVeduGByPb0Tz9LpAi4olfkEm8XPgv0o7GRsk=",
+        "lastModified": 1706473109,
+        "narHash": "sha256-iyuAvpKTsq2u23Cr07RcV5XlfKExrG8gRpF75hf1uVc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b2f56952074cb46e93902ecaabfb04dd93733434",
+        "rev": "d634c3abafa454551f2083b054cd95c3f287be61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`d634c3ab`](https://github.com/nix-community/home-manager/commit/d634c3abafa454551f2083b054cd95c3f287be61) | `` tealdeer: add option to toggle update on activation `` |
| [`4d54c29b`](https://github.com/nix-community/home-manager/commit/4d54c29bce71f8c261513e0662cc573d30f3e33e) | `` home-manager: remove the export of `run` ``            |
| [`ebba24a6`](https://github.com/nix-community/home-manager/commit/ebba24a6fefa3d749291be7192ef817736a10bd1) | `` wob: add module ``                                     |
| [`7a461c70`](https://github.com/nix-community/home-manager/commit/7a461c70ed20e7e4a2af1710fdfb89ec70473e47) | `` firefox: fix darwin NativeMessagingHostsPath ``        |
| [`e5f2a059`](https://github.com/nix-community/home-manager/commit/e5f2a0590a9387e17e6433b280e45d14f82683b4) | `` flake.lock: Update (#4964) ``                          |