### PR TITLE
chore(flake/hyprland): `7447be82` -> `5d4ff60f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -310,11 +310,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1706838674,
-        "narHash": "sha256-umU1VC3bI4L/ZHpl/bZsm4MSUnX9wZrQRmbEjNLeQV4=",
+        "lastModified": 1706985179,
+        "narHash": "sha256-4XX9Hb1lE5YzpCkcQ21+BwBsZ4fvSfJSgAMxiLELuo8=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "7447be822080fac5b8515a177773ec74b4d6c925",
+        "rev": "5d4ff60f535b65dc3db4cd0fb20e44c1f4360769",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                  |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------- |
| [`5d4ff60f`](https://github.com/hyprwm/Hyprland/commit/5d4ff60f535b65dc3db4cd0fb20e44c1f4360769) | `` hyprpm: fix invalid pkg-config path env in build ``   |
| [`504ebe1b`](https://github.com/hyprwm/Hyprland/commit/504ebe1b373726947a44fa2d6a68498d0edb85b6) | `` box: add missing include ``                           |
| [`cf1886ca`](https://github.com/hyprwm/Hyprland/commit/cf1886ca44c78de3424d96fd18023eb0db759af6) | `` renderer: avoid unnecessary gpu resource deletions `` |
| [`341e04a3`](https://github.com/hyprwm/Hyprland/commit/341e04a36ce5254315a40c563ea7f5d891b289e8) | `` dwindle: avoid sending negative sizes to wlr ``       |
| [`d7514412`](https://github.com/hyprwm/Hyprland/commit/d7514412d8bd143858c53d87fe0d7108f9171cff) | `` renderer: reset fb pointers after render pass ``      |