### PR TITLE
chore(flake/nix-colors): `37227f27` -> `fc080c51`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -452,11 +452,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1695388192,
-        "narHash": "sha256-2jelpE7xK+4M7jZNyWL7QYOYegQLYBDQS5bvdo8XRUQ=",
+        "lastModified": 1706637303,
+        "narHash": "sha256-K6SqE9diWDCoEQ+MzuVlTfNrAKcdIa/dLHBtKfz445U=",
         "owner": "misterio77",
         "repo": "nix-colors",
-        "rev": "37227f274b34a3b51649166deb94ce7fec2c6a4c",
+        "rev": "fc080c51d2a219b40d886870e364243783ed5ca1",
         "type": "github"
       },
       "original": {
@@ -525,11 +525,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1694911725,
-        "narHash": "sha256-8YqI+YU1DGclEjHsnrrGfqsQg3Wyga1DfTbJrN3Ud0c=",
+        "lastModified": 1697935651,
+        "narHash": "sha256-qOfWjQ2JQSQL15KLh6D7xQhx0qgZlYZTYlcEiRuAMMw=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "819180647f428a3826bfc917a54449da1e532ce0",
+        "rev": "e1e11fdbb01113d85c7f41cada9d2847660e3902",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                 | Message                                         |
| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------- |
| [`fc080c51`](https://github.com/Misterio77/nix-colors/commit/fc080c51d2a219b40d886870e364243783ed5ca1) | `` deprecate schemeToYAML ``                    |
| [`f84b4255`](https://github.com/Misterio77/nix-colors/commit/f84b4255d2c635c97378af20fa704561b9247435) | `` rename kind to variant, colors to palette `` |
| [`0ed6b055`](https://github.com/Misterio77/nix-colors/commit/0ed6b055c3e033cd6cafaa731fbab0b0f6c1e48c) | `` allow custom logo colors (#46) ``            |
| [`da785956`](https://github.com/Misterio77/nix-colors/commit/da785956f62d9197c25cb27fa0325a92e13b7509) | `` bump lock (#40) ``                           |