### PR TITLE
chore(flake/spicetify-nix): `c0479fde` -> `2d8b70d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1065,11 +1065,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707624651,
-        "narHash": "sha256-O1+Ww3bHeHvzzkGEputOwOF/qhzBLw5qDuou5+MP1qE=",
+        "lastModified": 1707883839,
+        "narHash": "sha256-j+PQJ3fErLKlbXdkefIxdGGPyCjH8rv5pmacPfARRLc=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "c0479fde680d721a750e55a0ccdae52e9641b4d4",
+        "rev": "2d8b70d9a078676412fbd40df63f3a556e359446",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`2d8b70d9`](https://github.com/Gerg-L/spicetify-nix/commit/2d8b70d9a078676412fbd40df63f3a556e359446) | `` CI update 2024-02-14 (#72) `` |
| [`1759b6d9`](https://github.com/Gerg-L/spicetify-nix/commit/1759b6d9c2f0b58b59b9973e2ec71d6fc5529594) | `` CI update 2024-02-13 (#71) `` |
| [`892e3522`](https://github.com/Gerg-L/spicetify-nix/commit/892e3522a0220784ee8ba1d2b68c794f0c510cc9) | `` CI update 2024-02-12 (#70) `` |