### PR TITLE
chore(flake/spicetify-nix): `eafd15bf` -> `fe2db390`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1065,11 +1065,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706933357,
-        "narHash": "sha256-MB/jy3aWrTtxzHUQB8vH1YGH4ha24MrnMyGMeknhxrY=",
+        "lastModified": 1707365435,
+        "narHash": "sha256-nxk4jnN8zq4Ju68VBXScT3qxPXhhEqs4ripEmVk68EQ=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "eafd15bf5fa3f69609a5a99bc4ed2a529952b1a1",
+        "rev": "fe2db3900d0fb355a521892cf3c6e45399089fe3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`fe2db390`](https://github.com/Gerg-L/spicetify-nix/commit/fe2db3900d0fb355a521892cf3c6e45399089fe3) | `` CI update 2024-02-08 (#66) `` |
| [`a96d81b3`](https://github.com/Gerg-L/spicetify-nix/commit/a96d81b3922ff134afbd2ea4963e39564066fb4b) | `` CI update 2024-02-07 (#65) `` |
| [`a0498cce`](https://github.com/Gerg-L/spicetify-nix/commit/a0498ccea68a497b57c0807b1a4787c0526770fa) | `` CI update 2024-02-05 (#64) `` |