### PR TITLE
chore(flake/emacs-overlay): `763c614a` -> `4887a3bf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -193,11 +193,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1707901582,
-        "narHash": "sha256-/u7TGrMRoT/h360iHThg1cumIJ9l2+xw51w4qi+cgFA=",
+        "lastModified": 1708103144,
+        "narHash": "sha256-+HWM66eCCeok8tA1IF4lpSvrreYPcZjayo0i2Vn1RyI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "763c614a4cce4296941b44dece54390dd108b781",
+        "rev": "4887a3bf368f7ba9fe2640c23ce08646918d4414",
         "type": "github"
       },
       "original": {
@@ -860,11 +860,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1707786466,
-        "narHash": "sha256-yLPfrmW87M2qt+8bAmwopJawa+MJLh3M9rUbXtpUc1o=",
+        "lastModified": 1707978831,
+        "narHash": "sha256-UblFdWQ2MMZNzD9C/w8+7RjAJ2QIbebbzHUniQ/a44o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01885a071465e223f8f68971f864b15829988504",
+        "rev": "c68a9fc85c2cb3a313be6ff40511635544dde8da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4887a3bf`](https://github.com/nix-community/emacs-overlay/commit/4887a3bf368f7ba9fe2640c23ce08646918d4414) | `` Updated emacs ``        |
| [`b0df43bf`](https://github.com/nix-community/emacs-overlay/commit/b0df43bf17931a6b870194770340d268fe7412c2) | `` Updated melpa ``        |
| [`609ba40f`](https://github.com/nix-community/emacs-overlay/commit/609ba40f7e228e70b102c14b084e63445decae0b) | `` Updated elpa ``         |
| [`1572bc00`](https://github.com/nix-community/emacs-overlay/commit/1572bc00e95555e6c4743957103d69c9ec08a336) | `` Updated emacs ``        |
| [`a1245ef1`](https://github.com/nix-community/emacs-overlay/commit/a1245ef1bb10e332d1353312c058169407145cc7) | `` Updated melpa ``        |
| [`512ec36b`](https://github.com/nix-community/emacs-overlay/commit/512ec36be62eaec6ddec1515a2a659029e35de30) | `` Updated emacs ``        |
| [`872e3935`](https://github.com/nix-community/emacs-overlay/commit/872e3935226c183c84707fda203a08ce2358f2b9) | `` Updated melpa ``        |
| [`38e6edaa`](https://github.com/nix-community/emacs-overlay/commit/38e6edaa6d0aa316bd16042c76e5af93287b2512) | `` Updated elpa ``         |
| [`ccf25455`](https://github.com/nix-community/emacs-overlay/commit/ccf254555f8586272e1e50dc11eb9dc82ee51103) | `` Updated flake inputs `` |
| [`45b3e94d`](https://github.com/nix-community/emacs-overlay/commit/45b3e94dfd35aa81f150d293089ed8c28f602f5f) | `` Updated emacs ``        |
| [`b234c1f8`](https://github.com/nix-community/emacs-overlay/commit/b234c1f87824418a6c6effcf3f9ad805221d1d5c) | `` Updated melpa ``        |
| [`f9ac504d`](https://github.com/nix-community/emacs-overlay/commit/f9ac504d6dceac20600690ec40b2774ce98a6b7f) | `` Updated elpa ``         |
| [`f2566442`](https://github.com/nix-community/emacs-overlay/commit/f2566442d6ff7837f89dc962d0bce70c68a7d6a3) | `` Updated flake inputs `` |
| [`93c49f34`](https://github.com/nix-community/emacs-overlay/commit/93c49f3479f3abb5e0ed2c62387af0a83e5d59dc) | `` Updated emacs ``        |
| [`8057607a`](https://github.com/nix-community/emacs-overlay/commit/8057607aec6360988e4a1951fedbfb4fe7552ddf) | `` Updated melpa ``        |
| [`0e8b7913`](https://github.com/nix-community/emacs-overlay/commit/0e8b7913eb5577cec50e119c66fe1c647d440a31) | `` Updated flake inputs `` |
| [`3ca8fd85`](https://github.com/nix-community/emacs-overlay/commit/3ca8fd85438bf9e717628f519044b56d54e56911) | `` Updated emacs ``        |
| [`645894d1`](https://github.com/nix-community/emacs-overlay/commit/645894d1da1ee1987d58149910440a3856d04f79) | `` Updated melpa ``        |
| [`fe8db2c0`](https://github.com/nix-community/emacs-overlay/commit/fe8db2c01aa9a1cf77a9bb9346081e21090b8890) | `` Updated elpa ``         |
| [`8ceb0a35`](https://github.com/nix-community/emacs-overlay/commit/8ceb0a355b70a76ca3e4aad4584c7be55e0ad0e1) | `` Updated nongnu ``       |
| [`9327b7e1`](https://github.com/nix-community/emacs-overlay/commit/9327b7e16a991c8a2efbad729ac28452d7c40bf0) | `` Updated emacs ``        |
| [`e42410cb`](https://github.com/nix-community/emacs-overlay/commit/e42410cb62a21e0f39051ea76beaac7175ef8ede) | `` Updated melpa ``        |
| [`b69808ce`](https://github.com/nix-community/emacs-overlay/commit/b69808ceea4367b7826d4045958d3e556365d3f4) | `` Updated elpa ``         |
| [`7e59721f`](https://github.com/nix-community/emacs-overlay/commit/7e59721f8aef4297683eae683c6883ca08957d0a) | `` Updated nongnu ``       |