### PR TITLE
chore(flake/nix-index-database): `3e3dad28` -> `0cb43457`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -760,11 +760,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707016097,
-        "narHash": "sha256-V4lHr6hFQ3rK650dh64Xffxsf4kse9vUYWsM+ldjkco=",
+        "lastModified": 1707620986,
+        "narHash": "sha256-XE0tCSkSVBeJDWhjFwusNInwAhrnp+TloUNUpvnTiLw=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "3e3dad2808379c522138e2e8b0eb73500721a237",
+        "rev": "0cb4345704123492e6d1f1068629069413c80de0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`0cb43457`](https://github.com/nix-community/nix-index-database/commit/0cb4345704123492e6d1f1068629069413c80de0) | `` update packages.nix to release 2024-02-11-030837 `` |
| [`2fc7cf56`](https://github.com/nix-community/nix-index-database/commit/2fc7cf56050f0d3e1f793cfee0f88f894870035e) | `` flake.lock: Update ``                               |