### PR TITLE
chore(flake/nur): `8097ddfa` -> `e8622366`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -924,11 +924,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707637525,
-        "narHash": "sha256-lGAF0DFNpozP8k2GplHkNrOayP/tpRMCYzVnVDE9XKk=",
+        "lastModified": 1707920456,
+        "narHash": "sha256-KMp+LZ3Wc4pWvhdPRaxzdiaWRirGBlx/VFh4FSPhIms=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "8097ddfab1b83c26b2f828c069803e3ee6159bd8",
+        "rev": "e8622366c2f04b2c09f00dd781188075ada2cb33",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`e8622366`](https://github.com/nix-community/NUR/commit/e8622366c2f04b2c09f00dd781188075ada2cb33) | `` automatic update `` |
| [`56322db4`](https://github.com/nix-community/NUR/commit/56322db4d90c22d91274c173ef21d9aa3df37d8d) | `` automatic update `` |
| [`53747802`](https://github.com/nix-community/NUR/commit/537478022fa6267cc9dc6d5b25a2a1e3fa06f48d) | `` automatic update `` |
| [`aa59c0f6`](https://github.com/nix-community/NUR/commit/aa59c0f62204dedf092ee8a46311a659ea010ea2) | `` automatic update `` |
| [`0e46a94c`](https://github.com/nix-community/NUR/commit/0e46a94c5b5e29ff1f62d78bcb595a3fcba4ecf3) | `` automatic update `` |
| [`c91eaea9`](https://github.com/nix-community/NUR/commit/c91eaea9542b47725232e008fd0b7d762f852286) | `` automatic update `` |
| [`27e450f5`](https://github.com/nix-community/NUR/commit/27e450f536763feaf4bfe41ff3f0a83a2804cf5c) | `` automatic update `` |
| [`bb1b8093`](https://github.com/nix-community/NUR/commit/bb1b80932f0d5d34624d4d1260071cc9ef88dedc) | `` automatic update `` |
| [`8eebb200`](https://github.com/nix-community/NUR/commit/8eebb20097ee19431d6ac6b2c36a95e38ed57188) | `` automatic update `` |
| [`b8f58824`](https://github.com/nix-community/NUR/commit/b8f58824a8b5e2c4e4d5ffa51739f23e021935a5) | `` automatic update `` |
| [`26ae54f2`](https://github.com/nix-community/NUR/commit/26ae54f21cacae653cf9561c9afe5ba9496e80b6) | `` automatic update `` |
| [`9c0e71b2`](https://github.com/nix-community/NUR/commit/9c0e71b2416828e1305b4846e51011d88e6551e5) | `` automatic update `` |
| [`b41ad07a`](https://github.com/nix-community/NUR/commit/b41ad07abb6e0b062bbb12d14a5bf0b0d7ffb6c8) | `` automatic update `` |
| [`38411021`](https://github.com/nix-community/NUR/commit/38411021532bd70fb7b761d3485d3fae0d30d559) | `` automatic update `` |
| [`f17a0504`](https://github.com/nix-community/NUR/commit/f17a0504887729ba9a1f2871db8f6b35e937d17c) | `` automatic update `` |
| [`be990e92`](https://github.com/nix-community/NUR/commit/be990e92c190dc8390897b98c1dfc13274a5321d) | `` automatic update `` |
| [`c8a49afe`](https://github.com/nix-community/NUR/commit/c8a49afeed5ab5ee819e10b53ed46dbda5516aa8) | `` automatic update `` |
| [`202b1d62`](https://github.com/nix-community/NUR/commit/202b1d62a55d01aa3e1eb474a989df291718fd71) | `` automatic update `` |
| [`056feb1c`](https://github.com/nix-community/NUR/commit/056feb1c831d61bf6635824876828e56a7fe81ab) | `` automatic update `` |
| [`4350cd5e`](https://github.com/nix-community/NUR/commit/4350cd5ea70e50e041ce61bd67cb04b43dc514a3) | `` automatic update `` |
| [`e6708f99`](https://github.com/nix-community/NUR/commit/e6708f99c724920c27a9a8ebefa277ab8669aab2) | `` automatic update `` |
| [`8e791f2d`](https://github.com/nix-community/NUR/commit/8e791f2d764320a89a651ca78ad0dbbaeaca144f) | `` automatic update `` |
| [`cc2cac41`](https://github.com/nix-community/NUR/commit/cc2cac415909790218b873720a74d7e95fa4e0ea) | `` automatic update `` |
| [`42b2f038`](https://github.com/nix-community/NUR/commit/42b2f0389e0f4fe9e41c20528e9afff8f0124e41) | `` automatic update `` |
| [`d9a57377`](https://github.com/nix-community/NUR/commit/d9a5737771bb4a1cd70897ca4552f491880273e6) | `` automatic update `` |
| [`89c17529`](https://github.com/nix-community/NUR/commit/89c1752919eb4615b35db22557a10b3ac5aedc00) | `` automatic update `` |
| [`c82ebd04`](https://github.com/nix-community/NUR/commit/c82ebd0408ea922b3ac48961cbad797319e2b9e5) | `` automatic update `` |
| [`e2395575`](https://github.com/nix-community/NUR/commit/e2395575d2912b95a27d116e527a1ee2812d8692) | `` automatic update `` |
| [`e3d440d5`](https://github.com/nix-community/NUR/commit/e3d440d55073b3fcf5003b4ef27241f668e4a972) | `` automatic update `` |
| [`b059ee00`](https://github.com/nix-community/NUR/commit/b059ee000b1f960c84a1118bfe9db8823c8a00d5) | `` automatic update `` |
| [`427055c5`](https://github.com/nix-community/NUR/commit/427055c52403dc52f3fa9ba074e116ce6db2685b) | `` automatic update `` |
| [`4990bd96`](https://github.com/nix-community/NUR/commit/4990bd96a1e0102ff1354f317cd19cc4b4c08c42) | `` automatic update `` |
| [`835bffd3`](https://github.com/nix-community/NUR/commit/835bffd3ca5761f73a60cee4fe0a328b81bbbd7d) | `` automatic update `` |
| [`8ffb7d2f`](https://github.com/nix-community/NUR/commit/8ffb7d2fe51b383e3c844d38cf48c4de8a35742f) | `` automatic update `` |
| [`26e9a8e4`](https://github.com/nix-community/NUR/commit/26e9a8e46faaf3c55cdfba0a9c7adcf90677d3fa) | `` automatic update `` |
| [`38d6c257`](https://github.com/nix-community/NUR/commit/38d6c25795837df0476e7c3e940a3da595a50067) | `` automatic update `` |
| [`c3a14371`](https://github.com/nix-community/NUR/commit/c3a1437116c490fa7b2d47253ac5d862005ba5db) | `` automatic update `` |
| [`c3641e09`](https://github.com/nix-community/NUR/commit/c3641e09dbea9b64a331d5d8b5345dbda14ed42b) | `` automatic update `` |
| [`744d76e1`](https://github.com/nix-community/NUR/commit/744d76e115389e0729c2d5de9a678b4f3d55db53) | `` automatic update `` |
| [`beaff8ee`](https://github.com/nix-community/NUR/commit/beaff8ee0fa795e4fd3a87acc5fb03bebe600d02) | `` automatic update `` |
| [`a9077460`](https://github.com/nix-community/NUR/commit/a907746031a38749d38b02987d6ce950ab330bd1) | `` automatic update `` |
| [`34a6ec5d`](https://github.com/nix-community/NUR/commit/34a6ec5d3a223e31298326b5e384044d4aa599cc) | `` automatic update `` |
| [`135827c3`](https://github.com/nix-community/NUR/commit/135827c341c23db57ba6655f89100752c2d637ad) | `` automatic update `` |
| [`fece3b48`](https://github.com/nix-community/NUR/commit/fece3b48c569c4adb1a4e8a8956cf121e2df8437) | `` automatic update `` |
| [`7e8189b8`](https://github.com/nix-community/NUR/commit/7e8189b89c1c6cb92f141f2bcd6b8296b6274992) | `` automatic update `` |
| [`37429213`](https://github.com/nix-community/NUR/commit/37429213accf748b9ccaaac4af5674119d9171b6) | `` automatic update `` |
| [`73479b37`](https://github.com/nix-community/NUR/commit/73479b37282accecfc7f3f91e56a0b709f104ad2) | `` automatic update `` |
| [`6b338c8b`](https://github.com/nix-community/NUR/commit/6b338c8b0e0631d77b18d2535078c837264227a9) | `` automatic update `` |
| [`a530d179`](https://github.com/nix-community/NUR/commit/a530d17981f9bd20f249486db3f6e9ad446ee446) | `` automatic update `` |
| [`60ef97da`](https://github.com/nix-community/NUR/commit/60ef97da55cb8640cc646b66e6a51fac452c7202) | `` automatic update `` |
| [`e8455970`](https://github.com/nix-community/NUR/commit/e84559701c5ad9e914a378cefbfbf7118c7e3666) | `` automatic update `` |
| [`4dca2c63`](https://github.com/nix-community/NUR/commit/4dca2c63b91e5f93bbdd62afb2860a35725b2a67) | `` automatic update `` |
| [`5ec9be8a`](https://github.com/nix-community/NUR/commit/5ec9be8abec9ab008486961c1c49f05774b8458c) | `` automatic update `` |
| [`24c4260f`](https://github.com/nix-community/NUR/commit/24c4260f6f0e43244e2a35773d88c5d708ae2d95) | `` automatic update `` |
| [`c7fa9c6c`](https://github.com/nix-community/NUR/commit/c7fa9c6c3becdb8a330bf1202e009494a381ef32) | `` automatic update `` |