### PR TITLE
chore(flake/treefmt-nix): `c6153c2a` -> `ac599dab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1145,11 +1145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706462057,
-        "narHash": "sha256-7dG1D4iqqt0bEbBqUWk6lZiSqqwwAO0Hd1L5opVyhNM=",
+        "lastModified": 1707300477,
+        "narHash": "sha256-qQF0fEkHlnxHcrKIMRzOETnRBksUK048MXkX0SOmxvA=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "c6153c2a3ff4c38d231e3ae99af29b87f1df5901",
+        "rev": "ac599dab59a66304eb511af07b3883114f061b9d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                     |
| ---------------------------------------------------------------------------------------------------- | --------------------------- |
| [`ac599dab`](https://github.com/numtide/treefmt-nix/commit/ac599dab59a66304eb511af07b3883114f061b9d) | `` docs: fix typo (#157) `` |