### PR TITLE
chore(flake/flake-parts): `60c61400` -> `b253292d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -175,11 +175,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706569497,
-        "narHash": "sha256-oixb0IDb5eZYw6BaVr/R/1pSoMh4rfJHkVnlgeRIeZs=",
+        "lastModified": 1706830856,
+        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "60c614008eed1d0383d21daac177a3e036192ed8",
+        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                   | Message                  |
| -------------------------------------------------------------------------------------------------------- | ------------------------ |
| [`8a099348`](https://github.com/hercules-ci/flake-parts/commit/8a099348752aa5fa09b3ebb6b5f422af10d250aa) | `` flake.lock: Update `` |