### PR TITLE
chore(flake/nur): `20260b5a` -> `3a315bbd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -924,11 +924,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707381565,
-        "narHash": "sha256-uvIk890e7TsYhenORzqKAfIMmJ2QNpTX6WL79rl5+Xk=",
+        "lastModified": 1707607086,
+        "narHash": "sha256-69fTyKaUqBUmXafkS9YZG7L0kvQeO0KuLa+fF09u7Ro=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "20260b5a03e74c6d624e4b983e5b482a8ec1a0c0",
+        "rev": "3a315bbd42ead8a1bafa90e8c3d14c43c80db912",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`3a315bbd`](https://github.com/nix-community/NUR/commit/3a315bbd42ead8a1bafa90e8c3d14c43c80db912) | `` automatic update `` |
| [`a0e18535`](https://github.com/nix-community/NUR/commit/a0e185354efd1ef8701224bbe1fc68c532436dc1) | `` automatic update `` |
| [`d744fce5`](https://github.com/nix-community/NUR/commit/d744fce52b50d53a3bc77720125f281d6c682f37) | `` automatic update `` |
| [`2f014699`](https://github.com/nix-community/NUR/commit/2f014699cc4a8b9f42b48c9d79f3a69654ae3501) | `` automatic update `` |
| [`4c94f025`](https://github.com/nix-community/NUR/commit/4c94f0253e60c9071064ff23ad880a1cbeaff704) | `` automatic update `` |
| [`d52b9e3d`](https://github.com/nix-community/NUR/commit/d52b9e3d55a8ec67a0fd08dce7a511a670d5d99a) | `` automatic update `` |
| [`aaf38150`](https://github.com/nix-community/NUR/commit/aaf38150714d016ade37f5f38112819ebb75c9a2) | `` automatic update `` |
| [`d57ddfeb`](https://github.com/nix-community/NUR/commit/d57ddfebbc4a97ff6b054f06d066020a4455f7e9) | `` automatic update `` |
| [`8ee91739`](https://github.com/nix-community/NUR/commit/8ee9173918959d2f6a080163cce766a831395bfc) | `` automatic update `` |
| [`9b627fcf`](https://github.com/nix-community/NUR/commit/9b627fcf736577ed07fd3f8294db9c01f64e4863) | `` automatic update `` |
| [`f1bcb540`](https://github.com/nix-community/NUR/commit/f1bcb540b8ae8bd8e6609b8475d8d55f1a57f52e) | `` automatic update `` |
| [`ecaddbc1`](https://github.com/nix-community/NUR/commit/ecaddbc1aacd0f81bd9248a9184d6e1df90d29af) | `` automatic update `` |
| [`27ddd21e`](https://github.com/nix-community/NUR/commit/27ddd21e02b78d7e29da520484745afc26bdc423) | `` automatic update `` |
| [`896df0e4`](https://github.com/nix-community/NUR/commit/896df0e4f5bbfc619c11d88881cc691a153b75b0) | `` automatic update `` |
| [`72e84ed7`](https://github.com/nix-community/NUR/commit/72e84ed764782d61c5cd6f08ef221f1e59cf50db) | `` automatic update `` |
| [`6443c52d`](https://github.com/nix-community/NUR/commit/6443c52d5f126822b872442b43b7eb5efa13411b) | `` automatic update `` |
| [`eec3054b`](https://github.com/nix-community/NUR/commit/eec3054bb44714b45c2a89816d194648758dc9ed) | `` automatic update `` |
| [`36487884`](https://github.com/nix-community/NUR/commit/3648788428ce6da20158d1c704128bb517a34b4b) | `` automatic update `` |
| [`bef795c8`](https://github.com/nix-community/NUR/commit/bef795c8806a21c5f8089f5dee354cb35885a74f) | `` automatic update `` |
| [`ec2de01a`](https://github.com/nix-community/NUR/commit/ec2de01a9a648f2e15e9634ce868e0e88d2deaea) | `` automatic update `` |
| [`5b9ab3fa`](https://github.com/nix-community/NUR/commit/5b9ab3fa6bafc55c71667ec966826035292e9685) | `` automatic update `` |
| [`9d786404`](https://github.com/nix-community/NUR/commit/9d78640429eedaffca63bf0b196bbc452e95523f) | `` automatic update `` |
| [`2e13570e`](https://github.com/nix-community/NUR/commit/2e13570e2eb9164eae348f806bc6493c5d194a1a) | `` automatic update `` |
| [`c5f8f80e`](https://github.com/nix-community/NUR/commit/c5f8f80e14293e269fe0f7aa98f04329eedfbe69) | `` automatic update `` |
| [`7401f125`](https://github.com/nix-community/NUR/commit/7401f12518027ed8ea1d8f7634a446ac3269c3c4) | `` automatic update `` |
| [`fa5f1139`](https://github.com/nix-community/NUR/commit/fa5f11396cf60d1f091336f344987539b46870cd) | `` automatic update `` |
| [`15db5a23`](https://github.com/nix-community/NUR/commit/15db5a2314372dde84a47f016c22c5cc4c47082a) | `` automatic update `` |
| [`7ca8beef`](https://github.com/nix-community/NUR/commit/7ca8beef3ee2c0c7bde39375c4a4a478eebf782f) | `` automatic update `` |
| [`52078524`](https://github.com/nix-community/NUR/commit/52078524325fd8473f872cfb387b37d5790d318f) | `` automatic update `` |
| [`eed80d9c`](https://github.com/nix-community/NUR/commit/eed80d9c52a5b0c8c49ebe4a4cce8ca1803b56f1) | `` automatic update `` |
| [`7bba799f`](https://github.com/nix-community/NUR/commit/7bba799fc1b49a73d24e92b7ac559de9d34929e4) | `` automatic update `` |
| [`59c2f310`](https://github.com/nix-community/NUR/commit/59c2f31018b7064bcb5634312dcc56dd94683adf) | `` automatic update `` |
| [`ddc28098`](https://github.com/nix-community/NUR/commit/ddc28098837535e1204cf101f958680fb84aeffc) | `` automatic update `` |
| [`e2be520b`](https://github.com/nix-community/NUR/commit/e2be520b7c9df9d71525661c33d32ca8e4012fcb) | `` automatic update `` |
| [`50edc276`](https://github.com/nix-community/NUR/commit/50edc276d561d0df01a3375f5a2d8e16eb1b2cf6) | `` automatic update `` |
| [`b59a09d1`](https://github.com/nix-community/NUR/commit/b59a09d1e4fbfdbfb420580a83ed560b21a44a89) | `` automatic update `` |
| [`44f236b5`](https://github.com/nix-community/NUR/commit/44f236b58e87ca17585ad066c5f21ee945e7d93a) | `` automatic update `` |
| [`a6dbfcbf`](https://github.com/nix-community/NUR/commit/a6dbfcbf002cf6309002bef91f61f39fcf0bba73) | `` automatic update `` |
| [`059c6787`](https://github.com/nix-community/NUR/commit/059c6787012ba8a4f48b2c621bcc88ea72997017) | `` automatic update `` |
| [`a61bebc1`](https://github.com/nix-community/NUR/commit/a61bebc12b20c4ed92df1dd8b479c6f91ee40188) | `` automatic update `` |
| [`c61e24b9`](https://github.com/nix-community/NUR/commit/c61e24b9c003ca9db760173787e43927c8d87030) | `` automatic update `` |
| [`dee5c587`](https://github.com/nix-community/NUR/commit/dee5c58753ebd74bf7434afc890689776ec2feee) | `` automatic update `` |
| [`59c3ac9c`](https://github.com/nix-community/NUR/commit/59c3ac9c9a0b8f34772ff32c2237c0524896f6c3) | `` automatic update `` |
| [`445e7ee7`](https://github.com/nix-community/NUR/commit/445e7ee7627e87a51fd1ba42f0407db8b2268d53) | `` automatic update `` |
| [`ea7d727e`](https://github.com/nix-community/NUR/commit/ea7d727e716d983bc9fcace2f712dd86b08edc47) | `` automatic update `` |
| [`68729fe4`](https://github.com/nix-community/NUR/commit/68729fe4b2511d27ad04e24148febca527ab9605) | `` automatic update `` |
| [`9621e2bf`](https://github.com/nix-community/NUR/commit/9621e2bfc47bbfe644c0f9f64b1aa44dec1f3afc) | `` automatic update `` |
| [`419d998d`](https://github.com/nix-community/NUR/commit/419d998dbab5c36dfc528dccffd6e53b55f9707a) | `` automatic update `` |
| [`3ded5d19`](https://github.com/nix-community/NUR/commit/3ded5d1998d41ae456d6ff35238643205293ae3d) | `` automatic update `` |
| [`6a29ce38`](https://github.com/nix-community/NUR/commit/6a29ce382fb00c8501c511e5f973199bb58f8f18) | `` automatic update `` |
| [`f8f65fbd`](https://github.com/nix-community/NUR/commit/f8f65fbd2e6fbf663f14f2f46c250f22bd86f3e9) | `` automatic update `` |
| [`cb959eeb`](https://github.com/nix-community/NUR/commit/cb959eeba711ab3fc17a388b572d64c5f193f1f7) | `` automatic update `` |
| [`ba3d65ee`](https://github.com/nix-community/NUR/commit/ba3d65eeda258c1aa84ffdf897234e90cbbab47a) | `` automatic update `` |
| [`43365ed8`](https://github.com/nix-community/NUR/commit/43365ed82d355ed9d5578897c1a99652c5b09ad4) | `` automatic update `` |