### PR TITLE
chore(flake/home-manager): `d634c3ab` -> `4d53427b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -287,11 +287,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706473109,
-        "narHash": "sha256-iyuAvpKTsq2u23Cr07RcV5XlfKExrG8gRpF75hf1uVc=",
+        "lastModified": 1706798041,
+        "narHash": "sha256-BbvuF4CsVRBGRP8P+R+JUilojk0M60D7hzqE0bEvJBQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d634c3abafa454551f2083b054cd95c3f287be61",
+        "rev": "4d53427bce7bf3d17e699252fd84dc7468afc46e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`4d53427b`](https://github.com/nix-community/home-manager/commit/4d53427bce7bf3d17e699252fd84dc7468afc46e) | `` xfconf: fix config loading ``                    |
| [`2db6a2a4`](https://github.com/nix-community/home-manager/commit/2db6a2a42930ffff0ffd690dec3f2c0b6f4fe66d) | `` docs: add style sheets and `scrubDerivations` `` |