### PR TITLE
chore(flake/hyprland): `df990c80` -> `e65f52bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -309,11 +309,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1706410805,
-        "narHash": "sha256-uRSL+r0nt172K/29IE2JfabH039UjkMcJ/o93EA2lic=",
+        "lastModified": 1706646126,
+        "narHash": "sha256-VnJBPei9N1wV6GOgZxTtm5X+s5Ek6tLtYkLCKWHKJ/U=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "df990c80e211553fc63136072b0e518860172f2f",
+        "rev": "e65f52bf2d6abb001c402c8302ac7003da8cd06d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                       |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
| [`e65f52bf`](https://github.com/hyprwm/Hyprland/commit/e65f52bf2d6abb001c402c8302ac7003da8cd06d) | `` Makefile: pass PREFIX to CMake ``                                          |
| [`c51b3fb0`](https://github.com/hyprwm/Hyprland/commit/c51b3fb06f48657bcf66a92eca3de04066a9c8ef) | `` events: ignore sending mouse enter to focused if a constraint is active `` |
| [`3ff59e7e`](https://github.com/hyprwm/Hyprland/commit/3ff59e7e1d859daa503b88ef125d087bc100abfe) | `` hyprpm: update global state on plugin recompile not header update ``       |
| [`3d0d3b63`](https://github.com/hyprwm/Hyprland/commit/3d0d3b634332419995799cf5677bd56e6c0d967c) | `` Meson: fix wallpaper installation ``                                       |
| [`2e3f0d59`](https://github.com/hyprwm/Hyprland/commit/2e3f0d5991874edb01f1bfe4ffc75701f8b398dc) | `` renderer: Add new background infrastructure ``                             |
| [`91e8c428`](https://github.com/hyprwm/Hyprland/commit/91e8c428431deac1e5eb8e537f002ab960777174) | `` hyprpm: don't update headers if they are up-to-date, only recompile ``     |
| [`4b4bd90b`](https://github.com/hyprwm/Hyprland/commit/4b4bd90b1450cbfc01d9ac429363cc7cecd6be8b) | `` renderer: fixup misaligned fsv1 surfaces with uv ``                        |
| [`7009dc91`](https://github.com/hyprwm/Hyprland/commit/7009dc9184317b7c68032fd733dfed268bc6c543) | `` nix: fix overlay composition ``                                            |
| [`b7840c64`](https://github.com/hyprwm/Hyprland/commit/b7840c646113af8c14e6e984a6cd29cc812af13f) | `` xwayland: remove delta from pos sets in configureX11 ``                    |
| [`5a90911b`](https://github.com/hyprwm/Hyprland/commit/5a90911b70ab19ea99efe2fa9ab4d8e2153df4eb) | `` hyprpm: verify headersHashCompiled as well in headersValid() ``            |
| [`0e5f14d8`](https://github.com/hyprwm/Hyprland/commit/0e5f14d8d2eb44ed0d8bad4628ab93075155f430) | `` xwayland: remove reportedsize set in unmanagedSetGeometry (#4539) ``       |