### PR TITLE
chore(flake/nur): `3a315bbd` -> `8097ddfa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -924,11 +924,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707607086,
-        "narHash": "sha256-69fTyKaUqBUmXafkS9YZG7L0kvQeO0KuLa+fF09u7Ro=",
+        "lastModified": 1707637525,
+        "narHash": "sha256-lGAF0DFNpozP8k2GplHkNrOayP/tpRMCYzVnVDE9XKk=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "3a315bbd42ead8a1bafa90e8c3d14c43c80db912",
+        "rev": "8097ddfab1b83c26b2f828c069803e3ee6159bd8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`8097ddfa`](https://github.com/nix-community/NUR/commit/8097ddfab1b83c26b2f828c069803e3ee6159bd8) | `` automatic update `` |
| [`7efd32ca`](https://github.com/nix-community/NUR/commit/7efd32ca3874101a3f16c06e5aade38153ca4fc7) | `` automatic update `` |
| [`b1858530`](https://github.com/nix-community/NUR/commit/b1858530c4ecc35c6b6f29319d69aab2948a8912) | `` automatic update `` |
| [`4acc83ad`](https://github.com/nix-community/NUR/commit/4acc83adfbe8844fdab0b3cc916394c4391379ea) | `` automatic update `` |
| [`c4278232`](https://github.com/nix-community/NUR/commit/c4278232d6c9ca6db2e278fbb30eea245c429fa0) | `` automatic update `` |
| [`6238b1b1`](https://github.com/nix-community/NUR/commit/6238b1b15a953d7bdc10be948551610e297cceb1) | `` automatic update `` |
| [`7a15e8db`](https://github.com/nix-community/NUR/commit/7a15e8dbdfb1b70a28e8d549e2747a4e1242d895) | `` automatic update `` |