### PR TITLE
chore(flake/chaotic): `204e506f` -> `82f97c8a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -21,16 +21,17 @@
         "compare-to": "compare-to",
         "flake-schemas": "flake-schemas",
         "home-manager": "home-manager",
+        "jovian": "jovian",
         "nixpkgs": "nixpkgs",
         "systems": "systems",
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1706623651,
-        "narHash": "sha256-2L2SbR9y73lImTT6K7X84DvmJUN1Anu6thECJPvcWVU=",
+        "lastModified": 1706798619,
+        "narHash": "sha256-U2UYfVYjX3bXnAsv3C98yWcDDlQVmk2eCB0XxDzA20o=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "204e506f24843d95c415210920160894f1f35fe8",
+        "rev": "82f97c8aa5b842be752e65933901cb20506a90bf",
         "type": "github"
       },
       "original": {
@@ -384,6 +385,28 @@
         "type": "github"
       }
     },
+    "jovian": {
+      "inputs": {
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "chaotic",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1706509827,
+        "narHash": "sha256-fnZ8BXDgfvXGwStQvmpUXe+I+Fjd2JCLm8xo0kVwVKc=",
+        "owner": "Jovian-Experiments",
+        "repo": "Jovian-NixOS",
+        "rev": "e2c026d8efea340d2a2dcc56775212979dd51ef2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Jovian-Experiments",
+        "repo": "Jovian-NixOS",
+        "type": "github"
+      }
+    },
     "lanzaboote": {
       "inputs": {
         "crane": "crane",
@@ -465,6 +488,29 @@
         "type": "github"
       }
     },
+    "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "chaotic",
+          "jovian",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1690328911,
+        "narHash": "sha256-fxtExYk+aGf2YbjeWQ8JY9/n9dwuEt+ma1eUFzF8Jeo=",
+        "owner": "zhaofengli",
+        "repo": "nix-github-actions",
+        "rev": "96df4a39c52f53cb7098b923224d8ce941b64747",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zhaofengli",
+        "ref": "matrix-name",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
     "nix-index-database": {
       "inputs": {
         "nixpkgs": [
@@ -511,12 +557,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1706371002,
-        "narHash": "sha256-dwuorKimqSYgyu8Cw6ncKhyQjUDOyuXoxDTVmAXq88s=",
-        "rev": "c002c6aa977ad22c60398daaa9be52f2203d0006",
-        "revCount": 576949,
+        "lastModified": 1706550542,
+        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "revCount": 577948,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.576949%2Brev-c002c6aa977ad22c60398daaa9be52f2203d0006/018d559d-9a3d-7239-b0a8-ac30145ac7f6/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.577948%2Brev-97b17f32362e475016f942bbdfda4a4a72a8a652/018d5e85-4e02-7200-b411-d764d60cd44e/source.tar.gz"
       },
       "original": {
         "type": "tarball",


### PR DESCRIPTION
| Commit                                                                                          | Message                                             |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`82f97c8a`](https://github.com/chaotic-cx/nyx/commit/82f97c8aa5b842be752e65933901cb20506a90bf) | `` jovian-chaotic: init (#574) ``                   |
| [`1b521b24`](https://github.com/chaotic-cx/nyx/commit/1b521b242c693d81855005e60ce82bea16e7a298) | `` ci/build: download "contents" separatedly ``     |
| [`28076944`](https://github.com/chaotic-cx/nyx/commit/28076944020e94d24fd3c9fb3566a7792686a882) | `` builder: download "contents" from cachix ``      |
| [`ebabd4a2`](https://github.com/chaotic-cx/nyx/commit/ebabd4a22142c622ed41d887350bd568df271d1d) | `` Bump 20240201-1 (#573) ``                        |
| [`c6098933`](https://github.com/chaotic-cx/nyx/commit/c609893339987d806a36ffac3f70d05daa080879) | `` libportal_git: init at 20240111193226-4a49716 `` |
| [`cdaa9fd5`](https://github.com/chaotic-cx/nyx/commit/cdaa9fd5372eaf6bf2644e619b5e46ffa9f1f3b5) | `` input-leap_git: fix lack of --use-ei ``          |
| [`cc3b300a`](https://github.com/chaotic-cx/nyx/commit/cc3b300a87bc0ae0178bb88b80c25d34a504eef7) | `` Bump 20240131-2 (#571) ``                        |
| [`65e71ad6`](https://github.com/chaotic-cx/nyx/commit/65e71ad667cf62fd751b723245b8d0f9203c3a15) | `` Bump 20240131-1 (#570) ``                        |