### PR TITLE
chore(flake/hyprland): `06087914` -> `fbf5ba87`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -474,11 +474,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1707911087,
-        "narHash": "sha256-nl/qnwsO6Trbt6l9V0HGDF3j0+q8oNWtZWwxX3IxByw=",
+        "lastModified": 1708018354,
+        "narHash": "sha256-MlbqBzAjiz4Va2M/AvLN96Wq+jsCbEedhfMs5wW1yFM=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "06087914807f88d2a9fc76c8108985f6327598de",
+        "rev": "fbf5ba87ce57752653f3bebf6e2be090c702836e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                          |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
| [`fbf5ba87`](https://github.com/hyprwm/Hyprland/commit/fbf5ba87ce57752653f3bebf6e2be090c702836e) | `` shaders: use highp for fragments ``                                           |
| [`a8dae8f5`](https://github.com/hyprwm/Hyprland/commit/a8dae8f5e198327e5de8508d860234089f31e272) | `` socket2: `monitoraddedv2` IPC event for monitor description and id (#4646) `` |
| [`a42b984f`](https://github.com/hyprwm/Hyprland/commit/a42b984f51a00e88a13a45e1b5e9e3d4ec470254) | `` screencopy: fix ~dtor being in monitorRenderResources map ``                  |
| [`e5ac970d`](https://github.com/hyprwm/Hyprland/commit/e5ac970d6eafa725167b3123e7f6c28aca20ff21) | `` input: fix follow_focus ``                                                    |
| [`770956b0`](https://github.com/hyprwm/Hyprland/commit/770956b0921139ea13b478dda0e301842546d74c) | `` input: don't schedule frame on cursor move on hw cursors ``                   |
| [`3cca36e7`](https://github.com/hyprwm/Hyprland/commit/3cca36e7738559bbc72ac8fc99eaca3e3d94c0cb) | `` input: avoid rampant refocuses on popups ``                                   |
| [`ef490965`](https://github.com/hyprwm/Hyprland/commit/ef490965a23e043692584ae26dec4f863c88f2f6) | `` screencopy: attempt binding framebuffer before gathering format ``            |
| [`b7ab15dc`](https://github.com/hyprwm/Hyprland/commit/b7ab15dc8083b87fe732d5baa43914a897c107fe) | `` input: log cursor image requests ``                                           |
| [`9c3f3b00`](https://github.com/hyprwm/Hyprland/commit/9c3f3b00183c9bcca528d1c74fa29eed0bd747fa) | `` renderer: don't calculate mirror damage without mirrors present ``            |
| [`8d68d6bf`](https://github.com/hyprwm/Hyprland/commit/8d68d6bfa5c27a7abea0ac52ddd8757581b34e99) | `` windowrules: nuke no*request ``                                               |
| [`60834a46`](https://github.com/hyprwm/Hyprland/commit/60834a46875587ce011f5134ce4f714b0acc8227) | `` config: remove usages of nomaximizerequest from default cfg ``                |
| [`7f52db80`](https://github.com/hyprwm/Hyprland/commit/7f52db806c149cb3331d6567706e7c19f5a8b692) | `` windowrules: add suppressevent ``                                             |
| [`305b1419`](https://github.com/hyprwm/Hyprland/commit/305b1419c8ff463836324168946bc34417dc0310) | `` renderer: accept custom state requests for fake outputs ``                    |
| [`d5950f77`](https://github.com/hyprwm/Hyprland/commit/d5950f7719d3c9ec5305208265366df5ce81b6c3) | `` dwindle: add swapsplit dispatcher (#4702) ``                                  |