### PR TITLE
chore(flake/emacs-overlay): `ccaf5772` -> `22cce99b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -193,11 +193,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1707356707,
-        "narHash": "sha256-EPMnOYkQdpz9ch4qiDB+VQ+RusojToPgM88bo/TXHTE=",
+        "lastModified": 1707555888,
+        "narHash": "sha256-opXjVZpavvfMFzv9c+teipFQ2zDs6+CX7KOQE8uhuHc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "ccaf577227e5a64f95c03d66b6ac50879b4a3521",
+        "rev": "22cce99b0abb79c5d00583f6f82e823b2bdb131b",
         "type": "github"
       },
       "original": {
@@ -860,11 +860,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1707238373,
-        "narHash": "sha256-WKxT0yLzWbFZwYi92lI0yWJpYtRaFSWHGX8QXzejapw=",
+        "lastModified": 1707347730,
+        "narHash": "sha256-0etC/exQIaqC9vliKhc3eZE2Mm2wgLa0tj93ZF/egvM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fb0c047e30b69696acc42e669d02452ca1b55755",
+        "rev": "6832d0d99649db3d65a0e15fa51471537b2c56a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`22cce99b`](https://github.com/nix-community/emacs-overlay/commit/22cce99b0abb79c5d00583f6f82e823b2bdb131b) | `` Updated emacs ``        |
| [`98d2b370`](https://github.com/nix-community/emacs-overlay/commit/98d2b3707652c8638046a7578f30924529965b90) | `` Updated melpa ``        |
| [`95acf329`](https://github.com/nix-community/emacs-overlay/commit/95acf3297bda934c1ec5260e18ffea39f05bbf3a) | `` Updated emacs ``        |
| [`06528d90`](https://github.com/nix-community/emacs-overlay/commit/06528d90408b8c86f6d70ad2bb5e7f6fc86441ef) | `` Updated melpa ``        |
| [`5c6b8429`](https://github.com/nix-community/emacs-overlay/commit/5c6b8429c02e6593ee2bab649b28225097893751) | `` Updated elpa ``         |
| [`45e69044`](https://github.com/nix-community/emacs-overlay/commit/45e690448c8b0c3d3906bab65152f1c7e2e202a4) | `` Updated emacs ``        |
| [`e73eddaa`](https://github.com/nix-community/emacs-overlay/commit/e73eddaaa5ffbdf35bda143a4068115a049f45a0) | `` Updated melpa ``        |
| [`eda89e24`](https://github.com/nix-community/emacs-overlay/commit/eda89e24ee4ceb6e4bfcd00dabb894d6301c36db) | `` Updated emacs ``        |
| [`bc4a6ddc`](https://github.com/nix-community/emacs-overlay/commit/bc4a6ddc986782a49d3bf6cf6af27c6aeca7d8e9) | `` Updated melpa ``        |
| [`3ab30310`](https://github.com/nix-community/emacs-overlay/commit/3ab303101f287c1769f0a0dc4f7ec5473e61f94f) | `` Updated melpa ``        |
| [`2e98b222`](https://github.com/nix-community/emacs-overlay/commit/2e98b222342ad0cc9682d450988b498fb5309772) | `` Updated elpa ``         |
| [`ae7f86b1`](https://github.com/nix-community/emacs-overlay/commit/ae7f86b13cab5b2e89f6d3e4c121471a59e7980e) | `` Updated flake inputs `` |
| [`a225b7bb`](https://github.com/nix-community/emacs-overlay/commit/a225b7bbeab6a594a7f3859fef4c3f6898b1fd50) | `` Updated emacs ``        |
| [`64a63365`](https://github.com/nix-community/emacs-overlay/commit/64a633659fab447f12c898a32c451f88b5c3c048) | `` Updated melpa ``        |
| [`fec6062d`](https://github.com/nix-community/emacs-overlay/commit/fec6062d065254ef7a6a288f63ed19c0fee6d6be) | `` Updated elpa ``         |
| [`4a34b655`](https://github.com/nix-community/emacs-overlay/commit/4a34b655ebc29a22f13b547c1fa3729f7dd42f94) | `` Updated emacs ``        |
| [`08d584a5`](https://github.com/nix-community/emacs-overlay/commit/08d584a52c965ad6cd592750e7e004a2bda0901a) | `` Updated melpa ``        |