### PR TITLE
chore(flake/nixpkgs): `4f301350` -> `9a113b42`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -908,11 +908,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1706941790,
-        "narHash": "sha256-V4apg6WJS6hc1VhHuUpaLt0r/ulu/hvFruP6NKdEdfo=",
+        "lastModified": 1707347693,
+        "narHash": "sha256-/MxX1WUwKui2dWtKghN+8qIKf8X7hHPD1KCeDXoApEI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4f301350dacb4eb0a93578ef3b07c8a996c777e7",
+        "rev": "9a113b42b3b15eafa91a027bd9fb9fd69fa6ed96",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                         |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
| [`9a113b42`](https://github.com/NixOS/nixpkgs/commit/9a113b42b3b15eafa91a027bd9fb9fd69fa6ed96) | `` nixos/version: add ANSI_COLOR ``                                                                             |
| [`c9223ea4`](https://github.com/NixOS/nixpkgs/commit/c9223ea44c223379f22a091c57700fa378a758df) | `` nwjs: 0.83.0 -> 0.84.0 ``                                                                                    |
| [`3cbc0a78`](https://github.com/NixOS/nixpkgs/commit/3cbc0a7859f9362bd014a8020600bcf7f8c1bd2a) | `` smb3-foundry: clean up installPhase, move to pkgs/by-name ``                                                 |
| [`73f6bc2c`](https://github.com/NixOS/nixpkgs/commit/73f6bc2c4e0b3dbcd82017a4394926121c67a8ee) | `` pdf-sign: fix version name, simplify installPhase, move to pkgs/by-name ``                                   |
| [`3392575c`](https://github.com/NixOS/nixpkgs/commit/3392575c4008b9a98dc69e68d02a031b379d5a81) | `` onnxruntime: use system eigen ``                                                                             |
| [`aec707e0`](https://github.com/NixOS/nixpkgs/commit/aec707e098fadacc0a1ae08412a2c9091e83dfba) | `` xv: 4.2.0 -> 5.0.0 ``                                                                                        |
| [`13ba002d`](https://github.com/NixOS/nixpkgs/commit/13ba002dd0be470f182eee16f9e791d76875c771) | `` nixos/services.gitlab: loosen the coupling between gitlab and postgres/ redis to avoid restarts and races `` |
| [`28c1d054`](https://github.com/NixOS/nixpkgs/commit/28c1d054376033cff62460236ebb5e09d5c6b77f) | `` onnxruntime: 1.15.1 -> 1.16.3 ``                                                                             |
| [`66deaec7`](https://github.com/NixOS/nixpkgs/commit/66deaec720a59bbf1e5c142d8a856e67cd81530c) | `` nixos/appliance-repart-image: use UKI in docs ``                                                             |
| [`106626b8`](https://github.com/NixOS/nixpkgs/commit/106626b8d7fb3708e72d566d843fa78f0a294022) | `` nixos/tt-rss: add phpPackage option ``                                                                       |
| [`17adf961`](https://github.com/NixOS/nixpkgs/commit/17adf961ceb74a49b174f6938e24d4eca2fa55d6) | `` broot: 1.32.0 -> 1.33.1 ``                                                                                   |
| [`55747839`](https://github.com/NixOS/nixpkgs/commit/55747839b5affc1dd7df52342d975d1ed5ddcf15) | `` cudaPackages.nccl-tests: 2.13.8 -> 2.13.9 ``                                                                 |
| [`2002957f`](https://github.com/NixOS/nixpkgs/commit/2002957f20f8bfbac65f18a68a209633a8e10b2d) | `` chromium: 121.0.6167.139 -> 121.0.6167.160 ``                                                                |
| [`ad674855`](https://github.com/NixOS/nixpkgs/commit/ad67485526c1e0984dd160b983023a27079d7b71) | `` kanidm: 1.1.0-rc.15 -> 1.1.0-rc.16 ``                                                                        |
| [`afbfbf01`](https://github.com/NixOS/nixpkgs/commit/afbfbf01643bf315605be4b764e90e4cdcf8ddd7) | `` minio: 2024-01-31T20-20-33Z -> 2024-02-04T22-36-13Z ``                                                       |
| [`07d406f7`](https://github.com/NixOS/nixpkgs/commit/07d406f7a75b25104bbcf102440bb9e3fe6a7474) | `` gqlgenc: 0.18.0 -> 0.18.1 ``                                                                                 |
| [`02324756`](https://github.com/NixOS/nixpkgs/commit/02324756dd489f3728d0a228d4fce672157b3924) | `` nixos/zigbee2mqtt: revert systemd unit to simple type ``                                                     |
| [`a292ac8c`](https://github.com/NixOS/nixpkgs/commit/a292ac8cd25d2a3e7125a4efea750f82f03a4f48) | `` libgit2: add gitstatus to passthru.tests ``                                                                  |
| [`371fcf04`](https://github.com/NixOS/nixpkgs/commit/371fcf049a2dc9ea44c953c83b4454b3196e642a) | `` zigbee2mqtt: 1.35.2 -> 1.35.3 ``                                                                             |
| [`ed54fe0d`](https://github.com/NixOS/nixpkgs/commit/ed54fe0d08a9fbad7825485a033f46e288931bb0) | `` python311Packages.sagemaker: 2.206.0 -> 2.207.1 ``                                                           |
| [`665b4e7b`](https://github.com/NixOS/nixpkgs/commit/665b4e7b14f2c11092ea57cf73eaf374f2bc2309) | `` gitstatus: disable checks for forked libgit2 dep ``                                                          |
| [`9ddf764b`](https://github.com/NixOS/nixpkgs/commit/9ddf764b404c9da4fcdc775da98c093e98cb1234) | `` emplace: 1.5.1 -> 1.5.2 ``                                                                                   |
| [`f0bc2e58`](https://github.com/NixOS/nixpkgs/commit/f0bc2e58bb566112799a5e3a88d20460e47cdcd3) | `` pysqlrecon: 0.1.3 -> 0.1.4 ``                                                                                |
| [`c319883b`](https://github.com/NixOS/nixpkgs/commit/c319883be28aec0fa165df7a49ba004b765e62e8) | `` numix-icon-theme-square: 23.12.10 -> 24.02.05 ``                                                             |
| [`8f096454`](https://github.com/NixOS/nixpkgs/commit/8f096454c3fbb7a0fb5b842f7ddf81734c4a1746) | `` halloy: set `meta.mainProgram` ``                                                                            |
| [`f1d3bd69`](https://github.com/NixOS/nixpkgs/commit/f1d3bd6991234239daa6d64b62c749282fef5844) | `` home-manager: unstable-2024-02-03 -> unstable-2024-02-06 ``                                                  |
| [`2e75dc82`](https://github.com/NixOS/nixpkgs/commit/2e75dc8282734c1bd32ad724daf49e434190fc12) | `` phrase-cli: 2.21.0 -> 2.21.2 ``                                                                              |
| [`0004d79a`](https://github.com/NixOS/nixpkgs/commit/0004d79a2e8d9e55dad0e6f3d7607009f956c9f3) | `` upterm: 0.12.0 -> 0.13.2 ``                                                                                  |
| [`e1569fbb`](https://github.com/NixOS/nixpkgs/commit/e1569fbb4585f7ee9747b9479e59f8774eb52d56) | `` python311Packages.pytest-md-report: 0.5.0 -> 0.5.1 ``                                                        |
| [`75bc0374`](https://github.com/NixOS/nixpkgs/commit/75bc0374e0216e40e11b97b7d90ffcc8c46a7bbc) | `` python311Packages.spacy: 3.7.2 -> 3.7.3 ``                                                                   |
| [`f4f9d00a`](https://github.com/NixOS/nixpkgs/commit/f4f9d00a45a7757a647f99d165e2800911472b82) | `` go_1_20: 1.20.13 -> 1.20.14 ``                                                                               |
| [`1b3f9208`](https://github.com/NixOS/nixpkgs/commit/1b3f92087bc8d15fa86ca97379d18aeb963443b7) | `` nixos/govee2mqtt: init ``                                                                                    |
| [`48622254`](https://github.com/NixOS/nixpkgs/commit/486222545b3157118ca738a229030e4a91a304ca) | `` govee2mqtt: init at 2024.01.24-ea3cd430 ``                                                                   |
| [`32ac0582`](https://github.com/NixOS/nixpkgs/commit/32ac05825f7ef1823c4a1e7e13a3c47f61f8883d) | `` gvproxy: 0.7.2 -> 0.7.3 ``                                                                                   |
| [`ebae8f3f`](https://github.com/NixOS/nixpkgs/commit/ebae8f3f0260502c6d5550a92472f57587c63ee9) | `` remote-touchpad: 1.4.5 -> 1.4.6 ``                                                                           |
| [`ca067c78`](https://github.com/NixOS/nixpkgs/commit/ca067c7863982a3c44323c63034e0a8447bce8b8) | `` tdl: init at 0.15.1 ``                                                                                       |
| [`d1238f35`](https://github.com/NixOS/nixpkgs/commit/d1238f3546b55cda310d74eeacb239c8c7c8b78e) | `` phosh-mobile-settings: Drop desktop entry tweaks ``                                                          |
| [`8513f69b`](https://github.com/NixOS/nixpkgs/commit/8513f69b24a08de94af164aa068b90ad0da74630) | `` nixos/phosh: Ensure that desktop session is identified as Phosh ``                                           |
| [`a9982a78`](https://github.com/NixOS/nixpkgs/commit/a9982a78ee7057eb58e988d865156ed41e690ba8) | `` phosh: Use wayland session desktop entry from upstream ``                                                    |
| [`42952e0e`](https://github.com/NixOS/nixpkgs/commit/42952e0ea27fd88d39f9350aca33b6883fe96236) | `` phosh: build tweaks ``                                                                                       |
| [`1326c3db`](https://github.com/NixOS/nixpkgs/commit/1326c3dbb4c1ad80fb5004fff3102f7df6f69207) | `` phosh-mobile-settings: set meta.maintainers to self ``                                                       |
| [`6263d48e`](https://github.com/NixOS/nixpkgs/commit/6263d48ee01bd31bf05b55151b078607b79af05c) | `` phosh-mobile-settings: 0.31.0 -> 0.35.1 ``                                                                   |
| [`a45634d4`](https://github.com/NixOS/nixpkgs/commit/a45634d41506651da468dcff8f7a22bd2073b71c) | `` phosh-mobile-settings: 0.23.1 -> 0.31.0, use release tarball for src ``                                      |
| [`d1b00d07`](https://github.com/NixOS/nixpkgs/commit/d1b00d0765502651990a85d51105bfedc17a845a) | `` phosh: 0.34.1 -> 0.35.0 ``                                                                                   |
| [`45cac737`](https://github.com/NixOS/nixpkgs/commit/45cac73752e4b7ec13be57d96d1174af3555d268) | `` phosh: 0.33.0 -> 0.34.1, use release tarball for src ``                                                      |
| [`bc695020`](https://github.com/NixOS/nixpkgs/commit/bc695020db880c0e7e9321ff19748f5805091732) | `` phoc: add passthru.tests.version ``                                                                          |
| [`6885a4db`](https://github.com/NixOS/nixpkgs/commit/6885a4db8f923f8a809a4367c80c313024a2dbe5) | `` phoc: 0.31.0 -> 0.35.0 ``                                                                                    |
| [`ea05237d`](https://github.com/NixOS/nixpkgs/commit/ea05237d93e7ca8ec101bfe557a34ba29b2725f5) | `` phoc: Provide patched wlroots as mkDerivation attribute ``                                                   |
| [`d15652a1`](https://github.com/NixOS/nixpkgs/commit/d15652a1afbdcac74b00e049ab1ab2ce278f2a3b) | `` phoc: Update source url to point to new releases page ``                                                     |
| [`9c8e2ca8`](https://github.com/NixOS/nixpkgs/commit/9c8e2ca8714ba17ba1f30386723a6bb6fd1e3acb) | `` python311Packages.mujoco: 3.1.1 -> 3.1.2 ``                                                                  |
| [`ddb38332`](https://github.com/NixOS/nixpkgs/commit/ddb383321763ae35d8bb1e56f96965352d3441ad) | `` mujoco: 3.1.1 -> 3.1.2 ``                                                                                    |
| [`62da9ca2`](https://github.com/NixOS/nixpkgs/commit/62da9ca2392e4fbb1e97d6f78991ff40f0d0b581) | `` mujoco: mark as broken on darwin ``                                                                          |
| [`bb6dfcc9`](https://github.com/NixOS/nixpkgs/commit/bb6dfcc947fbd6ddb20acc5292e3395927fb88cb) | `` python311Packages.aio-georss-gdacs: 0.8 -> 0.9 ``                                                            |
| [`b115ae54`](https://github.com/NixOS/nixpkgs/commit/b115ae5464e8f9a1d8b0438166f83958822604af) | `` python311Packages.aio-georss-client: 0.11 -> 0.12 ``                                                         |
| [`9d318b3a`](https://github.com/NixOS/nixpkgs/commit/9d318b3af0ee9ce4197906a573613b5769a050f5) | `` python311Packages.skodaconnect: 1.3.9 -> 1.3.10 ``                                                           |
| [`0f92e1e0`](https://github.com/NixOS/nixpkgs/commit/0f92e1e02435296e2a655fead2b5b6b798e62298) | `` python311Packages.py-dmidecode: 0.1.2 -> 0.1.3 ``                                                            |
| [`ad6ae861`](https://github.com/NixOS/nixpkgs/commit/ad6ae861ae7838b93fcab1d25ac928d1d0a1648e) | `` python311Packages.publicsuffixlist: 0.10.0.20240205 -> 0.10.0.20240207 ``                                    |
| [`e5fae89c`](https://github.com/NixOS/nixpkgs/commit/e5fae89ca7ef81ecc75c933bef1a9af0e416b71d) | `` python311Packages.plexapi: 4.15.7 -> 4.15.9 ``                                                               |
| [`6a79953c`](https://github.com/NixOS/nixpkgs/commit/6a79953ce1af501de23a6562ebdade0d12e05e2b) | `` redli: 0.11.0 -> 0.12.0 ``                                                                                   |
| [`9c346d1d`](https://github.com/NixOS/nixpkgs/commit/9c346d1d9a35b1e14ec3f29c74ae334a866cf7c3) | `` regctl: 0.5.6 -> 0.5.7 ``                                                                                    |
| [`50f7d86a`](https://github.com/NixOS/nixpkgs/commit/50f7d86aa69b400376efd3d12e9961b5f45cf9a8) | `` semantic-release: 23.0.0 -> 23.0.1 ``                                                                        |
| [`a8ae7c8f`](https://github.com/NixOS/nixpkgs/commit/a8ae7c8f0da4600e917af36cc9955e00b79d719a) | `` regclient: 0.5.6 -> 0.5.7 ``                                                                                 |
| [`d83aa4d2`](https://github.com/NixOS/nixpkgs/commit/d83aa4d2f475ff72159f3ca5ad91e7e77cf37e23) | `` k9s: 0.31.7 -> 0.31.8 ``                                                                                     |
| [`efb604a6`](https://github.com/NixOS/nixpkgs/commit/efb604a6a11c065e7c8f67882297d487940230cb) | `` python311Packages.pex: 2.1.159 -> 2.1.162 ``                                                                 |
| [`2d55bd01`](https://github.com/NixOS/nixpkgs/commit/2d55bd012beec84a4ccfec6639d7fa82fc69a479) | `` regsync: 0.5.6 -> 0.5.7 ``                                                                                   |
| [`b5e4a84c`](https://github.com/NixOS/nixpkgs/commit/b5e4a84cd5a28b127b0b5261beaf46f2aeca3819) | `` regbot: 0.5.6 -> 0.5.7 ``                                                                                    |
| [`e7a7fda1`](https://github.com/NixOS/nixpkgs/commit/e7a7fda14d7c37e70db9e56ec86a8fb082c1577d) | `` mdbook-katex: 0.5.9 -> 0.5.10 ``                                                                             |
| [`38c08f46`](https://github.com/NixOS/nixpkgs/commit/38c08f46a4c9c400078ff1f311a3ae6c3d283c5a) | `` zf: 0.9.0 -> 0.9.1 ``                                                                                        |
| [`79affc18`](https://github.com/NixOS/nixpkgs/commit/79affc18ffa110fecefe837e69256e0017825716) | `` pg_featureserv: 1.3.0 -> 1.3.1 ``                                                                            |
| [`d5917b14`](https://github.com/NixOS/nixpkgs/commit/d5917b14b367fe517070503f6a93881991424961) | `` mk-python-derivation: fix passthru.updateScript being merged into the derivation (#241922) ``                |
| [`99d8d50c`](https://github.com/NixOS/nixpkgs/commit/99d8d50cd5408aab36d91d211c41d3591fb68f7f) | `` python311Packages.google-cloud-spanner: 3.41.0 -> 3.42.0 ``                                                  |
| [`ea4a1d1e`](https://github.com/NixOS/nixpkgs/commit/ea4a1d1e494647b715cb69ca01c24ec251ad92a5) | `` python311Packages.grpc-interceptor: 0.15.3 -> 0.15.4 ``                                                      |
| [`41c5d384`](https://github.com/NixOS/nixpkgs/commit/41c5d38419e666d2cbf7b9b30c2cf724cca70ea3) | `` python311Packages.mandown: add meta.changelog ``                                                             |
| [`3c29dc68`](https://github.com/NixOS/nixpkgs/commit/3c29dc6808e287d8ea59c70d9ec1742f8ee0ec48) | `` trivy: 0.49.0 -> 0.49.1 ``                                                                                   |
| [`25f8533f`](https://github.com/NixOS/nixpkgs/commit/25f8533f8852ffb4bcd0c13a68399f43bf82e115) | `` python311Packages.mandown: unpin pillow ``                                                                   |
| [`95dae9bd`](https://github.com/NixOS/nixpkgs/commit/95dae9bd60a64e9ee2ba981099d6645d90a3daa3) | `` runme: 2.2.2 -> 2.2.5 ``                                                                                     |
| [`b8a1ff8e`](https://github.com/NixOS/nixpkgs/commit/b8a1ff8e2d8543f22d184308dffbae801e1fbadb) | `` python311Packages.comicon: 1.0.0 -> 1.0.1 ``                                                                 |
| [`0df3b6e3`](https://github.com/NixOS/nixpkgs/commit/0df3b6e38e283c6c627e611d132dc37b8c839e4b) | `` python311Packages.google-cloud-pubsub: 2.19.0 -> 2.19.1 ``                                                   |
| [`bea217ba`](https://github.com/NixOS/nixpkgs/commit/bea217ba83f3c61d5cfa1336e1768765c0ca4b35) | `` croc: 9.6.6 -> 9.6.8 ``                                                                                      |
| [`09c27fe4`](https://github.com/NixOS/nixpkgs/commit/09c27fe4b2a143a0b37c8129356b5a49296b7ec1) | `` yazi: 0.2.2 -> 0.2.3 ``                                                                                      |
| [`d43ac1a5`](https://github.com/NixOS/nixpkgs/commit/d43ac1a5dd16cb0a499bb390501b188b0fcd4280) | `` aiac: 4.1.0 -> 4.2.0 ``                                                                                      |
| [`b141f346`](https://github.com/NixOS/nixpkgs/commit/b141f3467b7c2a0aa04686bfd039031c01e7652c) | `` ocamlPackages.capnp: init at 3.6.0 ``                                                                        |
| [`9d6ec0c4`](https://github.com/NixOS/nixpkgs/commit/9d6ec0c45ae807995ea30293015c995764ad4b64) | `` ocamlPackages.res: init at 5.0.1 ``                                                                          |
| [`5963e2fd`](https://github.com/NixOS/nixpkgs/commit/5963e2fd3cbf6a70724ac96d3adb2eedd5098a30) | `` exoscale-cli: 1.75.0 -> 1.76.0 ``                                                                            |
| [`b1687d15`](https://github.com/NixOS/nixpkgs/commit/b1687d1533a30ed8d122502e170c524342ff8c5c) | `` astyle: 3.4.11 -> 3.4.12 ``                                                                                  |
| [`229e7f35`](https://github.com/NixOS/nixpkgs/commit/229e7f351add5b5aea35a52315a2c03343139d4a) | `` ignite-cli: 28.1.1 -> 28.2.0 ``                                                                              |
| [`7cb73f98`](https://github.com/NixOS/nixpkgs/commit/7cb73f985d094ebc17557064c84a4655b6765c8c) | `` arduino-language-server: 0.7.5 -> 0.7.6 ``                                                                   |
| [`0388cf09`](https://github.com/NixOS/nixpkgs/commit/0388cf09055be8bcc2597bb76ab08f832e543bcd) | `` python312Packages.puremagic: 1.15 -> 1.20 ``                                                                 |
| [`cd5e8f2a`](https://github.com/NixOS/nixpkgs/commit/cd5e8f2aabaaeb9b70cd5a3b96b3275607ba690d) | `` slirp4netns: 1.2.2 -> 1.2.3 ``                                                                               |
| [`2eb2d1bc`](https://github.com/NixOS/nixpkgs/commit/2eb2d1bc43d565aaa5a4f5610ebb22e72df118ad) | `` fsautocomplete: enable on darwin ``                                                                          |
| [`57b63849`](https://github.com/NixOS/nixpkgs/commit/57b638490339bdf3795aa76a9f39240499489f0c) | `` home-assistant-custom-components.emporia_vue: init at 0.8.3 ``                                               |
| [`08a263dd`](https://github.com/NixOS/nixpkgs/commit/08a263dd226831dd09207afd3bd0db3bc324fb9e) | `` python311Packages.blebox-uniapi: use pyproject = true ``                                                     |
| [`f8e2ebd6`](https://github.com/NixOS/nixpkgs/commit/f8e2ebd66d097614d51a56a755450d4ae1632df1) | `` camunda-modeler: 5.18.0 -> 5.19.0 (#282648) ``                                                               |
| [`a2528ef7`](https://github.com/NixOS/nixpkgs/commit/a2528ef72aad18d06a63c256758b02f826fafc82) | `` python311Packages.cmdstanpy: 1.2.0 -> 1.2.1 ``                                                               |
| [`c46bdb2e`](https://github.com/NixOS/nixpkgs/commit/c46bdb2e32fec400c6237513500ea8778a1ed8f2) | `` python311Packages.blebox-uniapi: 2.2.1 -> 2.2.2 ``                                                           |
| [`b39d11c4`](https://github.com/NixOS/nixpkgs/commit/b39d11c4a438138893fe1999e74754dc2c734eb9) | `` home-assistant: support blue_current component ``                                                            |
| [`9a2dd8e4`](https://github.com/NixOS/nixpkgs/commit/9a2dd8e4798be098877175e835eb8e23b85f2c33) | `` go_1_22: 1.22rc2 -> 1.22.0 ``                                                                                |
| [`588e5f80`](https://github.com/NixOS/nixpkgs/commit/588e5f80bf691de6d89f587253e57bbdf21b6770) | `` esphome: remove reference to test inputs ``                                                                  |
| [`0b9427cf`](https://github.com/NixOS/nixpkgs/commit/0b9427cf71692882a063a395554fe1cc5e0ede4b) | `` snakemake: 8.3.2 -> 8.4.4 ``                                                                                 |
| [`724b8ca5`](https://github.com/NixOS/nixpkgs/commit/724b8ca51ee57b5d89de063b48ed11d21bb2e1ae) | `` python311Packages.bluecurrent-api: init at 1.0.6 ``                                                          |
| [`14a041aa`](https://github.com/NixOS/nixpkgs/commit/14a041aa79811bfdd31e2383d597b8af978a116d) | `` python311Packages.botocore-stubs: 1.34.35 -> 1.34.36 ``                                                      |
| [`50d2bdfb`](https://github.com/NixOS/nixpkgs/commit/50d2bdfbe325c97a83c404f5811511098a362be2) | `` python311Packages.boto3-stubs: 1.34.35 -> 1.34.36 ``                                                         |
| [`df951021`](https://github.com/NixOS/nixpkgs/commit/df9510216f94f1b0a29537b6591eaf42f2c09caa) | `` home-assistant: support aosmith component ``                                                                 |
| [`e3f28575`](https://github.com/NixOS/nixpkgs/commit/e3f2857596c35a00346908c47bf92daa9602860c) | `` python311Packages.py-aosmith: init at 1.0.6 ``                                                               |
| [`8a43061f`](https://github.com/NixOS/nixpkgs/commit/8a43061fa55cda17747c236139aaabf86a0d54f3) | `` python311Packages.python-otbr-api: 2.5.0 -> 2.6.0 ``                                                         |
| [`d9fd193d`](https://github.com/NixOS/nixpkgs/commit/d9fd193d2f3943a956669d916ed3f30023187d3c) | `` python311Packages.xknxproject: 3.4.1 -> 3.5.0 ``                                                             |
| [`a45d18db`](https://github.com/NixOS/nixpkgs/commit/a45d18dbb652b0df5dc776a6e780a8d5732a27ce) | `` python311Packages.xknx: 2.11.2 -> 2.12.0 ``                                                                  |
| [`21924d4c`](https://github.com/NixOS/nixpkgs/commit/21924d4c931f4149ba26e13d79e17301550040a5) | `` wireless-regdb: 2023.09.01 -> 2024.01.23 (take 2, with crda removed) ``                                      |
| [`8c618c74`](https://github.com/NixOS/nixpkgs/commit/8c618c742cdffd547d0c8e9810e1db2e7e185507) | `` crda: remove package ``                                                                                      |
| [`f7a897b9`](https://github.com/NixOS/nixpkgs/commit/f7a897b9feac95c0e7559acb1e549f688c37c755) | `` terraform-providers.slack: init at 1.2.2 ``                                                                  |
| [`5e716b34`](https://github.com/NixOS/nixpkgs/commit/5e716b3472bf2788d11bb97a47243620284f0cb1) | `` python311Packages.motionblinds: refactor ``                                                                  |
| [`31fc36fc`](https://github.com/NixOS/nixpkgs/commit/31fc36fcd96da4f7cc232c9beae1771aa919d15d) | `` wireless-regdb: revert "add `crda` to tests" ``                                                              |