### PR TITLE
chore(flake/nix-super): `661b025c` -> `924eb112`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -784,11 +784,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1701958654,
-        "narHash": "sha256-ZhXujNwvwTDLmCpYb7h2bTDdZG4h97hEYjzBmKP8p2U=",
+        "lastModified": 1708070219,
+        "narHash": "sha256-/2fidzoXrrNwr8te2cU3JdtrpockWIjU4DpLgNr4FTo=",
         "owner": "privatevoid-net",
         "repo": "nix-super",
-        "rev": "661b025c79eac08beda593ede47b41b2052e8ebf",
+        "rev": "924eb1127a21ebf4bd7f438d7c6aca133ce1de84",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                                                          |
| ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`88d8f741`](https://github.com/privatevoid-net/nix-super/commit/88d8f74152a9f8d94077066f5edecd0127733a38) | `` feat: add reject-flake-config setting to reject all nix config from flakes `` |