### PR TITLE
chore(flake/nix-index-database): `f8e04fbc` -> `c782f2a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -472,11 +472,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705806513,
-        "narHash": "sha256-FcOmNjhHFfPz2udZbRpZ1sfyhVMr+C2O8kOxPj+HDDk=",
+        "lastModified": 1706411424,
+        "narHash": "sha256-BzziJYucEZvdCE985vjPoo3ztWcmUiSQ1wJ2CoT6jCc=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "f8e04fbcebcc24cebc91989981bd45f69b963ed7",
+        "rev": "c782f2a4f6fc94311ab5ef31df2f1149a1856181",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`c782f2a4`](https://github.com/nix-community/nix-index-database/commit/c782f2a4f6fc94311ab5ef31df2f1149a1856181) | `` update packages.nix to release 2024-01-28-030920 `` |
| [`2c1a58ea`](https://github.com/nix-community/nix-index-database/commit/2c1a58ea29af0bd3da947c6bb3e7a7704a2f972b) | `` flake.lock: Update ``                               |