### PR TITLE
chore(flake/emacs-overlay): `3c0112ec` -> `763c614a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -193,11 +193,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1707642416,
-        "narHash": "sha256-8bnjLSZbLOLQrPX4dWsf+BEX1UhN2SlCYM9CbIF0LE4=",
+        "lastModified": 1707901582,
+        "narHash": "sha256-/u7TGrMRoT/h360iHThg1cumIJ9l2+xw51w4qi+cgFA=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "3c0112ec21770085a50d24a899d1644bb238cfef",
+        "rev": "763c614a4cce4296941b44dece54390dd108b781",
         "type": "github"
       },
       "original": {
@@ -860,11 +860,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1707514827,
-        "narHash": "sha256-Y+wqFkvikpE1epCx57PsGw+M1hX5aY5q/xgk+ebDwxI=",
+        "lastModified": 1707786466,
+        "narHash": "sha256-yLPfrmW87M2qt+8bAmwopJawa+MJLh3M9rUbXtpUc1o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "20f65b86b6485decb43c5498780c223571dd56ef",
+        "rev": "01885a071465e223f8f68971f864b15829988504",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`763c614a`](https://github.com/nix-community/emacs-overlay/commit/763c614a4cce4296941b44dece54390dd108b781) | `` Updated emacs ``        |
| [`b40877f8`](https://github.com/nix-community/emacs-overlay/commit/b40877f8ce5a3c4720e6d1e965bd65d9e9e1be3c) | `` Updated flake inputs `` |
| [`97d761e4`](https://github.com/nix-community/emacs-overlay/commit/97d761e40d1f82a982274fcdbef90c4316669052) | `` Updated emacs ``        |
| [`385de3ad`](https://github.com/nix-community/emacs-overlay/commit/385de3ad948bc01498b692a809f589a158bde91f) | `` Updated melpa ``        |
| [`31b87a76`](https://github.com/nix-community/emacs-overlay/commit/31b87a760714d848938827be5d53d6bf79d2caaa) | `` Updated elpa ``         |
| [`1c9b038a`](https://github.com/nix-community/emacs-overlay/commit/1c9b038a329736e444cabffb0e473642458a9858) | `` Updated emacs ``        |
| [`6af2cc79`](https://github.com/nix-community/emacs-overlay/commit/6af2cc7983267b08387630f0da8eac3b55482bc5) | `` Updated melpa ``        |
| [`376f5e10`](https://github.com/nix-community/emacs-overlay/commit/376f5e107de8e95d6decd185682c6deeef6ccbf5) | `` Updated elpa ``         |
| [`0f7f3b39`](https://github.com/nix-community/emacs-overlay/commit/0f7f3b39157419f3035a2dad39fbaf8a4ba0448d) | `` Updated emacs ``        |
| [`70266acb`](https://github.com/nix-community/emacs-overlay/commit/70266acb2bbfd9be21988aee89efab767d00913d) | `` Updated melpa ``        |
| [`be02660f`](https://github.com/nix-community/emacs-overlay/commit/be02660f6d6ab0a6add8652f6863d47157a5ae17) | `` Updated flake inputs `` |
| [`bf9f1098`](https://github.com/nix-community/emacs-overlay/commit/bf9f1098a348303e6eee96f02fc965531d86d984) | `` Updated emacs ``        |
| [`b33b514d`](https://github.com/nix-community/emacs-overlay/commit/b33b514df08dfc133f2ca5d43fcfbdb67f85fc1c) | `` Updated melpa ``        |
| [`ab891678`](https://github.com/nix-community/emacs-overlay/commit/ab89167867bba167b6e6c4f545952a7f74410bb2) | `` Updated elpa ``         |
| [`5e48f3ea`](https://github.com/nix-community/emacs-overlay/commit/5e48f3eafb4cccf45c30047bb2f27b6a4a02b52f) | `` Updated nongnu ``       |
| [`78207864`](https://github.com/nix-community/emacs-overlay/commit/78207864349fb13b7ffd9445d2e0566376e3b738) | `` Updated emacs ``        |
| [`dd946433`](https://github.com/nix-community/emacs-overlay/commit/dd946433ce801fab90088ceb499c2490ec97417c) | `` Updated melpa ``        |
| [`e830065f`](https://github.com/nix-community/emacs-overlay/commit/e830065f1f726fe3d8fffe641939ad66b9237f89) | `` Updated elpa ``         |
| [`12f6e2ea`](https://github.com/nix-community/emacs-overlay/commit/12f6e2ea14f50b96ff1de2d0e4e5d809f014a924) | `` Updated flake inputs `` |
| [`7e74ec81`](https://github.com/nix-community/emacs-overlay/commit/7e74ec81680fff91bf07330c0e23d1b4c7aeb6af) | `` Updated emacs ``        |
| [`fc571589`](https://github.com/nix-community/emacs-overlay/commit/fc57158935b23b709de7d74e023084ce6332e86d) | `` Updated melpa ``        |
| [`f797cc93`](https://github.com/nix-community/emacs-overlay/commit/f797cc93d86b19e5e007f6df584a12ce6a3cc7e4) | `` Updated emacs ``        |
| [`6bf6a11f`](https://github.com/nix-community/emacs-overlay/commit/6bf6a11f29c04046a7a60795a90ac4932b70caba) | `` Updated melpa ``        |
| [`7cdc51cc`](https://github.com/nix-community/emacs-overlay/commit/7cdc51cc725dbbf25173d0a5517448572cf041fe) | `` Updated elpa ``         |
| [`6a029558`](https://github.com/nix-community/emacs-overlay/commit/6a029558e537f597a436ba36a7ffc28730ecb27e) | `` Updated emacs ``        |
| [`d33b7a3d`](https://github.com/nix-community/emacs-overlay/commit/d33b7a3d9b9b12e4da69f5539845cf872cc0f8b3) | `` Updated melpa ``        |
| [`9a84e691`](https://github.com/nix-community/emacs-overlay/commit/9a84e691ce4df35ba795b2bbb1945d3139f45a9e) | `` Updated elpa ``         |
| [`d67fd9c9`](https://github.com/nix-community/emacs-overlay/commit/d67fd9c98f2694d771fb6b4f9390678683ccc064) | `` Updated flake inputs `` |