### PR TITLE
chore(flake/nur): `1059ebf9` -> `a30b8d63`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -666,11 +666,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1706862671,
-        "narHash": "sha256-pmZ4DMIWU2uMUYGEDHy2X0YiSfLP+o8H/W4Vjhgq4F8=",
+        "lastModified": 1707003862,
+        "narHash": "sha256-XYstV4DLkO60Gxr7y9IWiz8XENWmvy2svwlvpf700xw=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "1059ebf9a4a6ba47180c1616195ec807ecef6702",
+        "rev": "a30b8d6366e36e256e803c14f81da4068bd134c2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`a30b8d63`](https://github.com/nix-community/NUR/commit/a30b8d6366e36e256e803c14f81da4068bd134c2) | `` automatic update `` |
| [`c21b0244`](https://github.com/nix-community/NUR/commit/c21b0244a519085f2597ec75854ce3671e68e32d) | `` automatic update `` |
| [`2550466d`](https://github.com/nix-community/NUR/commit/2550466d4a700a11b4b1d37f0803eac56a5355a3) | `` automatic update `` |
| [`1932c503`](https://github.com/nix-community/NUR/commit/1932c50322b1c6e191a88da3436c6da6b18eca88) | `` automatic update `` |
| [`bcaef5f9`](https://github.com/nix-community/NUR/commit/bcaef5f9f718b523117ad5a3798d7ed072bfa6bb) | `` automatic update `` |
| [`66d6b7b3`](https://github.com/nix-community/NUR/commit/66d6b7b355f3b10ea4140f8b85b2e274c24d442a) | `` automatic update `` |
| [`6578a7cb`](https://github.com/nix-community/NUR/commit/6578a7cbd8a0a898f1814e5b7e55015d59f839cb) | `` automatic update `` |
| [`713b918b`](https://github.com/nix-community/NUR/commit/713b918bf04438463f7587fe23a092648a863d26) | `` automatic update `` |
| [`481c3d7c`](https://github.com/nix-community/NUR/commit/481c3d7ce8fbee0de1e4375a2e86d862b0c3de2d) | `` automatic update `` |
| [`28cb99d3`](https://github.com/nix-community/NUR/commit/28cb99d30a99625796619b525a5e69aec1058368) | `` automatic update `` |
| [`b1011120`](https://github.com/nix-community/NUR/commit/b10111201b4064d90e42db525b2648aa9d0f754b) | `` automatic update `` |
| [`88c97939`](https://github.com/nix-community/NUR/commit/88c97939e93769bb00312ff612489ceaffdaa5a0) | `` automatic update `` |
| [`5dc2f93e`](https://github.com/nix-community/NUR/commit/5dc2f93e4a5965e2d50da740bee8aa3d661cb079) | `` automatic update `` |
| [`12015b20`](https://github.com/nix-community/NUR/commit/12015b208a5f627aafc9fd8a3b93b8487f5774ed) | `` automatic update `` |
| [`bd5c490c`](https://github.com/nix-community/NUR/commit/bd5c490c6073077f14ca8570b0aac1fc741470ad) | `` automatic update `` |
| [`3324c298`](https://github.com/nix-community/NUR/commit/3324c298a423c2eef03488b6f9a2ef0d82e42083) | `` automatic update `` |
| [`2f0cb902`](https://github.com/nix-community/NUR/commit/2f0cb902c5888a434c24746fd5b4f2d4494d3c14) | `` automatic update `` |
| [`b7feb2f4`](https://github.com/nix-community/NUR/commit/b7feb2f4f95f208044e5be1f4bb5080cfd8f3652) | `` automatic update `` |
| [`c791e8be`](https://github.com/nix-community/NUR/commit/c791e8becc5137946cf40e86bdb0e7f64e80a280) | `` automatic update `` |
| [`23f628ec`](https://github.com/nix-community/NUR/commit/23f628ec120e128b5ed0dcccb68d788b52839d4e) | `` automatic update `` |
| [`d8183104`](https://github.com/nix-community/NUR/commit/d81831044d87718c4ce4d268b0528dddb7758a68) | `` automatic update `` |
| [`4483245d`](https://github.com/nix-community/NUR/commit/4483245d746ce8e67073af4d4f819b9e5cc1c617) | `` automatic update `` |
| [`f9ac11b3`](https://github.com/nix-community/NUR/commit/f9ac11b3fb8670bfe7034eaaba8b5abb5bc17322) | `` automatic update `` |
| [`65b7f961`](https://github.com/nix-community/NUR/commit/65b7f961d25c02c750907c9a69972a8eb89e83a3) | `` automatic update `` |
| [`4cadb9c9`](https://github.com/nix-community/NUR/commit/4cadb9c9a0210fbfb53f3517559877b50eebed1a) | `` automatic update `` |
| [`9c02deda`](https://github.com/nix-community/NUR/commit/9c02dedaf63decb814dabd377b22b40735287488) | `` automatic update `` |
| [`492bf04e`](https://github.com/nix-community/NUR/commit/492bf04e19a98008c0fae15baa0bccbf8d3adb91) | `` automatic update `` |
| [`651abfb4`](https://github.com/nix-community/NUR/commit/651abfb46a238ffb0d71bee02c368a18aa528b35) | `` automatic update `` |
| [`c62ee958`](https://github.com/nix-community/NUR/commit/c62ee9580c8a875f53e8456c391efa2ee8143620) | `` automatic update `` |
| [`96b0e9d3`](https://github.com/nix-community/NUR/commit/96b0e9d38890afb8e4af6d6a556ee27e79fd6e22) | `` automatic update `` |
| [`91ae5ad5`](https://github.com/nix-community/NUR/commit/91ae5ad5a5578726ada9a98f2c839040b93ab03a) | `` automatic update `` |
| [`cc8e0246`](https://github.com/nix-community/NUR/commit/cc8e0246cfaf80298f17da838f70b1d492e17ea6) | `` automatic update `` |
| [`97ffd0a3`](https://github.com/nix-community/NUR/commit/97ffd0a361d591ca708d3552c0f70a99f0a06430) | `` automatic update `` |
| [`f579af61`](https://github.com/nix-community/NUR/commit/f579af614747e1aacb4426dfded1c6f5d9b70592) | `` automatic update `` |
| [`87beeb72`](https://github.com/nix-community/NUR/commit/87beeb7278639b639d2e2789f531a586da11c295) | `` automatic update `` |
| [`6a31ec36`](https://github.com/nix-community/NUR/commit/6a31ec36961e3c3da30aa1dbbdcb654ba9c513b5) | `` automatic update `` |
| [`04a91253`](https://github.com/nix-community/NUR/commit/04a91253344796e363f4938ff9b1f7e15a943f80) | `` automatic update `` |
| [`fba4ee3b`](https://github.com/nix-community/NUR/commit/fba4ee3ba82ddef9cfcc183af9b5e9cb7ae15277) | `` automatic update `` |
| [`e16514a5`](https://github.com/nix-community/NUR/commit/e16514a57faf7092aa9e7d54dd134453bebeca2c) | `` automatic update `` |
| [`2f898c47`](https://github.com/nix-community/NUR/commit/2f898c47cb6d8954ab021ee8593f3a5f5bdcf062) | `` automatic update `` |
| [`4a6bf969`](https://github.com/nix-community/NUR/commit/4a6bf969ebd7383e60aacd1e7d251f0d45ac7372) | `` automatic update `` |
| [`05ed926a`](https://github.com/nix-community/NUR/commit/05ed926a9a38779b9dd6b2a0527bb8f83d412fa1) | `` automatic update `` |
| [`f02a048d`](https://github.com/nix-community/NUR/commit/f02a048d5950e81e1e1254f4617448cfe323058d) | `` automatic update `` |
| [`b059a4cc`](https://github.com/nix-community/NUR/commit/b059a4cc6638f3be13c710dbbf1ee537eeb37359) | `` automatic update `` |
| [`bfb80b4b`](https://github.com/nix-community/NUR/commit/bfb80b4b69abcdab9f09e83637fb88de3c5c890c) | `` automatic update `` |