### PR TITLE
chore(flake/hyprland): `e65f52bf` -> `7447be82`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -309,11 +309,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1706646126,
-        "narHash": "sha256-VnJBPei9N1wV6GOgZxTtm5X+s5Ek6tLtYkLCKWHKJ/U=",
+        "lastModified": 1706838674,
+        "narHash": "sha256-umU1VC3bI4L/ZHpl/bZsm4MSUnX9wZrQRmbEjNLeQV4=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "e65f52bf2d6abb001c402c8302ac7003da8cd06d",
+        "rev": "7447be822080fac5b8515a177773ec74b4d6c925",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                      |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
| [`7447be82`](https://github.com/hyprwm/Hyprland/commit/7447be822080fac5b8515a177773ec74b4d6c925) | `` hyprpm: fix crash on add plugin ``                                        |
| [`4644de22`](https://github.com/hyprwm/Hyprland/commit/4644de2269b06e60764cc788e39a18f44d1dd9b6) | `` keybinds: fix ignoremods with release ``                                  |
| [`3656045a`](https://github.com/hyprwm/Hyprland/commit/3656045ad88717fbc079c1ebb44c6f7d2ed85cf2) | `` hyprpm: install headers locally (#4585) ``                                |
| [`15316aaa`](https://github.com/hyprwm/Hyprland/commit/15316aaa311ce27982d4df3c9514f042290853a3) | `` subsurfaceTree: Fix nullptr crash when disconnecting a monitor (#4577) `` |
| [`cfd68af5`](https://github.com/hyprwm/Hyprland/commit/cfd68af5b6c26f244838b628cf375b9cc0c5cfdf) | `` tearing-control: handle unmapped surfaces for hints ``                    |
| [`4f804d5f`](https://github.com/hyprwm/Hyprland/commit/4f804d5f962070c531dea5025e61be8a0da8129e) | `` Makefile: remove hyprland symlink on uninstall ``                         |
| [`e6f7724a`](https://github.com/hyprwm/Hyprland/commit/e6f7724ab0f72f190e0005c6959c11625cc0c6fe) | `` subprojects: remove wlroots.wrap ``                                       |