### PR TITLE
chore(flake/emacs-overlay): `22cce99b` -> `3c0112ec`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -193,11 +193,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1707555888,
-        "narHash": "sha256-opXjVZpavvfMFzv9c+teipFQ2zDs6+CX7KOQE8uhuHc=",
+        "lastModified": 1707642416,
+        "narHash": "sha256-8bnjLSZbLOLQrPX4dWsf+BEX1UhN2SlCYM9CbIF0LE4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "22cce99b0abb79c5d00583f6f82e823b2bdb131b",
+        "rev": "3c0112ec21770085a50d24a899d1644bb238cfef",
         "type": "github"
       },
       "original": {
@@ -860,11 +860,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1707347730,
-        "narHash": "sha256-0etC/exQIaqC9vliKhc3eZE2Mm2wgLa0tj93ZF/egvM=",
+        "lastModified": 1707514827,
+        "narHash": "sha256-Y+wqFkvikpE1epCx57PsGw+M1hX5aY5q/xgk+ebDwxI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6832d0d99649db3d65a0e15fa51471537b2c56a6",
+        "rev": "20f65b86b6485decb43c5498780c223571dd56ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`3c0112ec`](https://github.com/nix-community/emacs-overlay/commit/3c0112ec21770085a50d24a899d1644bb238cfef) | `` Updated emacs ``        |
| [`ad4a3a32`](https://github.com/nix-community/emacs-overlay/commit/ad4a3a3271d161eedf9e85f851be60b8a361bcf2) | `` Updated melpa ``        |
| [`1e43a6cb`](https://github.com/nix-community/emacs-overlay/commit/1e43a6cba24ba1da009fd358ddde947c9df07afa) | `` Updated emacs ``        |
| [`6e3c4ba0`](https://github.com/nix-community/emacs-overlay/commit/6e3c4ba04fd2db2b3ef737071043c66755c92187) | `` Updated melpa ``        |
| [`410471ee`](https://github.com/nix-community/emacs-overlay/commit/410471eea4a07ef88f2ff7be21d5cfae645beedb) | `` Updated elpa ``         |
| [`b1ad7329`](https://github.com/nix-community/emacs-overlay/commit/b1ad7329314c03fddd5326344dab21ebdd65a775) | `` Updated nongnu ``       |
| [`44600b1d`](https://github.com/nix-community/emacs-overlay/commit/44600b1d1af7e752cfff9981d3ee980d0bf979b5) | `` Updated flake inputs `` |