### PR TITLE
chore(flake/chaotic): `c73af1d6` -> `aba46bb7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1706978170,
-        "narHash": "sha256-mS5Ex8OKfZYp6M8nUdFQt7Ppuc50QdGtZgbJJROjbWs=",
+        "lastModified": 1707327858,
+        "narHash": "sha256-fPTE6hUNezT4B7lhjWB6zFPslXot4SPrt6WLAPlgDbw=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "c73af1d6032e139a37f3918d32d0665ca987b93d",
+        "rev": "aba46bb7b47c6478941ee0b20dbdfa317924dd9b",
         "type": "github"
       },
       "original": {
@@ -558,11 +558,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706954734,
-        "narHash": "sha256-R3t6ehjMXbLFUOB8BHJKzY1URALHztIvHyokvBII6+g=",
+        "lastModified": 1707226874,
+        "narHash": "sha256-uo3oGHc/oLbcS6tDlm+Z130tQNRX2ufs9r+kGRTx0Ng=",
         "owner": "Jovian-Experiments",
         "repo": "Jovian-NixOS",
-        "rev": "19057dafa099eb312d6c91175932f8880b68ed0f",
+        "rev": "8f355736d9449a6650418f8e70f8dacf652401a7",
         "type": "github"
       },
       "original": {
@@ -584,11 +584,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1706970432,
-        "narHash": "sha256-56nws7EAkx5ud8RiM2zeZZc06V+bvsXX73OpsMBXbGo=",
+        "lastModified": 1707284098,
+        "narHash": "sha256-tYVS7r8XmgHJp0o5qsPa33fCKL6JYFvg43+f29qOJK4=",
         "owner": "martinvonz",
         "repo": "jj",
-        "rev": "31e4061bab6cfc835e8ac65d263c29e99c937abf",
+        "rev": "1be82250460a914ba2c718260de32d2c9eb60f9d",
         "type": "github"
       },
       "original": {
@@ -681,11 +681,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706940006,
-        "narHash": "sha256-+Y7dnq8gwVxefwvRnamqGneCTI4uUXgAo0SEffIvNB0=",
+        "lastModified": 1707127787,
+        "narHash": "sha256-dxyrVH9O21A6kLIvtgeHHI9G7mqRNzNEgMGn/ovnrRg=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "72c8f569aca37ec45420b086a1aa488f5c4a2bd7",
+        "rev": "3a23417e980de908c3183749da9309e9dabc9ece",
         "type": "github"
       },
       "original": {
@@ -799,12 +799,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1706732774,
-        "narHash": "sha256-hqJlyJk4MRpcItGYMF+3uHe8HvxNETWvlGtLuVpqLU0=",
-        "rev": "b8b232ae7b8b144397fdb12d20f592e5e7c1a64d",
-        "revCount": 578631,
+        "lastModified": 1707092692,
+        "narHash": "sha256-ZbHsm+mGk/izkWtT4xwwqz38fdlwu7nUUKXTOmm4SyE=",
+        "rev": "faf912b086576fd1a15fca610166c98d47bc667e",
+        "revCount": 580425,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.578631%2Brev-b8b232ae7b8b144397fdb12d20f592e5e7c1a64d/018d6a7d-21b4-7935-bdaf-4c8682c7e5b1/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.580425%2Brev-faf912b086576fd1a15fca610166c98d47bc667e/018d7cf8-4100-74ee-a53f-928188670608/source.tar.gz"
       },
       "original": {
         "type": "tarball",


### PR DESCRIPTION
| Commit                                                                                          | Message                                             |
| ----------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`aba46bb7`](https://github.com/chaotic-cx/nyx/commit/aba46bb7b47c6478941ee0b20dbdfa317924dd9b) | `` Bump 20240207-1 (#582) ``                        |
| [`f2b3ec52`](https://github.com/chaotic-cx/nyx/commit/f2b3ec52fa959678915e685b4a890f0d410f1264) | `` firedragon: 119.0 -> 11.9.0 (#581) ``            |
| [`a7056b1f`](https://github.com/chaotic-cx/nyx/commit/a7056b1fed53a3ecce077eff53711bdc5f96ed94) | `` builder: can't have U ``                         |
| [`5ba7ee00`](https://github.com/chaotic-cx/nyx/commit/5ba7ee0020773bf7908712bdabe2ca44b354a620) | `` ci: add missing places to download cache list `` |
| [`0f2ced31`](https://github.com/chaotic-cx/nyx/commit/0f2ced3137bac3e3389dc24e9d07d24cca804349) | `` failures: update ``                              |
| [`dff263ee`](https://github.com/chaotic-cx/nyx/commit/dff263ee1b89f31262c6337ba12d21cd28bf2b23) | `` nixpkgs: bump to 20240206 ``                     |
| [`7302a93f`](https://github.com/chaotic-cx/nyx/commit/7302a93f7827b005eacfc8b4aa3a743deddae0ab) | `` Bump 20240205-1 (#580) ``                        |
| [`541899ea`](https://github.com/chaotic-cx/nyx/commit/541899ea3a4663ffcf347daf9f145dd9a0577b25) | `` failures: update ``                              |
| [`77aadf18`](https://github.com/chaotic-cx/nyx/commit/77aadf1865df59f83b4c1a041ca610861389e912) | `` Bump 20240204-1 (#579) ``                        |