### PR TITLE
chore(flake/chaotic): `aba46bb7` -> `1b53f92c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -69,11 +69,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1707327858,
-        "narHash": "sha256-fPTE6hUNezT4B7lhjWB6zFPslXot4SPrt6WLAPlgDbw=",
+        "lastModified": 1707427222,
+        "narHash": "sha256-iV1orQaKAC/LQXkk9+1B3AyRGoHdxxdIb0jIga3uEDM=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "aba46bb7b47c6478941ee0b20dbdfa317924dd9b",
+        "rev": "1b53f92c20a7e4d7ca97ad5e06ec0d6ade776450",
         "type": "github"
       },
       "original": {
@@ -584,11 +584,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1707284098,
-        "narHash": "sha256-tYVS7r8XmgHJp0o5qsPa33fCKL6JYFvg43+f29qOJK4=",
+        "lastModified": 1707354388,
+        "narHash": "sha256-ohO87JNC/NjO73TtXXw2pNLtfLZ52FzdLvCGFC43iqI=",
         "owner": "martinvonz",
         "repo": "jj",
-        "rev": "1be82250460a914ba2c718260de32d2c9eb60f9d",
+        "rev": "12c3be70f442d0ea54a0a536d743b17dd8c74e4a",
         "type": "github"
       },
       "original": {
@@ -799,12 +799,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707092692,
-        "narHash": "sha256-ZbHsm+mGk/izkWtT4xwwqz38fdlwu7nUUKXTOmm4SyE=",
-        "rev": "faf912b086576fd1a15fca610166c98d47bc667e",
-        "revCount": 580425,
+        "lastModified": 1707268954,
+        "narHash": "sha256-2en1kvde3cJVc3ZnTy8QeD2oKcseLFjYPLKhIGDanQ0=",
+        "rev": "f8e2ebd66d097614d51a56a755450d4ae1632df1",
+        "revCount": 581229,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.580425%2Brev-faf912b086576fd1a15fca610166c98d47bc667e/018d7cf8-4100-74ee-a53f-928188670608/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.581229%2Brev-f8e2ebd66d097614d51a56a755450d4ae1632df1/018d8a37-bd05-79cb-a42f-290c1f0ca0ce/source.tar.gz"
       },
       "original": {
         "type": "tarball",


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                       |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`1b53f92c`](https://github.com/chaotic-cx/nyx/commit/1b53f92c20a7e4d7ca97ad5e06ec0d6ade776450) | `` yuzu-early-access_git: fix env & pin ffmpeg to upstream version ``         |
| [`7df770b0`](https://github.com/chaotic-cx/nyx/commit/7df770b05a6ffc769adee316f3b166a08b24568b) | `` gamescope_git: rebase ``                                                   |
| [`e386edf8`](https://github.com/chaotic-cx/nyx/commit/e386edf84c261fb6bf18b44fe93d50a640143946) | `` failures: update ``                                                        |
| [`4ce602c2`](https://github.com/chaotic-cx/nyx/commit/4ce602c22928bdfd7f75a245cc54f09f66dd976f) | `` yuzu-early-access_git: 20240201215036-71a5679 -> 20240208184231-3308f3b `` |
| [`c3ced956`](https://github.com/chaotic-cx/nyx/commit/c3ced9564cc320a380906990b7e5e0efa2ea4456) | `` nixpkgs: bump to 20240208 ``                                               |
| [`f981e9b3`](https://github.com/chaotic-cx/nyx/commit/f981e9b3997715170fba6c4016a6c3b47c09b7d5) | `` Bump 20240208-1 (#583) ``                                                  |