### PR TITLE
chore(flake/nixpkgs): `5c5bca5a` -> `4f301350`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -650,11 +650,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1706812040,
-        "narHash": "sha256-pxgWZApBfqHi4I6Hz7nL/rSt0vGE62HvBwvuVXFXeOk=",
+        "lastModified": 1706941790,
+        "narHash": "sha256-V4apg6WJS6hc1VhHuUpaLt0r/ulu/hvFruP6NKdEdfo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5c5bca5a97c0982ea37a2fcf6d3860349b9f9a35",
+        "rev": "4f301350dacb4eb0a93578ef3b07c8a996c777e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`0b6749ef`](https://github.com/NixOS/nixpkgs/commit/0b6749ef23f500b26ebc207f8a8d2a961964fc96) | `` budgie.budgie-desktop: 10.9 -> 10.9.1 ``                                |
| [`dec6392b`](https://github.com/NixOS/nixpkgs/commit/dec6392bc29e34e23f21451b58f629930c6ddc78) | `` nixos/tests/zigbee2mqtt: test against dummy serial device ``            |
| [`165326d2`](https://github.com/NixOS/nixpkgs/commit/165326d2ca6e8bda65c06fd3166eeacebc703e05) | `` zigbee2mqtt: 1.35.1 -> 1.35.2 ``                                        |
| [`4b501fcd`](https://github.com/NixOS/nixpkgs/commit/4b501fcd603bbe9c4e5eacac5b9c6227a2d4a3d2) | `` vale: 3.0.6 -> 3.0.7 ``                                                 |
| [`ed3e7a52`](https://github.com/NixOS/nixpkgs/commit/ed3e7a5208ec040dd6de0585bdb232e21bc718a7) | `` nixosTests.nvmetcfg: init ``                                            |
| [`edb53211`](https://github.com/NixOS/nixpkgs/commit/edb53211cc68405d02999852d892968f1d46c5c9) | `` python311Packages.iminuit: 2.24.0 -> 2.25.0 ``                          |
| [`f131fbc5`](https://github.com/NixOS/nixpkgs/commit/f131fbc5e8207dcd200806e9cb574e2fb60ef5b6) | `` python311Packages.sense-energy: refactor ``                             |
| [`ca1262a4`](https://github.com/NixOS/nixpkgs/commit/ca1262a4832b290d9f35c4b9c5f67f93144c7f2a) | `` lib: Add optionalDrvAttr to conditionally set drv attributes. ``        |
| [`140ded88`](https://github.com/NixOS/nixpkgs/commit/140ded8823bbe0e8bb6b06919b75189c6f52a126) | `` python311Packages.google-cloud-datacatalog: 3.17.2 -> 3.18.0 ``         |
| [`6da57d02`](https://github.com/NixOS/nixpkgs/commit/6da57d024e1700cc808fa748823ed2ddb9db0067) | `` python311Packages.trimesh: 4.1.0 -> 4.1.3 ``                            |
| [`7845fa08`](https://github.com/NixOS/nixpkgs/commit/7845fa08042e3093fcd65a4c8d0dbbd3725468d9) | `` python311Packages.sense-energy: 0.12.2 -> 0.12.3 ``                     |
| [`5fd6c330`](https://github.com/NixOS/nixpkgs/commit/5fd6c33068e0c63011559ec4711e26107e4d8b6b) | `` strawberry: 1.0.21 -> 1.0.23 ``                                         |
| [`8dcfdd4d`](https://github.com/NixOS/nixpkgs/commit/8dcfdd4def0d8038b10a4b82100aa1e16c6ad40d) | `` floorp: 11.7.1 -> 11.8.2 ``                                             |
| [`409eb0cb`](https://github.com/NixOS/nixpkgs/commit/409eb0cbdffec6983c3fce7076a15ec26767cfcc) | `` php81Packages.php-cs-fixer: 3.48.0 -> 3.49.0 ``                         |
| [`0e7ddc9d`](https://github.com/NixOS/nixpkgs/commit/0e7ddc9d6d3a28f0d53253b2f1e41bbf6382f318) | `` python311Packages.types-psycopg2: 2.9.21.20240118 -> 2.9.21.20240201 `` |
| [`b7c9da4e`](https://github.com/NixOS/nixpkgs/commit/b7c9da4e93da49597dd6693329a8a136f8b09e19) | `` python311Packages.deebot-client: 5.0.0 -> 5.1.0 ``                      |
| [`ddfe5d84`](https://github.com/NixOS/nixpkgs/commit/ddfe5d840bc01d3fe3391a384d4275e9542d3b27) | `` python311Packages.botocore-stubs: 1.34.32 -> 1.34.33 ``                 |
| [`b5aee7ec`](https://github.com/NixOS/nixpkgs/commit/b5aee7ecab4595a68fdd135955cfa50039f4b50b) | `` python311Packages.boto3-stubs: 1.34.32 -> 1.34.33 ``                    |
| [`337cb995`](https://github.com/NixOS/nixpkgs/commit/337cb99591a03cde060f4e786127ac26d526bddb) | `` python311Packages.aliyun-python-sdk-iot: 8.58.0 -> 8.59.0 ``            |
| [`7585f268`](https://github.com/NixOS/nixpkgs/commit/7585f26855f12bd56b82e170617454443eb39a4e) | `` nixos/incus: add zfs/lib/udev to path ``                                |
| [`3b949567`](https://github.com/NixOS/nixpkgs/commit/3b949567cca7788ec66fb30a70320cbcefe41e42) | `` ascii: 3.18 -> 3.19 ``                                                  |
| [`79a23af8`](https://github.com/NixOS/nixpkgs/commit/79a23af83e26474cb29f1b41a4bbcc4253c7bc37) | `` plantuml: 1.2023.13 -> 1.2024.0 ``                                      |
| [`29a1b5b1`](https://github.com/NixOS/nixpkgs/commit/29a1b5b1a1541fd7d16da32425cb67542279dd3a) | `` python311Packages.qdrant-client: 1.7.1 -> 1.7.2 ``                      |
| [`0081f5b1`](https://github.com/NixOS/nixpkgs/commit/0081f5b10d4fd9b4f0db73c317f2cbcecff0971a) | `` keycloak: 23.0.5 -> 23.0.6 ``                                           |
| [`0f844727`](https://github.com/NixOS/nixpkgs/commit/0f8447279340375aa067cd6dcc98ed38700393f3) | `` youki: 0.3.1 -> 0.3.2 (#285601) ``                                      |
| [`cdcb919f`](https://github.com/NixOS/nixpkgs/commit/cdcb919ff7ffb337f21a60375a8738e0558bc91d) | `` nixos/tests/incus: check system is running for verifying up ``          |
| [`051a45ec`](https://github.com/NixOS/nixpkgs/commit/051a45ec8a3d978f151058db38ce0e684d714157) | `` gitlab: remove rustc runtime dependency from gitlab-glfm-markdown ``    |
| [`49978472`](https://github.com/NixOS/nixpkgs/commit/49978472c0338c6cb8bc502d53bd6cf598a179cd) | `` meteo: 0.9.9.2 -> 0.9.9.3 ``                                            |
| [`0955141b`](https://github.com/NixOS/nixpkgs/commit/0955141b74ac74c3878b77d28e7dcf2f08a61583) | `` snyk: 1.1274.0 -> 1.1276.0 ``                                           |
| [`a0f4dc53`](https://github.com/NixOS/nixpkgs/commit/a0f4dc5359f0cec41a6c26d2d7500dfdf520f1d0) | `` mdbook-pdf: 0.1.7 -> 0.1.8 ``                                           |
| [`ccdd15cd`](https://github.com/NixOS/nixpkgs/commit/ccdd15cd0499db08bb751969aec7997684100a94) | `` fbpanel: 6.1 -> 7.0 ``                                                  |
| [`edb1e29f`](https://github.com/NixOS/nixpkgs/commit/edb1e29f51669daf966faea71109bc399307f67f) | `` jackett: 0.21.1588 -> 0.21.1658 ``                                      |
| [`6e0187a4`](https://github.com/NixOS/nixpkgs/commit/6e0187a4603d5c72c74c03aa833cae908acad5a5) | `` rure: 0.2.2 -> 0.2.2 ``                                                 |
| [`13eb3a2a`](https://github.com/NixOS/nixpkgs/commit/13eb3a2abeea3a30339bcd75575d08a6644987f1) | `` gromacs: fix build on Darwin, add OpenMP for Darwin ``                  |
| [`0738ee23`](https://github.com/NixOS/nixpkgs/commit/0738ee23229dd054c158016fa8dadf88a2127584) | `` python311Packages.aws-adfs: 2.10.0 -> 2.11.2 ``                         |
| [`d667ddce`](https://github.com/NixOS/nixpkgs/commit/d667ddce4348316843fd4329da8c95479bcf89c4) | `` aliyun-cli: 3.0.197 -> 3.0.198 ``                                       |
| [`9eac76bf`](https://github.com/NixOS/nixpkgs/commit/9eac76bf41ab4ef5f5fbba1b24bf1298938a35bd) | `` python311Packages.adafruit-platformdetect: 3.59.0 -> 3.60.0 ``          |
| [`ee5e5d9c`](https://github.com/NixOS/nixpkgs/commit/ee5e5d9c1247275f992b08748c557328a1f6832c) | `` portfolio: 0.67.2 -> 0.67.3 ``                                          |
| [`9e50c4e5`](https://github.com/NixOS/nixpkgs/commit/9e50c4e5e1e702c4e48d6f52de635ffb0722cb94) | `` tui-journal: 0.8.1 -> 0.8.2 ``                                          |
| [`24729cbc`](https://github.com/NixOS/nixpkgs/commit/24729cbc4d0ce5f4c64844a9471d51f89860b6b5) | `` files-cli: 2.12.25 -> 2.12.27 ``                                        |
| [`422be052`](https://github.com/NixOS/nixpkgs/commit/422be0521bc27a98eb3f998eb77800548d83ba63) | `` ruff-lsp: 0.0.50 -> 0.0.51 ``                                           |
| [`cf63c1e7`](https://github.com/NixOS/nixpkgs/commit/cf63c1e7dad7f111bee2e4e5525df4f4058b21f7) | `` vencord: 1.6.5 -> 1.6.7 ``                                              |
| [`62969590`](https://github.com/NixOS/nixpkgs/commit/629695900fab78541c8f88e0c96ddd494a587d79) | `` op-geth: 1.101305.1 -> 1.101305.3 ``                                    |
| [`5bf6f716`](https://github.com/NixOS/nixpkgs/commit/5bf6f7164741cf32b2470a662fd18d3713f9b95b) | `` podman: 4.9.0 -> 4.9.1 ``                                               |
| [`262bb6ed`](https://github.com/NixOS/nixpkgs/commit/262bb6ed2e32f872d69db822a8bf63621bb33133) | `` flow: 0.227.0 -> 0.228.0 ``                                             |
| [`18af431f`](https://github.com/NixOS/nixpkgs/commit/18af431f377fca83ed49ba6e2e9abdd2e1e9881b) | `` ov: 0.33.1 -> 0.33.2 ``                                                 |
| [`30b82c74`](https://github.com/NixOS/nixpkgs/commit/30b82c74d5739045226fce215c96f491db39f07c) | `` ttyper: 1.4.0 -> 1.4.1 ``                                               |
| [`071c0b6d`](https://github.com/NixOS/nixpkgs/commit/071c0b6da6406a16c1a2f434bdccd5f54e9d6eb6) | `` commix: 3.8 -> 3.9 ``                                                   |
| [`22bfd663`](https://github.com/NixOS/nixpkgs/commit/22bfd663b8062fed22907c76cb5afc7368bfa745) | `` vultr-cli: 2.21.0 -> 2.22.0 ``                                          |
| [`4005f97c`](https://github.com/NixOS/nixpkgs/commit/4005f97c9965906d6815b1ecfb7fa0698481d222) | `` mob: 4.4.6 -> 4.5.0 ``                                                  |
| [`009d63f1`](https://github.com/NixOS/nixpkgs/commit/009d63f11251c67da58abd10c894cdef8ccf4865) | `` optimism: 1.1.6 -> 1.5.0 ``                                             |
| [`548088bb`](https://github.com/NixOS/nixpkgs/commit/548088bbcfa9c1874501fafd3e3b6829d3072547) | `` redis-plus-plus: 1.3.11 -> 1.3.12 ``                                    |
| [`1bf3a41c`](https://github.com/NixOS/nixpkgs/commit/1bf3a41ceb31622bed9edc4575f5ab6ad6644725) | `` skopeo: 1.14.1 -> 1.14.2 ``                                             |
| [`69e95a59`](https://github.com/NixOS/nixpkgs/commit/69e95a59831e83d8c7b6052930c95f121286bdbe) | `` kubedb-cli: 0.40.1 -> 0.41.0 ``                                         |
| [`5dc59b7c`](https://github.com/NixOS/nixpkgs/commit/5dc59b7c805a1a9479eb82f806efb844b0763e2f) | `` fedifetcher: 7.0.1 -> 7.0.3 ``                                          |
| [`164ec34e`](https://github.com/NixOS/nixpkgs/commit/164ec34e24b9d6d7210769c7bdbaa4171094328e) | `` pysqlrecon: set doCheck ``                                              |
| [`ac436aa7`](https://github.com/NixOS/nixpkgs/commit/ac436aa76f9d1da57bbc5f6c258d12d309ef2156) | `` faudio: 24.01 -> 24.02 ``                                               |
| [`18b2cd3c`](https://github.com/NixOS/nixpkgs/commit/18b2cd3cba2a3a84590be1f22efa836ad643291a) | `` do-agent: 3.16.7 -> 3.16.8 ``                                           |
| [`40457c0a`](https://github.com/NixOS/nixpkgs/commit/40457c0aafb1246617e2d8e4a6928ae776d943bd) | `` cargo-xwin: 0.16.3 -> 0.16.4 ``                                         |
| [`329f2211`](https://github.com/NixOS/nixpkgs/commit/329f22110d551c96d2dcaabc340333580bc516ea) | `` civo: 1.0.72 -> 1.0.73 ``                                               |
| [`2466f8b1`](https://github.com/NixOS/nixpkgs/commit/2466f8b163ae2aa77925c945b62b6af6312abf55) | `` trufflehog: 3.66.1 -> 3.66.3 ``                                         |
| [`83ba6cec`](https://github.com/NixOS/nixpkgs/commit/83ba6cec48b6dff87fb533720c9b846ea8dc0474) | `` allure: 2.26.0 -> 2.27.0 ``                                             |
| [`ce9798e6`](https://github.com/NixOS/nixpkgs/commit/ce9798e62fd6a3ced3aa74a9d403d57d8251f748) | `` roadrunner: 2023.3.9 -> 2023.3.10 ``                                    |
| [`77c887ce`](https://github.com/NixOS/nixpkgs/commit/77c887ce9004b4db8d6920657da95681a4779104) | `` checkov: 3.2.3 -> 3.2.5 ``                                              |
| [`37934524`](https://github.com/NixOS/nixpkgs/commit/379345249c24c1d8280489c16dc4b81372a55f80) | `` libucl: 0.8.2 -> 0.9.0 ``                                               |
| [`e650f2b5`](https://github.com/NixOS/nixpkgs/commit/e650f2b5eab1ad05aaecfe9c8c8cca88b32c1570) | `` python311Packages.google-cloud-redis: refactor ``                       |
| [`49cfaeeb`](https://github.com/NixOS/nixpkgs/commit/49cfaeeb62a4d1d4bfcc756efb928cb5a1076c8b) | `` python311Packages.airthings-ble: 0.6.0 -> 0.6.1 ``                      |
| [`77223a34`](https://github.com/NixOS/nixpkgs/commit/77223a34a17c1804c9c931b68cef990db91e906a) | `` cnspec: 10.0.3 -> 10.1.4 ``                                             |
| [`d150b7aa`](https://github.com/NixOS/nixpkgs/commit/d150b7aaae437e117a06f7f32a79d51d1552950f) | `` telegraf: 1.29.3 -> 1.29.4 ``                                           |
| [`c2b700d3`](https://github.com/NixOS/nixpkgs/commit/c2b700d30ea413766bbffe4a3a307ba28eeee232) | `` python312Packages.pipenv-poetry-migrate: 0.5.2 -> 0.5.3 ``              |
| [`ec57dc66`](https://github.com/NixOS/nixpkgs/commit/ec57dc6663f3fc816d0bfff1f48d3ea1cc214ae7) | `` papirus-icon-theme: 20231201 -> 20240201 ``                             |
| [`a812afc1`](https://github.com/NixOS/nixpkgs/commit/a812afc1a212a265cf632993c8e7354e6b8a2941) | `` trivy: 0.48.3 -> 0.49.0 ``                                              |
| [`d92a1b27`](https://github.com/NixOS/nixpkgs/commit/d92a1b27008a37687b1cc61066e574efaefe75ec) | `` hcloud: 1.41.1 -> 1.42.0 ``                                             |
| [`300c7860`](https://github.com/NixOS/nixpkgs/commit/300c7860938fd9e2a849340167b6a08c9488e7f5) | `` difftastic: 0.54.0 -> 0.55.0 ``                                         |
| [`18c624d1`](https://github.com/NixOS/nixpkgs/commit/18c624d10836f1bdac2e0c635c2f82cfd7149a9e) | `` ocamlPackages.zipc: 0.1.0 → 0.2.0 ``                                    |
| [`7db78605`](https://github.com/NixOS/nixpkgs/commit/7db78605ab41a2c76985eac985c62d2fd918cdee) | `` docker-slim: 1.40.10 -> 1.40.11 ``                                      |
| [`e560be4d`](https://github.com/NixOS/nixpkgs/commit/e560be4d16ee3f20f35653d383b2950fb74c419b) | `` nixd: 1.2.2 -> 1.2.3 ``                                                 |
| [`59f4ab88`](https://github.com/NixOS/nixpkgs/commit/59f4ab887354caf53e6f4d4c218cc019ef96c508) | `` atlas: 0.18.0 -> 0.19.0 ``                                              |
| [`0740d473`](https://github.com/NixOS/nixpkgs/commit/0740d47320a775c677cd01a8dc02d9f7fc09a796) | `` python3Packages.pyemvue: init at 0.18.0 ``                              |
| [`16c2c898`](https://github.com/NixOS/nixpkgs/commit/16c2c8985d26e208dd244695d5e974653ae2e6de) | `` maintainers: add presto8 ``                                             |
| [`33f5eba7`](https://github.com/NixOS/nixpkgs/commit/33f5eba75243d181061f52eeb282eb057f536ac1) | `` kubergrunt: 0.14.1 -> 0.14.2 ``                                         |
| [`295952fd`](https://github.com/NixOS/nixpkgs/commit/295952fd5102dec076c1bbf3400c3e1009b2f5ac) | `` synapse-matrix: have a valid `meta` attribute ``                        |
| [`9ce2748b`](https://github.com/NixOS/nixpkgs/commit/9ce2748b39346e5cce7fb5a37353640b7d4164eb) | `` signal-desktop-beta: 6.44.0-beta.1 -> 6.47.0-beta.1 ``                  |
| [`ec107ef9`](https://github.com/NixOS/nixpkgs/commit/ec107ef9bff99d79e5e392dba5dd0157c7bb1ea7) | `` python311Packages.pygmt: 0.10.0 -> 0.11.0 ``                            |
| [`09fb16db`](https://github.com/NixOS/nixpkgs/commit/09fb16db92b7a06a3a777b4fed4107141777a1d4) | `` nuclei: 3.1.8 -> 3.1.9 ``                                               |
| [`7abd4fee`](https://github.com/NixOS/nixpkgs/commit/7abd4feee6b93b0c106028bcad73fe79f9d761ba) | `` miriway: unstable-2024-01-26 -> unstable-2024-01-30 ``                  |
| [`91f6642e`](https://github.com/NixOS/nixpkgs/commit/91f6642e1b48ff77e88b9c69946a65719608f36c) | `` turso-cli: 0.88.2 -> 0.88.3 ``                                          |