### PR TITLE
chore(flake/nur): `e8622366` -> `2593837c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -924,11 +924,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1707920456,
-        "narHash": "sha256-KMp+LZ3Wc4pWvhdPRaxzdiaWRirGBlx/VFh4FSPhIms=",
+        "lastModified": 1708105507,
+        "narHash": "sha256-OLjuwC6g02i9c3IfbOEywOOcnsNZkqei9DcZ5BY1D2Q=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "e8622366c2f04b2c09f00dd781188075ada2cb33",
+        "rev": "2593837ca8fc3abd462bac0ac002eec451001418",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                         |
| -------------------------------------------------------------------------------------------------- | ------------------------------- |
| [`2593837c`](https://github.com/nix-community/NUR/commit/2593837ca8fc3abd462bac0ac002eec451001418) | `` automatic update ``          |
| [`31ba97e3`](https://github.com/nix-community/NUR/commit/31ba97e37ec8c14f8ec2f2baea1a31f0c9abfb3f) | `` automatic update ``          |
| [`339713c9`](https://github.com/nix-community/NUR/commit/339713c9f42013858739ea18aac30220f22dde08) | `` automatic update ``          |
| [`af0850f5`](https://github.com/nix-community/NUR/commit/af0850f5cf31764f16dd991fa75912ca707ee64d) | `` automatic update ``          |
| [`de895fa0`](https://github.com/nix-community/NUR/commit/de895fa08375ed930028216e925b88e98bea09a9) | `` automatic update ``          |
| [`c68cd1d1`](https://github.com/nix-community/NUR/commit/c68cd1d133108fe9d897fae6bd76bd17e2d9e7a4) | `` add ihaveamac repository ``  |
| [`6e10656f`](https://github.com/nix-community/NUR/commit/6e10656f87dbdcb622c81147b209c3ac14a2a3a5) | `` automatic update ``          |
| [`9b059055`](https://github.com/nix-community/NUR/commit/9b059055da534e79bd6205893d716e85a7945fda) | `` automatic update ``          |
| [`3de7e3a4`](https://github.com/nix-community/NUR/commit/3de7e3a40d340581b14415448cf18d26587d134f) | `` automatic update ``          |
| [`1155ba6a`](https://github.com/nix-community/NUR/commit/1155ba6a69b8a69d7edda02321a21ff993d9300e) | `` automatic update ``          |
| [`bc1ef9ea`](https://github.com/nix-community/NUR/commit/bc1ef9eadcb51c6ec28ead4bd0b10d1ef0cde763) | `` automatic update ``          |
| [`3e8c42ab`](https://github.com/nix-community/NUR/commit/3e8c42ab5f6dc1db57c5eac7f88892e479093525) | `` automatic update ``          |
| [`08fbc188`](https://github.com/nix-community/NUR/commit/08fbc18862d206b58976b9baa25f4ecf48b71e39) | `` automatic update ``          |
| [`8bdb7c0e`](https://github.com/nix-community/NUR/commit/8bdb7c0e1c22262e8fcd66aacab96afa8969ce74) | `` automatic update ``          |
| [`26add158`](https://github.com/nix-community/NUR/commit/26add158a316e1c5b091c8970943704ebec670e4) | `` automatic update ``          |
| [`96deee2a`](https://github.com/nix-community/NUR/commit/96deee2a5a19f00b6103b49075db66fe6f785aa1) | `` automatic update ``          |
| [`07c41ed0`](https://github.com/nix-community/NUR/commit/07c41ed015189e0c6aa0a8795120484f6e0eb090) | `` automatic update ``          |
| [`9ddce2d4`](https://github.com/nix-community/NUR/commit/9ddce2d418e29d5e51509d35a8f607087298fdaf) | `` automatic update ``          |
| [`e9c90796`](https://github.com/nix-community/NUR/commit/e9c90796f7a60ee60a34c4e4e98382d56abe4b55) | `` automatic update ``          |
| [`be8f2a41`](https://github.com/nix-community/NUR/commit/be8f2a4105bf8ea7b6a6d3b20a9197b22fab530c) | `` automatic update ``          |
| [`d0869493`](https://github.com/nix-community/NUR/commit/d0869493d7569fcfcc439273ca96e36acca35717) | `` automatic update ``          |
| [`9c12d8c5`](https://github.com/nix-community/NUR/commit/9c12d8c55be1297d0cdedd6591d4319aab80b4b0) | `` automatic update ``          |
| [`fe5e0fea`](https://github.com/nix-community/NUR/commit/fe5e0fea416cf5c2bb35253366d3d8ca5ab551ea) | `` automatic update ``          |
| [`61796609`](https://github.com/nix-community/NUR/commit/61796609aafd62b5bfc51557243a4c10fa8ef1e9) | `` automatic update ``          |
| [`e0c222bf`](https://github.com/nix-community/NUR/commit/e0c222bf9aaf27f225fd7e1f61a97722eec18aa2) | `` automatic update ``          |
| [`0ff60c10`](https://github.com/nix-community/NUR/commit/0ff60c109e6a0882b9b77c1d9fa2940a406a9735) | `` automatic update ``          |
| [`4f80eef9`](https://github.com/nix-community/NUR/commit/4f80eef9d04a980c8a75ac943640e2a2d64b348b) | `` automatic update ``          |
| [`e4d1d884`](https://github.com/nix-community/NUR/commit/e4d1d8843b4c65fca13143755f6744aa7f0ed41a) | `` automatic update ``          |
| [`f093b8a5`](https://github.com/nix-community/NUR/commit/f093b8a537d1b226a85352c03883175174b29da3) | `` automatic update ``          |
| [`1497e2d0`](https://github.com/nix-community/NUR/commit/1497e2d00a3dfef017c5ceff1da886b7032e1e6a) | `` automatic update ``          |
| [`80519ce1`](https://github.com/nix-community/NUR/commit/80519ce11b5ccd1c66cd39c412eb0fd500d4a799) | `` automatic update ``          |
| [`c189c2ff`](https://github.com/nix-community/NUR/commit/c189c2ffb9f8f5d7e1c37cb088dc90d68e3a2fd7) | `` automatic update ``          |
| [`55420932`](https://github.com/nix-community/NUR/commit/55420932ef6b5822a332b8617de623447549bb91) | `` automatic update ``          |
| [`765457f4`](https://github.com/nix-community/NUR/commit/765457f4b9375772a86e34314a03ca29d080159e) | `` automatic update ``          |
| [`f5f31894`](https://github.com/nix-community/NUR/commit/f5f31894eb886506cbc0e850f78340cd21d7fb18) | `` automatic update ``          |
| [`f5dce867`](https://github.com/nix-community/NUR/commit/f5dce8671a2ab93efd7dff51fa51aeaef9f0fefe) | `` automatic update ``          |
| [`62c3c670`](https://github.com/nix-community/NUR/commit/62c3c670366a5a0d9f1dfd0d9bd55bfb4395f46a) | `` rename bbjubjub ``           |
| [`b4925573`](https://github.com/nix-community/NUR/commit/b49255739b185560e4025ed905b76e12bd73ba40) | `` automatic update ``          |
| [`5342023b`](https://github.com/nix-community/NUR/commit/5342023b455909ebb7c53a1319036f42d7077c62) | `` automatic update ``          |
| [`a066606c`](https://github.com/nix-community/NUR/commit/a066606c2a8f27c2b8cec06583bf84c86da81d1a) | `` automatic update ``          |
| [`631e68ef`](https://github.com/nix-community/NUR/commit/631e68ef632edf20bd67809815d8b21a4fa949ee) | `` automatic update ``          |
| [`aa832b44`](https://github.com/nix-community/NUR/commit/aa832b44941921afc32f1db6875866a2fbd9e2a4) | `` automatic update ``          |
| [`72e1e983`](https://github.com/nix-community/NUR/commit/72e1e9834ac9738f125284bf409f1843b3115ed0) | `` automatic update ``          |
| [`ac0efe9d`](https://github.com/nix-community/NUR/commit/ac0efe9df31e79cb14a88103ebe9aaa97a6f595a) | `` automatic update ``          |
| [`28c9f59f`](https://github.com/nix-community/NUR/commit/28c9f59f9ca9cca4c8e20ecc37d6cc03c815422a) | `` automatic update ``          |
| [`671ca010`](https://github.com/nix-community/NUR/commit/671ca0107fb45ae50d72d20ea963c8a2c20b8d1c) | `` automatic update ``          |
| [`56e8d835`](https://github.com/nix-community/NUR/commit/56e8d835ee623651ba211d0486b34f0db10a4d47) | `` automatic update ``          |
| [`cd8875b0`](https://github.com/nix-community/NUR/commit/cd8875b09f4842e15b31e9034ca93dab5d715464) | `` automatic update ``          |
| [`59a17cf7`](https://github.com/nix-community/NUR/commit/59a17cf7763df662667440487b80d68156252c7c) | `` automatic update ``          |
| [`ef01ccac`](https://github.com/nix-community/NUR/commit/ef01ccac6e75ad3ed7d4d05c74d6e53378d9ca69) | `` automatic update ``          |
| [`1a0101aa`](https://github.com/nix-community/NUR/commit/1a0101aa6227bd06175dcdf33e1ae228e53fcd3e) | `` automatic update ``          |
| [`b615de6a`](https://github.com/nix-community/NUR/commit/b615de6a536e385b08627ae2e0d92a338c95819f) | `` automatic update ``          |
| [`5e350241`](https://github.com/nix-community/NUR/commit/5e350241541dfd9f2d5a9ef37653d08957ed12f3) | `` automatic update ``          |
| [`ef1f67d7`](https://github.com/nix-community/NUR/commit/ef1f67d787f406be2be12afd7c10346c9c93d650) | `` automatic update ``          |
| [`d94f513b`](https://github.com/nix-community/NUR/commit/d94f513be3a2156cf8644d45665cf00355c3eb9c) | `` automatic update ``          |
| [`dcdcdf48`](https://github.com/nix-community/NUR/commit/dcdcdf48d0327f1af728c30f641ff64d8ae72db9) | `` automatic update ``          |
| [`b4c6cee9`](https://github.com/nix-community/NUR/commit/b4c6cee90275b67d9533a1149893a73a0874b9fe) | `` automatic update ``          |
| [`93b2f73b`](https://github.com/nix-community/NUR/commit/93b2f73bfc0eba78d3e4e22aac849a4c6f8f1114) | `` automatic update ``          |
| [`31ddfee2`](https://github.com/nix-community/NUR/commit/31ddfee271a852372d2c86883c01702ffdb71894) | `` automatic update ``          |
| [`a7a4edf2`](https://github.com/nix-community/NUR/commit/a7a4edf2773f836746db68bc426a5d12bab2faa9) | `` automatic update ``          |
| [`0a0af4ae`](https://github.com/nix-community/NUR/commit/0a0af4ae70f79b5c68cf3f706b9e465ed40fbee6) | `` automatic update ``          |
| [`20df301a`](https://github.com/nix-community/NUR/commit/20df301a3354bdb93e10b05ff38bcc9b4d13744d) | `` automatic update ``          |
| [`c9ce9d9d`](https://github.com/nix-community/NUR/commit/c9ce9d9d4df39c555e7c866cfcc84f28a9ebc6e4) | `` add javimerino repository `` |
| [`aec3bd05`](https://github.com/nix-community/NUR/commit/aec3bd05a622d2cb6c511e36d2c0466ee00a4660) | `` automatic update ``          |
| [`3bea9ca4`](https://github.com/nix-community/NUR/commit/3bea9ca421a607108a138b51f627c445aaad1423) | `` Add nginx repository ``      |
| [`4c4b2c44`](https://github.com/nix-community/NUR/commit/4c4b2c44336ea60920cd362d32ba8b99cd11b0b0) | `` automatic update ``          |
| [`60f5c6d0`](https://github.com/nix-community/NUR/commit/60f5c6d0002b8b81249403b575cee9ec4e54233f) | `` Add abszero repository ``    |
| [`fb20dc16`](https://github.com/nix-community/NUR/commit/fb20dc16d264a16b3b6d228dc10fa925a3ff7592) | `` automatic update ``          |
| [`c84037a3`](https://github.com/nix-community/NUR/commit/c84037a3bacc2c2ae53ba61aa2da8035a3334c0e) | `` Add DanNixon repo ``         |
| [`60dcd0ce`](https://github.com/nix-community/NUR/commit/60dcd0ce01108cef6b18689d61c79b55b863097e) | `` automatic update ``          |
| [`e864daf9`](https://github.com/nix-community/NUR/commit/e864daf90c42cfad582308c81928bf55bf42c86b) | `` automatic update ``          |
| [`f6353326`](https://github.com/nix-community/NUR/commit/f63533267541376c9ce6a603fa5218b32a69f20f) | `` automatic update ``          |
| [`bfd822b1`](https://github.com/nix-community/NUR/commit/bfd822b11661a701bff17c720b42965fd32d1394) | `` automatic update ``          |