### PR TITLE
chore(flake/chaotic): `05858851` -> `204e506f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1706278412,
-        "narHash": "sha256-qdbKtbEHpnBgrdP6gCG97bHJv5rpVLwcwpI4eSJgm3k=",
+        "lastModified": 1706623651,
+        "narHash": "sha256-2L2SbR9y73lImTT6K7X84DvmJUN1Anu6thECJPvcWVU=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "05858851fcf6b687534c4a15d735b87309687cbd",
+        "rev": "204e506f24843d95c415210920160894f1f35fe8",
         "type": "github"
       },
       "original": {
@@ -511,12 +511,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705856552,
-        "narHash": "sha256-JXfnuEf5Yd6bhMs/uvM67/joxYKoysyE3M2k6T3eWbg=",
-        "rev": "612f97239e2cc474c13c9dafa0df378058c5ad8d",
-        "revCount": 574351,
+        "lastModified": 1706371002,
+        "narHash": "sha256-dwuorKimqSYgyu8Cw6ncKhyQjUDOyuXoxDTVmAXq88s=",
+        "rev": "c002c6aa977ad22c60398daaa9be52f2203d0006",
+        "revCount": 576949,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.574351%2Brev-612f97239e2cc474c13c9dafa0df378058c5ad8d/018d3085-aff0-7a0b-ab80-1a9c414de8cd/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.576949%2Brev-c002c6aa977ad22c60398daaa9be52f2203d0006/018d559d-9a3d-7239-b0a8-ac30145ac7f6/source.tar.gz"
       },
       "original": {
         "type": "tarball",


### PR DESCRIPTION
| Commit                                                                                          | Message                                               |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`204e506f`](https://github.com/chaotic-cx/nyx/commit/204e506f24843d95c415210920160894f1f35fe8) | `` scx: 0.1.5 -> 0.1.6 (#569) ``                      |
| [`557d6de2`](https://github.com/chaotic-cx/nyx/commit/557d6de26fd7c7c058e8d96695a54cd3dda341fa) | `` Bump 20240130-1 (#568) ``                          |
| [`b77fec37`](https://github.com/chaotic-cx/nyx/commit/b77fec371eae96f69cdaec9904307c5ffb921f14) | `` linux_cachyos-server: remove HDR patches (#567) `` |
| [`4f188bc0`](https://github.com/chaotic-cx/nyx/commit/4f188bc06fe97d5e9d0e346f2b04bdff7901e87e) | `` builder: fix wrong envvar name ``                  |
| [`ecdc562f`](https://github.com/chaotic-cx/nyx/commit/ecdc562fa2fa1094c4d5283fa1200821a7bd60ff) | `` yuzu-early-access_git: use NX_TZDB_ROMFS_DIR ``    |
| [`0603f3ca`](https://github.com/chaotic-cx/nyx/commit/0603f3cac49bcf39c91ea7b2aaff4ba672523f7a) | `` builder: add known-cached strategy ``              |
| [`3b2fd8bc`](https://github.com/chaotic-cx/nyx/commit/3b2fd8bc363d03fe99c245083fe0ebd2aab0ac76) | `` Bump 20240129-2 (#566) ``                          |
| [`ff8b9e11`](https://github.com/chaotic-cx/nyx/commit/ff8b9e11053c6c6d784029360209263e81cbfef2) | `` nixpkgs: bump to 20240129 ``                       |
| [`494accb2`](https://github.com/chaotic-cx/nyx/commit/494accb2c8116e9d93dd51bd00dbc83acc680158) | `` builder: add dry-build JSON ``                     |
| [`ee174707`](https://github.com/chaotic-cx/nyx/commit/ee17470747a0f6543ab110d83624713a3351e566) | `` failures: update ``                                |
| [`06eed990`](https://github.com/chaotic-cx/nyx/commit/06eed99035244d1abae49aae10c9be78060139cc) | `` qtile-extras_git: rebase for nixpkgs#20240126 ``   |
| [`1b0e8f4a`](https://github.com/chaotic-cx/nyx/commit/1b0e8f4a603ef7c4e2f01aa0b07222f9e25b87d0) | `` nixpkgs: bump to 20240126 ``                       |