### PR TITLE
chore(flake/hyprland): `e4bb5fa4` -> `06087914`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -474,11 +474,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1707586793,
-        "narHash": "sha256-Vdf5QGzkZe6UUdVZ80YT78id7Yw5ww9Fku0rEyPAkCg=",
+        "lastModified": 1707911087,
+        "narHash": "sha256-nl/qnwsO6Trbt6l9V0HGDF3j0+q8oNWtZWwxX3IxByw=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "e4bb5fa4af1a6c36aab1c28651b5403dc4952f93",
+        "rev": "06087914807f88d2a9fc76c8108985f6327598de",
         "type": "github"
       },
       "original": {
@@ -892,11 +892,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1706191920,
-        "narHash": "sha256-eLihrZAPZX0R6RyM5fYAWeKVNuQPYjAkCUBr+JNvtdE=",
+        "lastModified": 1707546158,
+        "narHash": "sha256-nYYJTpzfPMDxI8mzhQsYjIUX+grorqjKEU9Np6Xwy/0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ae5c332cbb5827f6b1f02572496b141021de335f",
+        "rev": "d934204a0f8d9198e1e4515dd6fec76a139c87f0",
         "type": "github"
       },
       "original": {
@@ -1194,11 +1194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706145785,
-        "narHash": "sha256-j9MP4fv2U/vdRKAXXc2gyMTmYwVnHP6kHx1/y6jprrU=",
+        "lastModified": 1706521509,
+        "narHash": "sha256-AInZ50acOJ3wzUwGzNr1TmxGTMx+8j6oSTzz4E7Vbp8=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "5a592647587cd20b9692a347df6939b6d371b3bb",
+        "rev": "c06fd88b3da492b8f9067be021b9184f7012b5a8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                           |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
| [`06087914`](https://github.com/hyprwm/Hyprland/commit/06087914807f88d2a9fc76c8108985f6327598de) | `` dwindle: round wbox before setting ``                                          |
| [`2a002f31`](https://github.com/hyprwm/Hyprland/commit/2a002f31e4077ff6dd20a7116e372712e3b4e7f8) | `` renderer: don't set solitary on present notifications ``                       |
| [`2a3429d4`](https://github.com/hyprwm/Hyprland/commit/2a3429d4cfdc01794b9d6fc1b49be1da019b5606) | `` internal: add `forcenofocus` prop (#4672) ``                                   |
| [`95abf122`](https://github.com/hyprwm/Hyprland/commit/95abf1220f56acbe88517799fc4b92be2e908575) | `` keybinds: fix swapactiveworkspaces not moving focus ``                         |
| [`b500e569`](https://github.com/hyprwm/Hyprland/commit/b500e5699b9aa0f5a92805707bcc88ba151a7c82) | `` renderer: update cursor also when hostpot only changes ``                      |
| [`61378380`](https://github.com/hyprwm/Hyprland/commit/61378380eee10e67726a10fcd7d74859e2b9fbf6) | `` config: fix tiny typo in defaultConfig.hpp (#4693) ``                          |
| [`89030753`](https://github.com/hyprwm/Hyprland/commit/890307532caa3369ea089b606b7786ccce4b8504) | `` input: avoid reassigns of unchanged surfaces in processMouseRequest ``         |
| [`f33d73b9`](https://github.com/hyprwm/Hyprland/commit/f33d73b9cf102d5de7bcc29721ec4f8fc7c0d66d) | `` nix: overlay polish for prev parameter (#4558) ``                              |
| [`927da86e`](https://github.com/hyprwm/Hyprland/commit/927da86e3e76a8465c8b45fd7a87a34f25401b37) | `` hyprctl: fix dispatchBatch() treating empty curitem as last request (#4681) `` |
| [`cca3c643`](https://github.com/hyprwm/Hyprland/commit/cca3c6430104836bdf5c060949a13b6b80ff0219) | `` hyprctl: remove hardcoded hyprctl commands. (#4671) ``                         |
| [`6e5c78bf`](https://github.com/hyprwm/Hyprland/commit/6e5c78bf632b6b6d3b32f132cf05b8f33ebf0e8a) | `` [gha] Nix: update inputs ``                                                    |