### PR TITLE
chore(flake/nur): `a30b8d63` -> `20260b5a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -924,11 +924,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707003862,
-        "narHash": "sha256-XYstV4DLkO60Gxr7y9IWiz8XENWmvy2svwlvpf700xw=",
+        "lastModified": 1707381565,
+        "narHash": "sha256-uvIk890e7TsYhenORzqKAfIMmJ2QNpTX6WL79rl5+Xk=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "a30b8d6366e36e256e803c14f81da4068bd134c2",
+        "rev": "20260b5a03e74c6d624e4b983e5b482a8ec1a0c0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                            |
| -------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`20260b5a`](https://github.com/nix-community/NUR/commit/20260b5a03e74c6d624e4b983e5b482a8ec1a0c0) | `` automatic update ``             |
| [`6cb13d15`](https://github.com/nix-community/NUR/commit/6cb13d15dd9b2b9ffb10e9d570233d3dcc36a71e) | `` automatic update ``             |
| [`aa75d9f3`](https://github.com/nix-community/NUR/commit/aa75d9f3084a6c17dd0e4bef38be65df390a50b9) | `` automatic update ``             |
| [`cd811be5`](https://github.com/nix-community/NUR/commit/cd811be5d7985403afd5728ab6905d6ab3c5e15e) | `` automatic update ``             |
| [`3154dd20`](https://github.com/nix-community/NUR/commit/3154dd2013a4a0f19cd62df84d344dff91ec88ae) | `` automatic update ``             |
| [`c43f3884`](https://github.com/nix-community/NUR/commit/c43f38848aa78cc2e649cf0232589a4e25958773) | `` automatic update ``             |
| [`eb12e2c5`](https://github.com/nix-community/NUR/commit/eb12e2c5e8b9c099eff2098924c760ad941a573c) | `` automatic update ``             |
| [`710b3dbf`](https://github.com/nix-community/NUR/commit/710b3dbf99f137ced15844fc87ac403f8b2f7211) | `` automatic update ``             |
| [`c6ce2176`](https://github.com/nix-community/NUR/commit/c6ce2176842d103b5c956269481169f1168ba5cd) | `` automatic update ``             |
| [`2b9cf08e`](https://github.com/nix-community/NUR/commit/2b9cf08e3131543bae936c75c8635f3de682fc4b) | `` automatic update ``             |
| [`0f0e4963`](https://github.com/nix-community/NUR/commit/0f0e49633ad3752a05c8e92864f013efc7c3c8bc) | `` automatic update ``             |
| [`9c188633`](https://github.com/nix-community/NUR/commit/9c188633a9cbfd0c1c81b0a8212c8486a3f10a30) | `` automatic update ``             |
| [`111f701e`](https://github.com/nix-community/NUR/commit/111f701e9a6ab1612e561397c66310772370d909) | `` automatic update ``             |
| [`4d14dfd1`](https://github.com/nix-community/NUR/commit/4d14dfd1ee00acc4e2e38982c4b104dce2e64b30) | `` automatic update ``             |
| [`63bd457d`](https://github.com/nix-community/NUR/commit/63bd457df8b0a9e3dd32350ce908b411a8b548e2) | `` automatic update ``             |
| [`f1ac582e`](https://github.com/nix-community/NUR/commit/f1ac582e2c7bcaa1e9b7e5e7d96e546391ca9bca) | `` automatic update ``             |
| [`219c8acc`](https://github.com/nix-community/NUR/commit/219c8accacaaed12989564d4bf2f6b9a39532944) | `` automatic update ``             |
| [`397ef4d1`](https://github.com/nix-community/NUR/commit/397ef4d149c587b19977209b0fbaaaf1c41edfb4) | `` automatic update ``             |
| [`4054c7e0`](https://github.com/nix-community/NUR/commit/4054c7e07150bac189d786c02d3cae13db151f56) | `` automatic update ``             |
| [`b9b75c71`](https://github.com/nix-community/NUR/commit/b9b75c71c0f520d644a07be8bb9deb33a6129927) | `` automatic update ``             |
| [`d47dbf43`](https://github.com/nix-community/NUR/commit/d47dbf43ced4485a2b05eb3430e85358b43f8dd1) | `` automatic update ``             |
| [`1dd57a39`](https://github.com/nix-community/NUR/commit/1dd57a39f8db7ca6cff9696c9ccf543df15bc263) | `` automatic update ``             |
| [`b3df65ab`](https://github.com/nix-community/NUR/commit/b3df65ab7e7aef08b1204efce768b577c5f48034) | `` automatic update ``             |
| [`1c51a38f`](https://github.com/nix-community/NUR/commit/1c51a38f6bb8297ffdcd4d203fed1154b8523361) | `` automatic update ``             |
| [`3d28563e`](https://github.com/nix-community/NUR/commit/3d28563eb8c950868143f0b2bd98e6aefcbf53a2) | `` automatic update ``             |
| [`1221ce16`](https://github.com/nix-community/NUR/commit/1221ce16e52f7ccb909b8a6970d792989f90aba7) | `` automatic update ``             |
| [`94ca1687`](https://github.com/nix-community/NUR/commit/94ca168756e90b856bb94a40b0c4cbc403ec4c10) | `` automatic update ``             |
| [`c893a063`](https://github.com/nix-community/NUR/commit/c893a063986c235396a6baca94a747bb879c1f5d) | `` automatic update ``             |
| [`f83a1817`](https://github.com/nix-community/NUR/commit/f83a1817d263a914ca4747fbb9026e8296db28f8) | `` automatic update ``             |
| [`7e0db0cf`](https://github.com/nix-community/NUR/commit/7e0db0cf2e4fd81fd9171b22c0598b3c10c07b93) | `` automatic update ``             |
| [`04cf6773`](https://github.com/nix-community/NUR/commit/04cf6773dda024c1ae0176e158d33c5d54e31975) | `` automatic update ``             |
| [`b3207b9c`](https://github.com/nix-community/NUR/commit/b3207b9cd0cfc0074645375bce1c90e6159458e9) | `` automatic update ``             |
| [`055eeb2d`](https://github.com/nix-community/NUR/commit/055eeb2d3c8f6c63c170b3b709478921e973c2fb) | `` automatic update ``             |
| [`86be2f15`](https://github.com/nix-community/NUR/commit/86be2f150dfce413d8d3a1bc782a2baea7f427e2) | `` automatic update ``             |
| [`80c86b64`](https://github.com/nix-community/NUR/commit/80c86b649fcc2b97d978379a271d344ac79fcf46) | `` automatic update ``             |
| [`d2c468ae`](https://github.com/nix-community/NUR/commit/d2c468ae02e54593b1d83537429853873b93abd0) | `` automatic update ``             |
| [`cd11db96`](https://github.com/nix-community/NUR/commit/cd11db9649316bcd231a6ab9c677284ee0d8c184) | `` automatic update ``             |
| [`caa41ebc`](https://github.com/nix-community/NUR/commit/caa41ebc039eb69147bc5c805c1d00ad447fc93d) | `` automatic update ``             |
| [`9534dd71`](https://github.com/nix-community/NUR/commit/9534dd7152380c152b5a14e646a882de59ea51c2) | `` automatic update ``             |
| [`0dbda58c`](https://github.com/nix-community/NUR/commit/0dbda58cb6ec3a800b15de114669e71a25c134a7) | `` automatic update ``             |
| [`d10584ba`](https://github.com/nix-community/NUR/commit/d10584ba0ab9f3e9dc2e451cc072a2c6cc2fddec) | `` automatic update ``             |
| [`59fceae7`](https://github.com/nix-community/NUR/commit/59fceae769455455ef44c1dfb63bbae1ecddc41d) | `` automatic update ``             |
| [`547506ae`](https://github.com/nix-community/NUR/commit/547506ae6419ea2e54e8fcf02c37fba340dd97d7) | `` automatic update ``             |
| [`c9082c6b`](https://github.com/nix-community/NUR/commit/c9082c6bafa25a4c1ad1b5ca370a063c723d9c21) | `` automatic update ``             |
| [`2f1ba0ef`](https://github.com/nix-community/NUR/commit/2f1ba0efb756f813843fb4be0a73cd0759852e03) | `` automatic update ``             |
| [`c8ca24b1`](https://github.com/nix-community/NUR/commit/c8ca24b1e7a7cafc2788e8da83793eb4c986d00e) | `` automatic update ``             |
| [`a92630ba`](https://github.com/nix-community/NUR/commit/a92630ba5bd35d9f3ea8432ffc8b75a3aa34df04) | `` automatic update ``             |
| [`b3ceff8d`](https://github.com/nix-community/NUR/commit/b3ceff8daa4c475f69de298d9493e0ae9de16002) | `` add eownerdead repository ``    |
| [`1d5ac4e7`](https://github.com/nix-community/NUR/commit/1d5ac4e7212e568f128644e993ac99363be15aa6) | `` automatic update ``             |
| [`f091eff0`](https://github.com/nix-community/NUR/commit/f091eff006378774b654635e115675814f783207) | `` add demivan repository ``       |
| [`c10720db`](https://github.com/nix-community/NUR/commit/c10720db02e241cdf92f0431013ca5c31ceed797) | `` automatic update ``             |
| [`de6bf2f2`](https://github.com/nix-community/NUR/commit/de6bf2f257fe7be5d363fb453884aa927d4528f0) | `` add ggemre repository ``        |
| [`2fa7d477`](https://github.com/nix-community/NUR/commit/2fa7d4770a2013aed3b8c65bf7f0414738813da4) | `` automatic update ``             |
| [`b26259c7`](https://github.com/nix-community/NUR/commit/b26259c7e5a213507c21a404e5eec9b7e40d3183) | `` add twistoy repository ``       |
| [`715b3554`](https://github.com/nix-community/NUR/commit/715b35541008f5b4c1147d42d3d8bbd2ce1c974d) | `` automatic update ``             |
| [`b975c5d3`](https://github.com/nix-community/NUR/commit/b975c5d3c3afa7f52aaad98e1cdcd7eae070bce3) | `` add harukafractus repository `` |
| [`af9064a5`](https://github.com/nix-community/NUR/commit/af9064a549d5f89d4a85d651b0b94ac4a3c2ea23) | `` automatic update ``             |
| [`69c5afb8`](https://github.com/nix-community/NUR/commit/69c5afb84f142bdbe9079c048941d03aefad9d10) | `` automatic update ``             |
| [`28a61f1b`](https://github.com/nix-community/NUR/commit/28a61f1b42334baba1fc179b632852845fb5a9c0) | `` automatic update ``             |
| [`6cbec5ec`](https://github.com/nix-community/NUR/commit/6cbec5ec7a282a1ef4dc683ad739ef309a356c18) | `` automatic update ``             |
| [`4b2a4b0a`](https://github.com/nix-community/NUR/commit/4b2a4b0aba080fa079e371125d5d0c84236727ee) | `` automatic update ``             |
| [`c65ad4eb`](https://github.com/nix-community/NUR/commit/c65ad4eb0467ed7cf3dd8b9f0c1e1369aa1fb2af) | `` automatic update ``             |
| [`e0bec738`](https://github.com/nix-community/NUR/commit/e0bec73865d244c1c4479112daf36c5b0e8078c1) | `` automatic update ``             |
| [`dacaa989`](https://github.com/nix-community/NUR/commit/dacaa989fba8c5bb3efa3d5d1964f99407a11ae2) | `` automatic update ``             |
| [`78bd9227`](https://github.com/nix-community/NUR/commit/78bd9227a16201515082cc5eeb5cad4e842a9616) | `` automatic update ``             |
| [`3247ef77`](https://github.com/nix-community/NUR/commit/3247ef77c09dd3f8138660dda48fac8b2d2a429d) | `` automatic update ``             |
| [`ff750f0d`](https://github.com/nix-community/NUR/commit/ff750f0d827f95ab132046d0d01e82c37b7a1c5c) | `` automatic update ``             |
| [`65a74c3f`](https://github.com/nix-community/NUR/commit/65a74c3f40d3e60ba1b7c04c63c371208ba88657) | `` automatic update ``             |
| [`25e43919`](https://github.com/nix-community/NUR/commit/25e4391947cc2bb53de6f2277893b5339207d41f) | `` automatic update ``             |
| [`1cef2d36`](https://github.com/nix-community/NUR/commit/1cef2d364b4b4ff28fde06483b4cf5df9fee8a97) | `` automatic update ``             |
| [`4f568381`](https://github.com/nix-community/NUR/commit/4f5683815bec121ca33ca76c3b3513ca6bdd47ad) | `` automatic update ``             |
| [`3ad87700`](https://github.com/nix-community/NUR/commit/3ad877008a525772f7a1162b825e72a224c00632) | `` automatic update ``             |
| [`38340847`](https://github.com/nix-community/NUR/commit/383408470fd7375c874c697df9e0eb151a74e276) | `` automatic update ``             |
| [`91b05f05`](https://github.com/nix-community/NUR/commit/91b05f0568aed3c03a602755f1457a228c73aa07) | `` automatic update ``             |
| [`9eec0266`](https://github.com/nix-community/NUR/commit/9eec02662a79129ddd96e8027ede1c513aa4a18d) | `` automatic update ``             |
| [`e3d41526`](https://github.com/nix-community/NUR/commit/e3d4152650489edee1282af7a7a7d95e110ef424) | `` automatic update ``             |
| [`aa997413`](https://github.com/nix-community/NUR/commit/aa997413d7772f3ab5d12b45f44ccb8a9fa03420) | `` automatic update ``             |
| [`e496b0a1`](https://github.com/nix-community/NUR/commit/e496b0a16f125fcbb1f613065eb6d61564b1acce) | `` automatic update ``             |
| [`2fd6d20b`](https://github.com/nix-community/NUR/commit/2fd6d20bb00f05fc91321c2eebd497c2e5247d74) | `` automatic update ``             |
| [`02d07e54`](https://github.com/nix-community/NUR/commit/02d07e54807dada0f00b8f297c872d5ecb9cf65d) | `` automatic update ``             |
| [`efe7184e`](https://github.com/nix-community/NUR/commit/efe7184e100553bbe6dfcbbd5911cb40f26c4564) | `` automatic update ``             |
| [`e55ccb49`](https://github.com/nix-community/NUR/commit/e55ccb495ff1c39fb600db4ba5b92e477e01213e) | `` automatic update ``             |
| [`08b53a97`](https://github.com/nix-community/NUR/commit/08b53a973f9fc702f90a5be56b7d9f47bb5aaa41) | `` automatic update ``             |
| [`2a244c5d`](https://github.com/nix-community/NUR/commit/2a244c5dd44f615430778f92cc270524b015cc52) | `` automatic update ``             |
| [`6e3c74c2`](https://github.com/nix-community/NUR/commit/6e3c74c2dc6c16725e1059015dc98fc7984e9302) | `` automatic update ``             |
| [`b4dc91a3`](https://github.com/nix-community/NUR/commit/b4dc91a3de210a54889bb5df410780783a5f0888) | `` automatic update ``             |
| [`e6f6f4d8`](https://github.com/nix-community/NUR/commit/e6f6f4d8d2ecb0efe4b51c8337d461c303319733) | `` automatic update ``             |
| [`4f131f19`](https://github.com/nix-community/NUR/commit/4f131f190ff362b8cadca9d063ac8e16207c7af7) | `` automatic update ``             |
| [`7da4a8a9`](https://github.com/nix-community/NUR/commit/7da4a8a9a76d5b62aba41fe9063341829f7e5707) | `` automatic update ``             |
| [`3c8e9a89`](https://github.com/nix-community/NUR/commit/3c8e9a897ca4e705c7dea1303b79830d06cb09f7) | `` automatic update ``             |
| [`2a045537`](https://github.com/nix-community/NUR/commit/2a0455372ab43453f4a7260bfa1aa64813f63933) | `` automatic update ``             |
| [`d697b6b0`](https://github.com/nix-community/NUR/commit/d697b6b0de1829b872c4a16e4d1c596699e9ea03) | `` automatic update ``             |
| [`47ff97d9`](https://github.com/nix-community/NUR/commit/47ff97d9b90f9f2c19022f12582fce59a45b504c) | `` automatic update ``             |
| [`d57cb6ba`](https://github.com/nix-community/NUR/commit/d57cb6ba576b907f4abe41dcf16e99620242eccf) | `` automatic update ``             |
| [`597c8934`](https://github.com/nix-community/NUR/commit/597c89346ff30536c9923d964893110213dd975c) | `` automatic update ``             |
| [`42d465eb`](https://github.com/nix-community/NUR/commit/42d465ebd6db46f3f03c9bbeeebb562f7cb4a023) | `` automatic update ``             |
| [`f837023b`](https://github.com/nix-community/NUR/commit/f837023b7dc36bceca1bc4b6becef87802f259a2) | `` automatic update ``             |
| [`674996ec`](https://github.com/nix-community/NUR/commit/674996ec4ce4f9c4771d110dd1767ad50390f54b) | `` automatic update ``             |
| [`e3d1786d`](https://github.com/nix-community/NUR/commit/e3d1786dc5957e85cf634309c69f00e36f3bd8d6) | `` automatic update ``             |
| [`51437703`](https://github.com/nix-community/NUR/commit/51437703b754e4be55f604c6cfb8eee8f8874ab8) | `` automatic update ``             |
| [`a3141350`](https://github.com/nix-community/NUR/commit/a31413502022e9f157a46570bbc34b7dce1a80da) | `` automatic update ``             |
| [`d4e19206`](https://github.com/nix-community/NUR/commit/d4e19206de96f8c824314ff9b6cbbc00ac9337b9) | `` automatic update ``             |
| [`c4d4b7ff`](https://github.com/nix-community/NUR/commit/c4d4b7ffa0166e69d45491ffa1bf53b58d8579f8) | `` automatic update ``             |
| [`51579816`](https://github.com/nix-community/NUR/commit/515798160ecfeef7b533cc772a6711d88f30b89f) | `` automatic update ``             |
| [`c4761461`](https://github.com/nix-community/NUR/commit/c4761461667441873565fb41ab947803255b1669) | `` automatic update ``             |
| [`abe9eb6d`](https://github.com/nix-community/NUR/commit/abe9eb6d605d624e121d4f84749b47f7816f1686) | `` automatic update ``             |
| [`f66ad1a3`](https://github.com/nix-community/NUR/commit/f66ad1a3a3aedd1862bc5dc1885ec348fa23f897) | `` automatic update ``             |
| [`dc62bfc9`](https://github.com/nix-community/NUR/commit/dc62bfc986c23304a671a977b663c948d60f0122) | `` automatic update ``             |
| [`bc997365`](https://github.com/nix-community/NUR/commit/bc9973659862d195272be7cf85ba9cd656d4dd21) | `` automatic update ``             |
| [`84d09dbc`](https://github.com/nix-community/NUR/commit/84d09dbc8092ac63ee99245bf8518276f12df4aa) | `` automatic update ``             |
| [`51b44c67`](https://github.com/nix-community/NUR/commit/51b44c67a6d45183f55b79a5d691d2093b2a046e) | `` automatic update ``             |
| [`8ab9654c`](https://github.com/nix-community/NUR/commit/8ab9654cc85c8b415660b98c942f4a7e6bf1bf7b) | `` automatic update ``             |
| [`a1a35629`](https://github.com/nix-community/NUR/commit/a1a35629e1836822cf67a2c555d0110d9784a4f9) | `` automatic update ``             |
| [`3029217b`](https://github.com/nix-community/NUR/commit/3029217b493a7f90093439a45c1bd2e1821e8f0e) | `` automatic update ``             |
| [`5c5049bf`](https://github.com/nix-community/NUR/commit/5c5049bf7c0054ac395bb5e1bc3ec6b105c196ec) | `` automatic update ``             |
| [`8b7fb422`](https://github.com/nix-community/NUR/commit/8b7fb42266d566a47777426dce429373cf68542d) | `` automatic update ``             |
| [`5b2e8b3c`](https://github.com/nix-community/NUR/commit/5b2e8b3cb4404e60da0c4f64f9c17feae02132e8) | `` automatic update ``             |
| [`ab432ace`](https://github.com/nix-community/NUR/commit/ab432acea15134873882610c0e936a882319bc8a) | `` automatic update ``             |