### PR TITLE
chore(flake/emacs-overlay): `d8b97372` -> `2d69eefb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706375167,
-        "narHash": "sha256-ScJ/hSeivguoMOos/rsbuvY1bekMffPID53ShqFTp0Y=",
+        "lastModified": 1706691967,
+        "narHash": "sha256-ADKh/Vss8ITblcLDl/LUM6GqJOahBktu4EXzhv7Uxbs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d8b97372ee6f5024ef715da603e40a62cc1f9703",
+        "rev": "2d69eefbcadbac97bda477477cd53c0ef815f436",
         "type": "github"
       },
       "original": {
@@ -556,11 +556,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1706098335,
-        "narHash": "sha256-r3dWjT8P9/Ah5m5ul4WqIWD8muj5F+/gbCdjiNVBKmU=",
+        "lastModified": 1706515015,
+        "narHash": "sha256-eFfY5A7wlYy3jD/75lx6IJRueg4noE+jowl0a8lIlVo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a77ab169a83a4175169d78684ddd2e54486ac651",
+        "rev": "f4a8d6d5324c327dcc2d863eb7f3cc06ad630df4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`2d69eefb`](https://github.com/nix-community/emacs-overlay/commit/2d69eefbcadbac97bda477477cd53c0ef815f436) | `` Updated emacs ``        |
| [`33e73c7e`](https://github.com/nix-community/emacs-overlay/commit/33e73c7e349b88ca393b5613c2b230cb82154eac) | `` Updated melpa ``        |
| [`45ee2dda`](https://github.com/nix-community/emacs-overlay/commit/45ee2dda7788c6f6adab331b904495f1fd95ae7e) | `` Updated flake inputs `` |
| [`6ed1948d`](https://github.com/nix-community/emacs-overlay/commit/6ed1948db6bf8b21ba2d25b3e2d9a45c0176b166) | `` Updated emacs ``        |
| [`4f8c4bbe`](https://github.com/nix-community/emacs-overlay/commit/4f8c4bbe1684ec4c6799454b89c66a439cb79433) | `` Updated melpa ``        |
| [`c1d91c19`](https://github.com/nix-community/emacs-overlay/commit/c1d91c199c6408abd286e7f65a89e3c246ece16d) | `` Updated elpa ``         |
| [`d34f17e6`](https://github.com/nix-community/emacs-overlay/commit/d34f17e62858894d8dbfd75c238dec79e5c0c62f) | `` Updated flake inputs `` |
| [`eb3071f9`](https://github.com/nix-community/emacs-overlay/commit/eb3071f959d2c4bd6eccd2176d43f33ccfbfb3b1) | `` Updated emacs ``        |
| [`630458ac`](https://github.com/nix-community/emacs-overlay/commit/630458acbc94c79af0c4eb26dd9ac26532e31d5a) | `` Updated melpa ``        |
| [`00418d6b`](https://github.com/nix-community/emacs-overlay/commit/00418d6b797f9cf85245cd014a6df4617961bcfe) | `` Updated elpa ``         |
| [`4224d726`](https://github.com/nix-community/emacs-overlay/commit/4224d7269955e4cab294384f7ba8daed73810946) | `` Updated emacs ``        |
| [`276530c6`](https://github.com/nix-community/emacs-overlay/commit/276530c68ca828bf33d2af230f73fe8a49778209) | `` Updated melpa ``        |
| [`392cb00f`](https://github.com/nix-community/emacs-overlay/commit/392cb00f9e019b9ec1ef4eb530ac0cfb2ddd32e3) | `` Updated emacs ``        |
| [`b7295450`](https://github.com/nix-community/emacs-overlay/commit/b7295450764fe32f3e478e31c4121bf05a6bc8a5) | `` Updated melpa ``        |
| [`de3f66c6`](https://github.com/nix-community/emacs-overlay/commit/de3f66c6abccf36c44a642b4dfa48d6326d0292e) | `` Updated elpa ``         |
| [`248e2664`](https://github.com/nix-community/emacs-overlay/commit/248e26643010de9f5dd61d4c4d592b72c6f2d16f) | `` Updated nongnu ``       |
| [`bf073f54`](https://github.com/nix-community/emacs-overlay/commit/bf073f540fd96d1c5f3faf56a7f4664c8bb49ede) | `` Updated emacs ``        |
| [`9f6d6ca6`](https://github.com/nix-community/emacs-overlay/commit/9f6d6ca61c8cf8cc39c2436d538a39d64720f4f7) | `` Updated melpa ``        |
| [`a9a8e422`](https://github.com/nix-community/emacs-overlay/commit/a9a8e422dffc94c697fb2f5495fbc83b6c64de59) | `` Updated elpa ``         |
| [`b22256e6`](https://github.com/nix-community/emacs-overlay/commit/b22256e6623d78a850143a4f381a3175432b7388) | `` Updated nongnu ``       |
| [`bc9d133f`](https://github.com/nix-community/emacs-overlay/commit/bc9d133ffbbcd1e3fe0ed78016deb1345912890b) | `` Updated flake inputs `` |
| [`380a2b90`](https://github.com/nix-community/emacs-overlay/commit/380a2b909774bc47385dfa9556f28f243ea87c71) | `` Updated emacs ``        |
| [`89b15dc9`](https://github.com/nix-community/emacs-overlay/commit/89b15dc964cd67eeedbeee4d68c5716211cfa0d8) | `` Updated melpa ``        |
| [`bceb8269`](https://github.com/nix-community/emacs-overlay/commit/bceb8269cbe8ed5b80c46dc43c8f5f6b785cbb84) | `` Updated elpa ``         |
| [`7428bf63`](https://github.com/nix-community/emacs-overlay/commit/7428bf63084f80df50a57903ce020dfac0b50128) | `` Updated flake inputs `` |
| [`87bfbcd2`](https://github.com/nix-community/emacs-overlay/commit/87bfbcd248f3f17040db47b2cc8542033b12d051) | `` Updated emacs ``        |
| [`eff17f93`](https://github.com/nix-community/emacs-overlay/commit/eff17f93e92eaa9ff77c79c1783d36267ce88450) | `` Updated elpa ``         |
| [`7c2ab8b3`](https://github.com/nix-community/emacs-overlay/commit/7c2ab8b3dc60b7f2d0d492472d0b6f1444712a21) | `` Updated nongnu ``       |
| [`a26ccf07`](https://github.com/nix-community/emacs-overlay/commit/a26ccf07b81aa26a4e7ee4c58f4a0f9d919e642a) | `` Updated emacs ``        |
| [`d6d5dd09`](https://github.com/nix-community/emacs-overlay/commit/d6d5dd09b6533a30e3b312f0f225bd3475733f23) | `` Updated emacs ``        |
| [`d423c8ca`](https://github.com/nix-community/emacs-overlay/commit/d423c8ca41a06c35a733d408c17f733ab8327f0a) | `` Updated elpa ``         |