### PR TITLE
chore(flake/nix-index-database): `c782f2a4` -> `3e3dad28`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -760,11 +760,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706411424,
-        "narHash": "sha256-BzziJYucEZvdCE985vjPoo3ztWcmUiSQ1wJ2CoT6jCc=",
+        "lastModified": 1707016097,
+        "narHash": "sha256-V4lHr6hFQ3rK650dh64Xffxsf4kse9vUYWsM+ldjkco=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "c782f2a4f6fc94311ab5ef31df2f1149a1856181",
+        "rev": "3e3dad2808379c522138e2e8b0eb73500721a237",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`3e3dad28`](https://github.com/nix-community/nix-index-database/commit/3e3dad2808379c522138e2e8b0eb73500721a237) | `` update packages.nix to release 2024-02-04-030719 `` |
| [`e260ddfd`](https://github.com/nix-community/nix-index-database/commit/e260ddfd7ab5d360172870b9dfb0fa15093cdb29) | `` flake.lock: Update ``                               |