### PR TITLE
chore(flake/spicetify-nix): `f842a134` -> `b65525c6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -717,11 +717,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706328557,
-        "narHash": "sha256-kpoSI9Y1KNsFLC6lBZG4isU9HHpCrKoAT5oBtO6ycRU=",
+        "lastModified": 1706674220,
+        "narHash": "sha256-venc9Ir5gjeIo/qGKRDgIICTFPZY68kB/4LA6XTnFXs=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "f842a1348f7f04e2a93d22bfec81f49923b9b0ec",
+        "rev": "b65525c685b8f5fa9651f971326256071132e222",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`b65525c6`](https://github.com/Gerg-L/spicetify-nix/commit/b65525c685b8f5fa9651f971326256071132e222) | `` CI update 2024-01-31 (#60) `` |
| [`928165ad`](https://github.com/Gerg-L/spicetify-nix/commit/928165aded4b5f7049cc348c42b23820e304b1ca) | `` CI update 2024-01-30 (#59) `` |
| [`50fee704`](https://github.com/Gerg-L/spicetify-nix/commit/50fee70442296ff6c010493cb2e42f4a2a10a3a9) | `` CI update 2024-01-29 (#58) `` |
| [`dd15db63`](https://github.com/Gerg-L/spicetify-nix/commit/dd15db6383872606db74c85c0f765d3ac36e1b03) | `` CI update 2024-01-28 (#57) `` |