### PR TITLE
chore(flake/emacs-overlay): `e4f17c81` -> `41b0349b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -85,11 +85,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1706861929,
-        "narHash": "sha256-zAEoyrNpmHu3hPZmy3u17v1L6y7s8mLgpyrm26UyW2Y=",
+        "lastModified": 1706980041,
+        "narHash": "sha256-bYvQUVStA5m2zZVRbzI5tdp3t5fiFTklNQE1Ewf6Q4w=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "e4f17c81782040f23958ed74f1ab3a56b53df197",
+        "rev": "41b0349b7219d5128acbf66d753e921f283cf1b2",
         "type": "github"
       },
       "original": {
@@ -602,11 +602,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1706718339,
-        "narHash": "sha256-S+S97c/HzkO2A/YsU7ZmNF9w2s7Xk6P8dzmfDdckzLs=",
+        "lastModified": 1706826059,
+        "narHash": "sha256-N69Oab+cbt3flLvYv8fYnEHlBsWwdKciNZHUbynVEOA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "53fbe41cf76b6a685004194e38e889bc8857e8c2",
+        "rev": "25e3d4c0d3591c99929b1ec07883177f6ea70c9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`41b0349b`](https://github.com/nix-community/emacs-overlay/commit/41b0349b7219d5128acbf66d753e921f283cf1b2) | `` Updated emacs ``        |
| [`87dec8f9`](https://github.com/nix-community/emacs-overlay/commit/87dec8f92846c69fb17e4bddd66c160bd769cb38) | `` Updated melpa ``        |
| [`4eec5674`](https://github.com/nix-community/emacs-overlay/commit/4eec567404d4f12acd70674cbc3c319cf92fb43f) | `` Updated elpa ``         |
| [`16ca106d`](https://github.com/nix-community/emacs-overlay/commit/16ca106d2a6efab591b7489d1839b391f660b1b9) | `` Updated flake inputs `` |
| [`164c11f0`](https://github.com/nix-community/emacs-overlay/commit/164c11f0ddbf47ed5a20272a35b8f24557eaabb1) | `` Updated emacs ``        |
| [`7f585f4a`](https://github.com/nix-community/emacs-overlay/commit/7f585f4ab4a726b3f6f73c2e5c267085bb0a13f2) | `` Updated melpa ``        |
| [`501cc214`](https://github.com/nix-community/emacs-overlay/commit/501cc2145240ef9e2c4e466dd229350f3a50de4e) | `` Updated emacs ``        |
| [`7759177b`](https://github.com/nix-community/emacs-overlay/commit/7759177bdc835391b892144af6488b6421946c34) | `` Updated melpa ``        |
| [`afa646fa`](https://github.com/nix-community/emacs-overlay/commit/afa646fadbdf62ce12a18d72c771bf3db60b0ba2) | `` Updated elpa ``         |
| [`e33ffe03`](https://github.com/nix-community/emacs-overlay/commit/e33ffe039bf46a8d10d3e73e48dd7e298f0232e7) | `` Updated emacs ``        |
| [`5cdd16c0`](https://github.com/nix-community/emacs-overlay/commit/5cdd16c04c0893ab07d28f6de20a3b7ec6f2f451) | `` Updated melpa ``        |
| [`2e1493b0`](https://github.com/nix-community/emacs-overlay/commit/2e1493b0e8b920d91a3d5c7382746dcd89ca2642) | `` Updated elpa ``         |
| [`a0a3bab9`](https://github.com/nix-community/emacs-overlay/commit/a0a3bab96eaa014edbf9868536f702fd57ac343e) | `` Updated flake inputs `` |
| [`d82554b4`](https://github.com/nix-community/emacs-overlay/commit/d82554b44a986ca44c0c533b6f0c8109ffe69dec) | `` Updated melpa ``        |