### PR TITLE
chore(flake/emacs-overlay): `41b0349b` -> `ccaf5772`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -193,11 +193,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1706980041,
-        "narHash": "sha256-bYvQUVStA5m2zZVRbzI5tdp3t5fiFTklNQE1Ewf6Q4w=",
+        "lastModified": 1707356707,
+        "narHash": "sha256-EPMnOYkQdpz9ch4qiDB+VQ+RusojToPgM88bo/TXHTE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "41b0349b7219d5128acbf66d753e921f283cf1b2",
+        "rev": "ccaf577227e5a64f95c03d66b6ac50879b4a3521",
         "type": "github"
       },
       "original": {
@@ -860,11 +860,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1706826059,
-        "narHash": "sha256-N69Oab+cbt3flLvYv8fYnEHlBsWwdKciNZHUbynVEOA=",
+        "lastModified": 1707238373,
+        "narHash": "sha256-WKxT0yLzWbFZwYi92lI0yWJpYtRaFSWHGX8QXzejapw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "25e3d4c0d3591c99929b1ec07883177f6ea70c9d",
+        "rev": "fb0c047e30b69696acc42e669d02452ca1b55755",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                            |
| ------------------------------------------------------------------------------------------------------------ | ---------------------------------- |
| [`ccaf5772`](https://github.com/nix-community/emacs-overlay/commit/ccaf577227e5a64f95c03d66b6ac50879b4a3521) | `` Updated emacs ``                |
| [`b1b55ae0`](https://github.com/nix-community/emacs-overlay/commit/b1b55ae037f900793dcb74d87b18b6ba5d8c5d38) | `` Updated melpa ``                |
| [`d28950bc`](https://github.com/nix-community/emacs-overlay/commit/d28950bce310568129d58b74639e73c7d3e73a78) | `` Updated elpa ``                 |
| [`97ebd2a2`](https://github.com/nix-community/emacs-overlay/commit/97ebd2a2bd3e4fc8ee09940822625654c949a391) | `` Updated nongnu ``               |
| [`97017b23`](https://github.com/nix-community/emacs-overlay/commit/97017b23dad7fe36be291d0b99584ff9f67d9c34) | `` Updated flake inputs ``         |
| [`202c1eec`](https://github.com/nix-community/emacs-overlay/commit/202c1eec521b02ccad6e7bdf32476c0eddb54c2d) | `` Updated emacs ``                |
| [`6ce89b64`](https://github.com/nix-community/emacs-overlay/commit/6ce89b64f94a846b185e9ef1f063099e4e170c86) | `` Updated melpa ``                |
| [`3c16647d`](https://github.com/nix-community/emacs-overlay/commit/3c16647dfd441883e733897e799fd450ebd7f2f3) | `` Updated elpa ``                 |
| [`223c6e9b`](https://github.com/nix-community/emacs-overlay/commit/223c6e9be9ef430d3523ec9c996eb74cb329c42f) | `` Updated emacs ``                |
| [`0db31bf7`](https://github.com/nix-community/emacs-overlay/commit/0db31bf7477ac7c58157aa7d5d7674936b712f47) | `` Updated melpa ``                |
| [`552a5b1f`](https://github.com/nix-community/emacs-overlay/commit/552a5b1fbcde5557b2a011956fa36fdef056fdb7) | `` Updated emacs ``                |
| [`1bb597ae`](https://github.com/nix-community/emacs-overlay/commit/1bb597ae016883152249651ceaaf85b1589d7ab4) | `` Updated melpa ``                |
| [`61b58a1c`](https://github.com/nix-community/emacs-overlay/commit/61b58a1cef89cf6b25fae43671ff33661ef1e6c3) | `` Updated elpa ``                 |
| [`bda20050`](https://github.com/nix-community/emacs-overlay/commit/bda20050fde1908491e9b573430ebc4745cdea58) | `` Updated emacs ``                |
| [`aa0155d1`](https://github.com/nix-community/emacs-overlay/commit/aa0155d148c316cc653476c83f3aac57afbde000) | `` Updated melpa ``                |
| [`5d4ab701`](https://github.com/nix-community/emacs-overlay/commit/5d4ab701c80872226f8dcaf0b494816746cdb738) | `` Updated elpa ``                 |
| [`5106217a`](https://github.com/nix-community/emacs-overlay/commit/5106217a5b0652bcd8f24ebf955aed45d2e7c2ad) | `` Updated emacs ``                |
| [`11c8e196`](https://github.com/nix-community/emacs-overlay/commit/11c8e196c5130ce4f91f9f433ee5067001382df5) | `` Updated melpa ``                |
| [`51d8c9b0`](https://github.com/nix-community/emacs-overlay/commit/51d8c9b0e14c73d3b52e3a5e894caff20337bc6a) | `` Updated flake inputs ``         |
| [`550f226f`](https://github.com/nix-community/emacs-overlay/commit/550f226f99b0e54179a76cf9500468e120def867) | `` Updated emacs ``                |
| [`fab6612e`](https://github.com/nix-community/emacs-overlay/commit/fab6612e70edd3d48993906a7e88c5216ce4c571) | `` Updated melpa ``                |
| [`ae6f9bc8`](https://github.com/nix-community/emacs-overlay/commit/ae6f9bc80ea20d24216b566aecfe8f3eb7b70363) | `` Updated elpa ``                 |
| [`68e08a9a`](https://github.com/nix-community/emacs-overlay/commit/68e08a9ac499542ef473bd5306345cf24a780f50) | `` Updated nongnu ``               |
| [`5531296a`](https://github.com/nix-community/emacs-overlay/commit/5531296a4fd231dee0ad5bb252a47cbd0198b06d) | `` Updated emacs ``                |
| [`6e6e5f78`](https://github.com/nix-community/emacs-overlay/commit/6e6e5f78c7e5edbf7091174a31b35446c3519098) | `` Updated melpa ``                |
| [`b814c602`](https://github.com/nix-community/emacs-overlay/commit/b814c6022b1658d29b0eacd4a1e797946ba2532a) | `` Updated elpa ``                 |
| [`7de6a630`](https://github.com/nix-community/emacs-overlay/commit/7de6a630960f81ab2bf5a12ecdd5678ffaee9f5c) | `` Updated emacs ``                |
| [`c748ebeb`](https://github.com/nix-community/emacs-overlay/commit/c748ebeb27022d6ece8d9bcda28755572f26dc5e) | `` Updated melpa ``                |
| [`b7c67b5f`](https://github.com/nix-community/emacs-overlay/commit/b7c67b5f71db89ec27e1aa4413fbbcdf5bbfa451) | `` Shut up obsolescence warning `` |
| [`72e11f21`](https://github.com/nix-community/emacs-overlay/commit/72e11f211bba2c57c5e646e35a95380fafd0341a) | `` Updated emacs ``                |
| [`f44c8471`](https://github.com/nix-community/emacs-overlay/commit/f44c8471e50df56af9229aa354f3061570dfab0a) | `` Updated melpa ``                |
| [`ac950010`](https://github.com/nix-community/emacs-overlay/commit/ac95001079db6ee5c1e05acf1c7fec33d1cf2f3a) | `` Updated elpa ``                 |
| [`6945b802`](https://github.com/nix-community/emacs-overlay/commit/6945b80223499bba37d46d9a0bc9ce85589df936) | `` Updated emacs ``                |
| [`9b34fbdd`](https://github.com/nix-community/emacs-overlay/commit/9b34fbdd9556dcf635abdd543f71f1d245c8634c) | `` Updated melpa ``                |
| [`8a3ac745`](https://github.com/nix-community/emacs-overlay/commit/8a3ac745eefe247bdb0f3a33e35586d0d41a91f5) | `` Updated elpa ``                 |
| [`77b373a3`](https://github.com/nix-community/emacs-overlay/commit/77b373a3930607022e7678ab30715763c24dfaa3) | `` Updated flake inputs ``         |
| [`f994dc5c`](https://github.com/nix-community/emacs-overlay/commit/f994dc5cd9323dc83968049348858ea7e683f424) | `` Updated emacs ``                |
| [`acdd825f`](https://github.com/nix-community/emacs-overlay/commit/acdd825fbf3127a8a12235c754ec5bd3d447c24d) | `` Updated melpa ``                |
| [`0c9de266`](https://github.com/nix-community/emacs-overlay/commit/0c9de2665a034fbc19782514e32595412cb6a781) | `` Updated emacs ``                |
| [`08ecda2d`](https://github.com/nix-community/emacs-overlay/commit/08ecda2df93d592fc6bf1ac7e9f5bc27ee876c11) | `` Updated melpa ``                |
| [`187befb5`](https://github.com/nix-community/emacs-overlay/commit/187befb50d43371b697cd6233e4caec3e18cd9f3) | `` Updated elpa ``                 |
| [`f2df9741`](https://github.com/nix-community/emacs-overlay/commit/f2df97415de3805c1daa3c14d30357e79943961e) | `` Updated nongnu ``               |