### PR TITLE
chore(flake/emacs-overlay): `2d69eefb` -> `e4f17c81`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706691967,
-        "narHash": "sha256-ADKh/Vss8ITblcLDl/LUM6GqJOahBktu4EXzhv7Uxbs=",
+        "lastModified": 1706861929,
+        "narHash": "sha256-zAEoyrNpmHu3hPZmy3u17v1L6y7s8mLgpyrm26UyW2Y=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "2d69eefbcadbac97bda477477cd53c0ef815f436",
+        "rev": "e4f17c81782040f23958ed74f1ab3a56b53df197",
         "type": "github"
       },
       "original": {
@@ -556,11 +556,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1706515015,
-        "narHash": "sha256-eFfY5A7wlYy3jD/75lx6IJRueg4noE+jowl0a8lIlVo=",
+        "lastModified": 1706718339,
+        "narHash": "sha256-S+S97c/HzkO2A/YsU7ZmNF9w2s7Xk6P8dzmfDdckzLs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f4a8d6d5324c327dcc2d863eb7f3cc06ad630df4",
+        "rev": "53fbe41cf76b6a685004194e38e889bc8857e8c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`e4f17c81`](https://github.com/nix-community/emacs-overlay/commit/e4f17c81782040f23958ed74f1ab3a56b53df197) | `` Updated emacs ``        |
| [`bdc43452`](https://github.com/nix-community/emacs-overlay/commit/bdc43452fa833f8ea0c78cb6e2bb67e4642e58ca) | `` Updated emacs ``        |
| [`28256189`](https://github.com/nix-community/emacs-overlay/commit/282561890cbd396a3da4a494cd17f71d111f35bf) | `` Updated melpa ``        |
| [`3756fc6f`](https://github.com/nix-community/emacs-overlay/commit/3756fc6fdf12c19fa36bfd8cf912bf59a9de19b6) | `` Updated elpa ``         |
| [`e7d08abf`](https://github.com/nix-community/emacs-overlay/commit/e7d08abf067abc211df72a0300bc24713105bad2) | `` Updated nongnu ``       |
| [`4e6805bd`](https://github.com/nix-community/emacs-overlay/commit/4e6805bd2930052e49344faf10f7e32f1bc2e34c) | `` Updated flake inputs `` |
| [`ad0b9834`](https://github.com/nix-community/emacs-overlay/commit/ad0b983479cb072cb0e97c9609c11d9e5aeced34) | `` Updated emacs ``        |
| [`488f22c2`](https://github.com/nix-community/emacs-overlay/commit/488f22c2eb3bc6a1cf0b4378afc7f331be67fc00) | `` Updated melpa ``        |
| [`fabe4b75`](https://github.com/nix-community/emacs-overlay/commit/fabe4b7550aaaf6e1fdc31cffe9164153a1e492c) | `` Updated elpa ``         |
| [`42f2c32d`](https://github.com/nix-community/emacs-overlay/commit/42f2c32d615b145ab47faeca4d9cfb48f7909052) | `` Updated melpa ``        |
| [`7130fb6c`](https://github.com/nix-community/emacs-overlay/commit/7130fb6cae4492784d282f005cfc3e43afc9ebb4) | `` Updated emacs ``        |
| [`f2d21ce0`](https://github.com/nix-community/emacs-overlay/commit/f2d21ce04546fe3120c1670f06e5f7598592ecd0) | `` Updated emacs ``        |
| [`19fac0e8`](https://github.com/nix-community/emacs-overlay/commit/19fac0e8e98cc770dc960094ff6be4f72f536e7d) | `` Updated melpa ``        |
| [`46140cd6`](https://github.com/nix-community/emacs-overlay/commit/46140cd6aea038eb370d01095f12d5da4f656a43) | `` Updated elpa ``         |
| [`bc072d9c`](https://github.com/nix-community/emacs-overlay/commit/bc072d9cca7c696b5167d352e20728515938f677) | `` Updated nongnu ``       |
| [`ca826bd6`](https://github.com/nix-community/emacs-overlay/commit/ca826bd6f5311300e47847adca289e580376d8ff) | `` Updated emacs ``        |
| [`512b3890`](https://github.com/nix-community/emacs-overlay/commit/512b3890a5bc20a6d9996dfdda4ca2276194eba8) | `` Updated melpa ``        |
| [`8db120f2`](https://github.com/nix-community/emacs-overlay/commit/8db120f2369ed54f570dcc146b244559468a2f6e) | `` Updated elpa ``         |
| [`852652c2`](https://github.com/nix-community/emacs-overlay/commit/852652c248f0448153dec4e1882ba04f6d02ac74) | `` Fix geiser hash ``      |