### PR TITLE
chore(flake/nur): `fab803d7` -> `1059ebf9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -620,11 +620,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706686049,
-        "narHash": "sha256-TCuYU/F5uuMDIBcFSm1xi2fYHt1Bit8fYPzIzB7T6HY=",
+        "lastModified": 1706862671,
+        "narHash": "sha256-pmZ4DMIWU2uMUYGEDHy2X0YiSfLP+o8H/W4Vjhgq4F8=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "fab803d7fa7e066ff6193fe40ba29d2e322835e1",
+        "rev": "1059ebf9a4a6ba47180c1616195ec807ecef6702",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`1059ebf9`](https://github.com/nix-community/NUR/commit/1059ebf9a4a6ba47180c1616195ec807ecef6702) | `` automatic update `` |
| [`be1fa0de`](https://github.com/nix-community/NUR/commit/be1fa0de949b3cb8b79be80dd4cd10f7869bca45) | `` automatic update `` |
| [`6ad802fb`](https://github.com/nix-community/NUR/commit/6ad802fb5e81af60a6ea0c8645aa5a6fa0d7d6dd) | `` automatic update `` |
| [`dc7f899f`](https://github.com/nix-community/NUR/commit/dc7f899faa627af70bab354984ec652275a06af5) | `` automatic update `` |
| [`f4849c93`](https://github.com/nix-community/NUR/commit/f4849c93fded99db928c59b0a28046702ab59fb7) | `` automatic update `` |
| [`1ac63d38`](https://github.com/nix-community/NUR/commit/1ac63d38c668d86be1c31e95aaee42b9986ce95d) | `` automatic update `` |
| [`c290e9ad`](https://github.com/nix-community/NUR/commit/c290e9ada7a920be104e37c3052b0c142eb3157d) | `` automatic update `` |
| [`55de3834`](https://github.com/nix-community/NUR/commit/55de3834d91a4fe68ba2b54253827546d20de133) | `` automatic update `` |
| [`76510831`](https://github.com/nix-community/NUR/commit/765108312dd833802189d15f93c9883b2ca776ab) | `` automatic update `` |
| [`0422ac6b`](https://github.com/nix-community/NUR/commit/0422ac6b6eb0ed71487041fec6b2bf11edc62503) | `` automatic update `` |
| [`cccf44e0`](https://github.com/nix-community/NUR/commit/cccf44e078fcc9e3d797d8be9ad34a27a6a0629a) | `` automatic update `` |
| [`9356aa54`](https://github.com/nix-community/NUR/commit/9356aa54aaae959f0770dc9a24cb7a64fba70bda) | `` automatic update `` |
| [`bea3201f`](https://github.com/nix-community/NUR/commit/bea3201f4f38f83e83079a5bddc7c587ec91162a) | `` automatic update `` |
| [`91d594fb`](https://github.com/nix-community/NUR/commit/91d594fbe9e38f7248fcc36f2f102082f1170ef8) | `` automatic update `` |
| [`c0285ab2`](https://github.com/nix-community/NUR/commit/c0285ab2aea80da369c0d2f56ebdbcd95fce9f9a) | `` automatic update `` |
| [`d36360d3`](https://github.com/nix-community/NUR/commit/d36360d3bc247b7b7f08f53d21dd727196f1f0e8) | `` automatic update `` |
| [`d656e0cf`](https://github.com/nix-community/NUR/commit/d656e0cfb6d38df52f93a3e3c31f9231fcc7d794) | `` automatic update `` |
| [`c8afc5fb`](https://github.com/nix-community/NUR/commit/c8afc5fb671e272af825d979ce60f70b647aa035) | `` automatic update `` |
| [`9c29bd89`](https://github.com/nix-community/NUR/commit/9c29bd8955e64ea7aec76de7e1a6541ac40e3f4d) | `` automatic update `` |
| [`52ebbcb0`](https://github.com/nix-community/NUR/commit/52ebbcb0de8dd0e916211ae8084fafe4ee23650a) | `` automatic update `` |
| [`234fac39`](https://github.com/nix-community/NUR/commit/234fac39724697dac46e735c514e2c8e33b2082d) | `` automatic update `` |
| [`45fb7fa3`](https://github.com/nix-community/NUR/commit/45fb7fa3eeab66b5c7dff1dfeb9817175c96d781) | `` automatic update `` |
| [`22a1c517`](https://github.com/nix-community/NUR/commit/22a1c5173e73320bfbd4cbe31369b3337a913528) | `` automatic update `` |
| [`da285bde`](https://github.com/nix-community/NUR/commit/da285bdefd95343608560429b1b223ed5b29fbcb) | `` automatic update `` |
| [`06e75011`](https://github.com/nix-community/NUR/commit/06e750117be4920f4d8fb2a831eb63d98440eeef) | `` automatic update `` |
| [`2dc6c5f0`](https://github.com/nix-community/NUR/commit/2dc6c5f06e6323699a6fa713f65793ee4d493917) | `` automatic update `` |
| [`f21ac749`](https://github.com/nix-community/NUR/commit/f21ac7498b17300be04a2ceffc623c94678211d9) | `` automatic update `` |
| [`3b8fdc2d`](https://github.com/nix-community/NUR/commit/3b8fdc2dfa3fd900578fdc99b58764b4b2a2da2b) | `` automatic update `` |
| [`f1e570f7`](https://github.com/nix-community/NUR/commit/f1e570f71db5e465d2cc0ddccbdc4b3934c34dbb) | `` automatic update `` |
| [`996662cd`](https://github.com/nix-community/NUR/commit/996662cd85aa302a29a2229d4a21b825c4e30ee0) | `` automatic update `` |
| [`49928a2a`](https://github.com/nix-community/NUR/commit/49928a2aa14988820a75f123004e6ee638b54f0d) | `` automatic update `` |
| [`006d8808`](https://github.com/nix-community/NUR/commit/006d88080f6b231ea268bb3298f23040eaa8cd1e) | `` automatic update `` |
| [`ae03b5f3`](https://github.com/nix-community/NUR/commit/ae03b5f3fe8cb99cfa26b31c61a3a96fb8e4ad33) | `` automatic update `` |
| [`538803b1`](https://github.com/nix-community/NUR/commit/538803b10d4986336c30743baa8e4b8b5590e943) | `` automatic update `` |
| [`c8974169`](https://github.com/nix-community/NUR/commit/c89741693418dc01bc1d01df5cee04abdfd53a47) | `` automatic update `` |
| [`97236a74`](https://github.com/nix-community/NUR/commit/97236a744ef30a8e928555844ec0654ec7569d2a) | `` automatic update `` |
| [`b8a6ba0f`](https://github.com/nix-community/NUR/commit/b8a6ba0f01c785b0240e306e765e71850c1943e8) | `` automatic update `` |
| [`d3108de1`](https://github.com/nix-community/NUR/commit/d3108de1be7c167695eb3f383f1484f0bbe7b60a) | `` automatic update `` |
| [`6bc9f506`](https://github.com/nix-community/NUR/commit/6bc9f506e6299fc5e02bb7f5f7d7692b82df628d) | `` automatic update `` |
| [`88061a9d`](https://github.com/nix-community/NUR/commit/88061a9d6cfd09617228d66fade1ac8ab46dea02) | `` automatic update `` |
| [`c462af68`](https://github.com/nix-community/NUR/commit/c462af68ad7740ed50079d2b6be2dadfaf0e211c) | `` automatic update `` |
| [`9be129c1`](https://github.com/nix-community/NUR/commit/9be129c15b400bae1ba97abc14d62c718c660fc2) | `` automatic update `` |
| [`e52bfdd7`](https://github.com/nix-community/NUR/commit/e52bfdd7d331dd32f0f0f8eb430488a36d6e6402) | `` automatic update `` |
| [`b8cec179`](https://github.com/nix-community/NUR/commit/b8cec1790834718d4381bcca40340365aefc2195) | `` automatic update `` |