### PR TITLE
chore(flake/hyprland): `5d4ff60f` -> `a6ccd361`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -474,11 +474,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1706985179,
-        "narHash": "sha256-4XX9Hb1lE5YzpCkcQ21+BwBsZ4fvSfJSgAMxiLELuo8=",
+        "lastModified": 1707349634,
+        "narHash": "sha256-enBIncPDMroHjkykdRdvjvaZbhlb4d/LrR4R1qHeenY=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "5d4ff60f535b65dc3db4cd0fb20e44c1f4360769",
+        "rev": "a6ccd36147109d5cb2981122595f06ae93999b55",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                             |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
| [`a6ccd361`](https://github.com/hyprwm/Hyprland/commit/a6ccd36147109d5cb2981122595f06ae93999b55) | `` screencopy: move monitor verif check to the proper place ``                      |
| [`3d9ca638`](https://github.com/hyprwm/Hyprland/commit/3d9ca6381df1cdbf1731d7e2b39ea3f7574fce1e) | `` crashreporter: fix logging of function data (#4632) ``                           |
| [`f085ed44`](https://github.com/hyprwm/Hyprland/commit/f085ed4454fc0c9045b324c32f9ca34cd4c28808) | `` screencopy/toplevelexport: sanitize pointers in ::copyFrame ``                   |
| [`ded174d6`](https://github.com/hyprwm/Hyprland/commit/ded174d6e5d14bc376919194cbc52c238a07f640) | `` misc: remove unused var ``                                                       |
| [`181f651d`](https://github.com/hyprwm/Hyprland/commit/181f651de2e67917c7fcc72f7a69e6f4707954e5) | `` vector: avoid min0 clamps without a max being invalid ``                         |
| [`8a6e428d`](https://github.com/hyprwm/Hyprland/commit/8a6e428d32f170737110a2184c4d59c98f317422) | `` keybinds: focusWorkspaceOnCurrentMonitor: use focused monitor instead (#4625) `` |
| [`1fd82e37`](https://github.com/hyprwm/Hyprland/commit/1fd82e37a782a3506accb63cd470fe96db772cc0) | `` xwaylandmgr: proper clamping for setWindowSize ``                                |
| [`f9202f79`](https://github.com/hyprwm/Hyprland/commit/f9202f791e3690ad248c842158ee9fa9e1105ea6) | `` xwaylandmgr: clamp size in setWindowSize ``                                      |
| [`84ab8d11`](https://github.com/hyprwm/Hyprland/commit/84ab8d11e8951a6551d1e1bf87796a8589da6d47) | `` props: bump ver to 0.35.0 ``                                                     |
| [`60bda7ee`](https://github.com/hyprwm/Hyprland/commit/60bda7ee3d0a77d19277540cce53ecbddeabd716) | `` pluginapi: allow registering hyprctl commands ``                                 |
| [`939696f9`](https://github.com/hyprwm/Hyprland/commit/939696f97e2dcfa9ed6b91aa7ddf608c454d49e5) | `` hyprctl: move to a class and unify commands ``                                   |
| [`cbadf3e3`](https://github.com/hyprwm/Hyprland/commit/cbadf3e3f31ab5ad5d192daac5f2ca930d08b8fb) | `` input: focus window on mouse down on decoration (#4514) ``                       |
| [`1ed4f1cb`](https://github.com/hyprwm/Hyprland/commit/1ed4f1cb254ce4b4e55727d972998be1ef4baf22) | `` screenshader: rename output uniform to wl_output (#4606) ``                      |