### PR TITLE
chore(flake/hyprland): `a6ccd361` -> `e4bb5fa4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -474,11 +474,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1707349634,
-        "narHash": "sha256-enBIncPDMroHjkykdRdvjvaZbhlb4d/LrR4R1qHeenY=",
+        "lastModified": 1707586793,
+        "narHash": "sha256-Vdf5QGzkZe6UUdVZ80YT78id7Yw5ww9Fku0rEyPAkCg=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "a6ccd36147109d5cb2981122595f06ae93999b55",
+        "rev": "e4bb5fa4af1a6c36aab1c28651b5403dc4952f93",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                  |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
| [`e4bb5fa4`](https://github.com/hyprwm/Hyprland/commit/e4bb5fa4af1a6c36aab1c28651b5403dc4952f93) | `` input: focus monitor on mouse down ``                                 |
| [`cb258c82`](https://github.com/hyprwm/Hyprland/commit/cb258c82f4fa3276ad9b2e2dfc1243e8ee683b2c) | `` assets: update tetrahedra by honkadaloonga ``                         |
| [`658f718f`](https://github.com/hyprwm/Hyprland/commit/658f718fa3b2e08653493a00aeaa670a41d19c8d) | `` input: partially revert #4514 ``                                      |
| [`334a0f03`](https://github.com/hyprwm/Hyprland/commit/334a0f03ee2f80118418c16cc06005a1fe8cfd60) | `` keybinds: Fix focus not moving along when moving workspace (#4660) `` |
| [`289d4241`](https://github.com/hyprwm/Hyprland/commit/289d4241bea72ebd891e037996ec4ffd356aadc8) | `` groupbar: scale groupbar text according to monitor scale (#4640) ``   |