### PR TITLE
chore(flake/spicetify-nix): `471e7f90` -> `eafd15bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -763,11 +763,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706847053,
-        "narHash": "sha256-iTLT5hzD5VmNcHvl4bpZtxO5tipAPMnsvwKQnQLtIAo=",
+        "lastModified": 1706933357,
+        "narHash": "sha256-MB/jy3aWrTtxzHUQB8vH1YGH4ha24MrnMyGMeknhxrY=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "471e7f904a728ee3b40a32b3a09987a993c0bfda",
+        "rev": "eafd15bf5fa3f69609a5a99bc4ed2a529952b1a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`eafd15bf`](https://github.com/Gerg-L/spicetify-nix/commit/eafd15bf5fa3f69609a5a99bc4ed2a529952b1a1) | `` CI update 2024-02-03 (#63) `` |