### PR TITLE
chore(flake/spicetify-nix): `fe2db390` -> `a04e54da`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1065,11 +1065,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707365435,
-        "narHash": "sha256-nxk4jnN8zq4Ju68VBXScT3qxPXhhEqs4ripEmVk68EQ=",
+        "lastModified": 1707538208,
+        "narHash": "sha256-RxrOGK4NbNpdslT++kNlIdX4Hmyrn2LpIqmAczYfvAo=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "fe2db3900d0fb355a521892cf3c6e45399089fe3",
+        "rev": "a04e54da49a3e0d6d1a8c4a0e5b059c206868198",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`a04e54da`](https://github.com/Gerg-L/spicetify-nix/commit/a04e54da49a3e0d6d1a8c4a0e5b059c206868198) | `` CI update 2024-02-10 (#68) `` |
| [`abe212ac`](https://github.com/Gerg-L/spicetify-nix/commit/abe212ac652354a6bc519effae917f51e64a1678) | `` CI update 2024-02-09 (#67) `` |