### PR TITLE
chore(flake/nur): `81804f94` -> `fab803d7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -620,11 +620,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706399070,
-        "narHash": "sha256-0qCf75Wuwe0qP1zEKLn0PUXRf6VUa4+WkKHjtAOCPps=",
+        "lastModified": 1706686049,
+        "narHash": "sha256-TCuYU/F5uuMDIBcFSm1xi2fYHt1Bit8fYPzIzB7T6HY=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "81804f94bec0198d25a2d2fd9359a46e5d618637",
+        "rev": "fab803d7fa7e066ff6193fe40ba29d2e322835e1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`fab803d7`](https://github.com/nix-community/NUR/commit/fab803d7fa7e066ff6193fe40ba29d2e322835e1) | `` automatic update `` |
| [`7f970ae3`](https://github.com/nix-community/NUR/commit/7f970ae3b784af7e4505ae09780a56a13300a1be) | `` automatic update `` |
| [`9bc44fec`](https://github.com/nix-community/NUR/commit/9bc44feccbc86196b9b6d15e31d4a85efe1abcca) | `` automatic update `` |
| [`72aec480`](https://github.com/nix-community/NUR/commit/72aec4801b982219a2f4b98c41b1b97131917ce0) | `` automatic update `` |
| [`6f1371fe`](https://github.com/nix-community/NUR/commit/6f1371fef7cd2f64e6a9f191350649417c595e44) | `` automatic update `` |
| [`a2756748`](https://github.com/nix-community/NUR/commit/a2756748687453a23348c7d9ee46a11f79403398) | `` automatic update `` |
| [`98930fb5`](https://github.com/nix-community/NUR/commit/98930fb5cf79e652111ed531e6ce777618b1c898) | `` automatic update `` |
| [`93218f25`](https://github.com/nix-community/NUR/commit/93218f250e2d949cecf4efce55c8d4423852aae5) | `` automatic update `` |
| [`152b28e6`](https://github.com/nix-community/NUR/commit/152b28e6796be0de8b2c45876e5692f0746948c6) | `` automatic update `` |
| [`071d505b`](https://github.com/nix-community/NUR/commit/071d505b63297d5b3e358326c00e58ee39c18341) | `` automatic update `` |
| [`c1ff1093`](https://github.com/nix-community/NUR/commit/c1ff109362e22cf30ea1f16edd462100e646e7b7) | `` automatic update `` |
| [`117de70f`](https://github.com/nix-community/NUR/commit/117de70feb65cfdd62f855d8093aacdc51ea930e) | `` automatic update `` |
| [`d5fea764`](https://github.com/nix-community/NUR/commit/d5fea7648ed92a859cb837e5b2331fabe802c0a5) | `` automatic update `` |
| [`f241c228`](https://github.com/nix-community/NUR/commit/f241c228a76c4be5adbfd532760a427aaadf7a90) | `` automatic update `` |
| [`68b210c7`](https://github.com/nix-community/NUR/commit/68b210c7240de86b3639cf9542df9dcb9c504914) | `` automatic update `` |
| [`7d66edbb`](https://github.com/nix-community/NUR/commit/7d66edbb4817023b9bef059d3aeefcd0585c777c) | `` automatic update `` |
| [`07f80cd6`](https://github.com/nix-community/NUR/commit/07f80cd6480e31b8bbe4ed8be90d100af453d750) | `` automatic update `` |
| [`09e9ec2e`](https://github.com/nix-community/NUR/commit/09e9ec2ef914bbcfc547f61242078b9219de0a8e) | `` automatic update `` |
| [`b2cf62d0`](https://github.com/nix-community/NUR/commit/b2cf62d00a5a591f6f288c97d8b22b69df6c7721) | `` automatic update `` |
| [`b9f4941a`](https://github.com/nix-community/NUR/commit/b9f4941ab6f28d520a056ef139bfd96e4ad9e5f6) | `` automatic update `` |
| [`298613e6`](https://github.com/nix-community/NUR/commit/298613e6c804d1798096203f7907deee2bde2d5d) | `` automatic update `` |
| [`0d59dcdf`](https://github.com/nix-community/NUR/commit/0d59dcdfdbaf840996b4240295cf93342590e316) | `` automatic update `` |
| [`d1333968`](https://github.com/nix-community/NUR/commit/d133396849f86db1ddeb3e32ddd01181aaee8e3c) | `` automatic update `` |
| [`ce9c09fb`](https://github.com/nix-community/NUR/commit/ce9c09fbd09d8cccb7353fe32bdfbd39ff3cb7be) | `` automatic update `` |
| [`d7e286c2`](https://github.com/nix-community/NUR/commit/d7e286c21530da5d6da54424d64e15de14f7c07a) | `` automatic update `` |
| [`7256ff5d`](https://github.com/nix-community/NUR/commit/7256ff5dd278dfaf675de442839b51b5b94347c3) | `` automatic update `` |
| [`6ece651b`](https://github.com/nix-community/NUR/commit/6ece651b79e370a0f872c0c9628b84a790d73f88) | `` automatic update `` |
| [`c9046b98`](https://github.com/nix-community/NUR/commit/c9046b986e29d7f0f2c9c4c2575260ee8544403f) | `` automatic update `` |
| [`48bbc63e`](https://github.com/nix-community/NUR/commit/48bbc63ea14b02c77723aff536d0785036d85e1f) | `` automatic update `` |
| [`dcfdf5e5`](https://github.com/nix-community/NUR/commit/dcfdf5e57688fcd44ab72d921f8a4986dc4d6d23) | `` automatic update `` |
| [`55bf2dc6`](https://github.com/nix-community/NUR/commit/55bf2dc692fdf37401bd11e1c1a61e2488e167f7) | `` automatic update `` |
| [`db25a01d`](https://github.com/nix-community/NUR/commit/db25a01deab2b9e4edadbf19f957ae4649a81b36) | `` automatic update `` |
| [`b4d4d180`](https://github.com/nix-community/NUR/commit/b4d4d180c89478e2bf745dc555d8db897e0d3811) | `` automatic update `` |
| [`cfcdba22`](https://github.com/nix-community/NUR/commit/cfcdba22aacb9150ecd7347a4c8576a01a600bb2) | `` automatic update `` |
| [`dabf5222`](https://github.com/nix-community/NUR/commit/dabf5222e6467876462328871860e16a4ccf53ed) | `` automatic update `` |
| [`24478b9e`](https://github.com/nix-community/NUR/commit/24478b9e556e4366ef0a2ff58590d8cf24c77267) | `` automatic update `` |
| [`e08169f2`](https://github.com/nix-community/NUR/commit/e08169f28b322bc3ba164aa2c837bd68475d24ea) | `` automatic update `` |
| [`60358a68`](https://github.com/nix-community/NUR/commit/60358a68c155b8a91d729fb50171f2e29723cfd8) | `` automatic update `` |
| [`af0ee065`](https://github.com/nix-community/NUR/commit/af0ee065b9b7f3415c7ce792078574c9e1b9b307) | `` automatic update `` |
| [`13a7c86f`](https://github.com/nix-community/NUR/commit/13a7c86f96ae7e8d2a53e7d5e526aaf3b9324821) | `` automatic update `` |
| [`24b087fd`](https://github.com/nix-community/NUR/commit/24b087fde8cbdd8642f394c7da5fd538fadf7c7c) | `` automatic update `` |
| [`136f332e`](https://github.com/nix-community/NUR/commit/136f332e3bc7aa6920afec573417e684452c3a6d) | `` automatic update `` |
| [`892517d7`](https://github.com/nix-community/NUR/commit/892517d79c1ddbedaa21f9f204cdfb4a12321360) | `` automatic update `` |
| [`f7d9d8bc`](https://github.com/nix-community/NUR/commit/f7d9d8bc877ab3036ea253dcd50305cc63081bc4) | `` automatic update `` |
| [`4986dcbe`](https://github.com/nix-community/NUR/commit/4986dcbe4ed18f9b23ce078d421b7febaa1d9b09) | `` automatic update `` |
| [`aad9d1d5`](https://github.com/nix-community/NUR/commit/aad9d1d5df0ba43a33b2b931ea11a7d98fb11927) | `` automatic update `` |
| [`e0293b12`](https://github.com/nix-community/NUR/commit/e0293b1268f2f832e0302a2465bf3ec79e1a5d95) | `` automatic update `` |
| [`44cc6d28`](https://github.com/nix-community/NUR/commit/44cc6d28900b3561343793ed40e2f61922267a9a) | `` automatic update `` |
| [`1e782d1d`](https://github.com/nix-community/NUR/commit/1e782d1db5b712e00436d9237a426b4d6ac51615) | `` automatic update `` |
| [`0416c890`](https://github.com/nix-community/NUR/commit/0416c8902949ad6fcfe91af8d9f9efa66bce8bef) | `` automatic update `` |
| [`634a80da`](https://github.com/nix-community/NUR/commit/634a80daf064af9c76b4c3693744df1d20665194) | `` automatic update `` |
| [`ed79ff2b`](https://github.com/nix-community/NUR/commit/ed79ff2bd2b8f96bcbfe01db9c58d5fec0921c81) | `` automatic update `` |
| [`3b667f15`](https://github.com/nix-community/NUR/commit/3b667f154e01d9c01298be604804f4f9f63c9795) | `` automatic update `` |
| [`4229f5a8`](https://github.com/nix-community/NUR/commit/4229f5a8f0c00b374b991c6617a4f36fd915f0a1) | `` automatic update `` |
| [`0777a688`](https://github.com/nix-community/NUR/commit/0777a6886749d6a726d5a3fab0156d5f92969fe6) | `` automatic update `` |
| [`ad66156e`](https://github.com/nix-community/NUR/commit/ad66156e8eab6dd59bbbe8ebe630595820dc4ded) | `` automatic update `` |
| [`4fc5b14c`](https://github.com/nix-community/NUR/commit/4fc5b14cae1e1b4fd6f4ef879a552e1d8c6f868a) | `` automatic update `` |
| [`cba525fe`](https://github.com/nix-community/NUR/commit/cba525fe33906e67fcd872448ba091456cc09f6e) | `` automatic update `` |
| [`183e7b71`](https://github.com/nix-community/NUR/commit/183e7b71b743e6801391e1c86a9529a353768a6b) | `` automatic update `` |
| [`82beb090`](https://github.com/nix-community/NUR/commit/82beb09009e4844811e2f35a7e67c04a215e2730) | `` automatic update `` |
| [`f271bc81`](https://github.com/nix-community/NUR/commit/f271bc81436c96bf40da5100d8c6aa754e5cc403) | `` automatic update `` |
| [`b226cd59`](https://github.com/nix-community/NUR/commit/b226cd59852745bce13dd3ce63c0ced9757e9606) | `` automatic update `` |
| [`082e6f72`](https://github.com/nix-community/NUR/commit/082e6f72dc501e9d01df29b5241f3a182476a945) | `` automatic update `` |
| [`0a68de7b`](https://github.com/nix-community/NUR/commit/0a68de7bb6a21eb68d6c58d715532825645e396b) | `` automatic update `` |
| [`36c9f9c3`](https://github.com/nix-community/NUR/commit/36c9f9c3571a7d3f34885bdebff1959d1ff2c97f) | `` automatic update `` |
| [`488b84b3`](https://github.com/nix-community/NUR/commit/488b84b36347304e6408381636eea97c9392af26) | `` automatic update `` |
| [`55770332`](https://github.com/nix-community/NUR/commit/5577033269154484a3194a9efb82b8f5137e2292) | `` automatic update `` |
| [`4d853e68`](https://github.com/nix-community/NUR/commit/4d853e68ed04ff32af7a53b97fdc5ae9244f040e) | `` automatic update `` |
| [`43c8ffcd`](https://github.com/nix-community/NUR/commit/43c8ffcd58bd718302cbb7ae719ac6e65aac5fae) | `` automatic update `` |
| [`f778c917`](https://github.com/nix-community/NUR/commit/f778c917fc46d2e038ad4645756a132b46b37884) | `` automatic update `` |
| [`f3b2c8dc`](https://github.com/nix-community/NUR/commit/f3b2c8dcff020cb7670bbc597a27a791e3f625fb) | `` automatic update `` |
| [`85bb76d4`](https://github.com/nix-community/NUR/commit/85bb76d48f81dba7a21dfefbc6cbfcddae8988f6) | `` automatic update `` |
| [`ab8cf147`](https://github.com/nix-community/NUR/commit/ab8cf147ee2254ef91e87ff7272524975fcbba3f) | `` automatic update `` |
| [`aa29a73b`](https://github.com/nix-community/NUR/commit/aa29a73b660e5292878c6db313f341bcf6e43895) | `` automatic update `` |