### PR TITLE
chore(flake/nixpkgs): `9a113b42` -> `5e55f0bb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -908,11 +908,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1707347693,
-        "narHash": "sha256-/MxX1WUwKui2dWtKghN+8qIKf8X7hHPD1KCeDXoApEI=",
+        "lastModified": 1708057191,
+        "narHash": "sha256-O3M5EGAeKZdEzfFIjqah0d8M44A4QCSVwvkbz4cbC2s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9a113b42b3b15eafa91a027bd9fb9fd69fa6ed96",
+        "rev": "5e55f0bb65124b05d0a52e164514c03596023634",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`13973b5c`](https://github.com/NixOS/nixpkgs/commit/13973b5cf77c85e7fe2f6ec62df4906f88e4f1de) | `` python311Packages.accelerate: fix build on linux ``                           |
| [`69c4e3af`](https://github.com/NixOS/nixpkgs/commit/69c4e3af3a750f12209a6a3b7507292b924d3f4e) | `` github-cli: 2.43.1 -> 2.44.0 ``                                               |
| [`a8edd167`](https://github.com/NixOS/nixpkgs/commit/a8edd1672461d124783a30cfa1f2d3cda94bd8c4) | `` dasel: 2.5.0 -> 2.6.0 ``                                                      |
| [`76c0b6b3`](https://github.com/NixOS/nixpkgs/commit/76c0b6b36e53042acf903e0f09fc6ca108104b1d) | `` python311Packages.peaqevcore: 19.6.6 -> 19.6.10 ``                            |
| [`0e66c8e1`](https://github.com/NixOS/nixpkgs/commit/0e66c8e1a4f76ea6de922303c167c0605c178626) | `` werf: 1.2.289 -> 1.2.290 ``                                                   |
| [`ace0a3bd`](https://github.com/NixOS/nixpkgs/commit/ace0a3bdddb9cfd56017fda756632630400e65cf) | `` vscode: 1.86.1 -> 1.86.2 ``                                                   |
| [`3a35d0c2`](https://github.com/NixOS/nixpkgs/commit/3a35d0c2506a0bd0d0e9023bee7396c2f57fa042) | `` kubectl-klock: 0.5.0 -> 0.5.1 ``                                              |
| [`4f6de75a`](https://github.com/NixOS/nixpkgs/commit/4f6de75a95b07472abb17ea9762dddbea5d30b17) | `` kubectl-klock: add completion script ``                                       |
| [`6c574adc`](https://github.com/NixOS/nixpkgs/commit/6c574adc0e25523e83fe70d4d6a3dcddd8e00e57) | `` python311Packages.deluge-client: 1.9.0 -> 1.10.0 ``                           |
| [`7f0abdc3`](https://github.com/NixOS/nixpkgs/commit/7f0abdc3ecb3fd53a1ea95b4bfda720db3e35dd0) | `` python311Packages.openwebifpy: 4.2.1 -> 4.2.4 ``                              |
| [`d1ee8af6`](https://github.com/NixOS/nixpkgs/commit/d1ee8af620dd96cb410625810b5399677ccddf77) | `` python3Packages.nix-prefetch-github: v7.0.0 -> v7.1.0 ``                      |
| [`1122f538`](https://github.com/NixOS/nixpkgs/commit/1122f53814335a328caa493ffacc0e5a9607a571) | `` plow: init at 1.3.1 ``                                                        |
| [`44275c8b`](https://github.com/NixOS/nixpkgs/commit/44275c8b864008080168ad7933eb19fc2798a200) | `` plantuml: use `finalAttrs` pattern ``                                         |
| [`7323b4ae`](https://github.com/NixOS/nixpkgs/commit/7323b4ae7257295f802c692de5c9f83b64eec283) | `` php83: 8.3.2 -> 8.3.3 ``                                                      |
| [`728d5991`](https://github.com/NixOS/nixpkgs/commit/728d5991d9b09effef73072e4d37cda7e05837ad) | `` php82: 8.2.15 -> 8.2.16 ``                                                    |
| [`80861fb0`](https://github.com/NixOS/nixpkgs/commit/80861fb03279dc0b391b1336079fb205b2c3a953) | `` lemmy-server: fix tests by waiting until backend is ready with 10s timeout `` |
| [`13fae614`](https://github.com/NixOS/nixpkgs/commit/13fae6142cea263714198e815dfdcb8fe72e1a57) | `` lemmy-server/ui: 0.18.5 -> 0.19.3 ``                                          |
| [`d11c768a`](https://github.com/NixOS/nixpkgs/commit/d11c768a57000597cfd0441043efe0b3bd684de1) | `` links2: Use fqdn instead of meta.homepage in src.url ``                       |
| [`62887593`](https://github.com/NixOS/nixpkgs/commit/6288759310e7105a3fecfea4dad52dd46378d758) | `` rofi-pass: unstable-2023-07-07 -> unstable-2024-02-13 ``                      |
| [`893ac592`](https://github.com/NixOS/nixpkgs/commit/893ac5926196d9d6803b189aecc3b01802f4ec0f) | `` crosvm: 120.0 -> 121.3 ``                                                     |
| [`8d3652ec`](https://github.com/NixOS/nixpkgs/commit/8d3652ecffcc7a2d1831566404cc7984b5b426b0) | `` kubernetes: 1.28.4 -> 1.29.2 ``                                               |
| [`b21ae125`](https://github.com/NixOS/nixpkgs/commit/b21ae1255bd4af0e57ae14acf3937d934d2e87c0) | `` reindeer: unstable-2024-02-03 -> unstable-2024-02-15 ``                       |
| [`3d695c17`](https://github.com/NixOS/nixpkgs/commit/3d695c171d8dbed8c7f80a23a56572f01c8304f1) | `` pythonPackages.xrootd: improve xrootd overriding (#289072) ``                 |
| [`3f04d960`](https://github.com/NixOS/nixpkgs/commit/3f04d960a2ce88c20778bef67b21027ad0d10732) | `` python312Packages.snakemake-interface-common: 1.15.3 -> 1.16.0 ``             |
| [`eed623cb`](https://github.com/NixOS/nixpkgs/commit/eed623cb885e2b2e9dea8de261d8554a2b92f4a1) | `` qt6.qtbase: fix calls to substituteInPlace ``                                 |
| [`592778c4`](https://github.com/NixOS/nixpkgs/commit/592778c4b0b88ee9e474c4c8e778a2769ec8504b) | `` yuzuPackages.early-access: 4115 -> 4141 ``                                    |
| [`dd1d6ba4`](https://github.com/NixOS/nixpkgs/commit/dd1d6ba4c395aa3a0bd5295024436f17da8c79e7) | `` yuzuPackages.mainline: 1704 -> 1715 ``                                        |
| [`7a445c51`](https://github.com/NixOS/nixpkgs/commit/7a445c511af4b0789aafe4a8cd6b399487f20080) | `` qovery-cli: 0.84.0 -> 0.84.1 ``                                               |
| [`d91b5f4c`](https://github.com/NixOS/nixpkgs/commit/d91b5f4c16567a8384121ac3cd278194bee531dc) | `` yuzuPackages.compat-list: unstable-2024-02-04 -> unstable-2024-02-14 ``       |
| [`5f30a9c7`](https://github.com/NixOS/nixpkgs/commit/5f30a9c70a0a8fcb7484e13cfb88d1667fdb9e9f) | `` owmods-cli: 0.12.1 -> 0.12.2 ``                                               |
| [`1bb5900d`](https://github.com/NixOS/nixpkgs/commit/1bb5900d8aac9d8a3bb3c21b2d1a0f57a98eefa8) | `` alacritty-theme: unstable-2024-01-21 -> unstable-2024-02-11 ``                |
| [`60a6ca4d`](https://github.com/NixOS/nixpkgs/commit/60a6ca4db24618fe827d9a829dd0b720e22e21ee) | `` kde/gear: 23.08.4 -> 23.08.5 ``                                               |
| [`295d8659`](https://github.com/NixOS/nixpkgs/commit/295d86590730e5801527f1ed5394edb2c0d0f406) | `` fangfrisch: 1.7.0 -> 1.8.0 ``                                                 |
| [`ec775651`](https://github.com/NixOS/nixpkgs/commit/ec775651d418a055c7b04f834a3c645f191d98be) | `` exploitdb: 2024-02-10 -> 2024-02-14 ``                                        |
| [`e3fcf863`](https://github.com/NixOS/nixpkgs/commit/e3fcf863a0d0534bd621538dcfd266b0b43a75a9) | `` tile38: 1.32.1 -> 1.32.2 ``                                                   |
| [`15c5f765`](https://github.com/NixOS/nixpkgs/commit/15c5f76541df4fd7fad8644acab23ad6fcbdc285) | `` python311Packages.aioecowitt: 2024.2.1 -> 2024.2.2 ``                         |
| [`68386cad`](https://github.com/NixOS/nixpkgs/commit/68386cad15c7f3443da8976957c21378ed51658c) | `` ttdl: 4.1.0 -> 4.2.0 ``                                                       |
| [`866e8949`](https://github.com/NixOS/nixpkgs/commit/866e894907ed49fac172245d574df0e2c28b3e5a) | `` opengrok: 1.13.2 -> 1.13.3 ``                                                 |
| [`7727237a`](https://github.com/NixOS/nixpkgs/commit/7727237a78b92a32a8cea8396ea0a011217e13ee) | `` aws-vault: drop xdg-open from dependencies on darwin (#288222) ``             |
| [`d1a490d3`](https://github.com/NixOS/nixpkgs/commit/d1a490d3a11e9de2f6026be7a2c63fded1a770a5) | `` paperless-ngx: 2.5.0 -> 2.5.2 ``                                              |
| [`0cb6bde0`](https://github.com/NixOS/nixpkgs/commit/0cb6bde0d5aba399673cd5dc6e1f9e81437f07d3) | `` angie-console-light: 1.1.1 -> 1.2.1 ``                                        |
| [`037353b1`](https://github.com/NixOS/nixpkgs/commit/037353b1d7a62981b4a5922c190bb45af8853307) | `` buildpack: 0.33.1 -> 0.33.2 ``                                                |
| [`4be2c26b`](https://github.com/NixOS/nixpkgs/commit/4be2c26bb547ea408c025600a977e75e64ac3cda) | `` vimPlugins.nvim-bacon: init at 2024-02-12 (#288660) ``                        |
| [`4715c040`](https://github.com/NixOS/nixpkgs/commit/4715c040693b6099e29130d67e06934a4572d1a5) | `` angie: 1.4.0 -> 1.4.1 ``                                                      |
| [`4fbb7ddc`](https://github.com/NixOS/nixpkgs/commit/4fbb7ddc7940eded64a14078773597441f5fcc3c) | `` klipper: unstable-2024-01-06 -> unstable-2024-02-13 ``                        |
| [`c3ef726e`](https://github.com/NixOS/nixpkgs/commit/c3ef726ee171a1f78def8c4da8a2e3719efbbfa4) | `` nixos/ldso: avoid instance of nixpkgs (#288509) ``                            |
| [`64e7fd68`](https://github.com/NixOS/nixpkgs/commit/64e7fd68dcd5852c494a7031e33e3846a86d91e3) | `` flexget: 3.11.17 -> 3.11.18 ``                                                |
| [`b8fe1746`](https://github.com/NixOS/nixpkgs/commit/b8fe1746608aea05721cd83c8f89ed4f720adfb1) | `` spike: unpin gcc12 ``                                                         |
| [`4a8def58`](https://github.com/NixOS/nixpkgs/commit/4a8def58feb660f2cf411b3f05fd1d2d45155427) | `` vimPlugins.elixir-tools-nvim: fix credo-language-server (#275505) ``          |
| [`bb661ae2`](https://github.com/NixOS/nixpkgs/commit/bb661ae246ca22ae40757223ab90251a95a7757c) | `` vimPlugins.baleia-nvim: init at 2024-01-06 (#289001) ``                       |
| [`47f2adfe`](https://github.com/NixOS/nixpkgs/commit/47f2adfe17d554beeaaffea77e3fa7d8c2a914dd) | `` vimPlugins.staline-nvim: init at 2024-02-14 (#288879) ``                      |
| [`c4dee7b4`](https://github.com/NixOS/nixpkgs/commit/c4dee7b41c8052c91fee0b896f3f4c455f9bdbaa) | `` gpxsee: 13.15 -> 13.16 ``                                                     |
| [`4c947c73`](https://github.com/NixOS/nixpkgs/commit/4c947c7337440843ba521c266277a161286e26a4) | `` netsurf.browser: 3.10 -> 3.11, fix build on darwin ``                         |
| [`6777670f`](https://github.com/NixOS/nixpkgs/commit/6777670fca9e13030f035d0f72b5b10ffadbf36b) | `` netsurf.libsvgtiny: 0.1.7 -> 0.1.8 ``                                         |
| [`1d4c4c8c`](https://github.com/NixOS/nixpkgs/commit/1d4c4c8c88a5f11c62b5b30b106b995f72470d45) | `` netsurf.libparserutils: 0.2.4 -> 0.2.5 ``                                     |
| [`c2ef7e87`](https://github.com/NixOS/nixpkgs/commit/c2ef7e877cf198f5cd30e356172dddf730074e8d) | `` netsurf.libnsutils: 0.1.0 -> 0.1.1 ``                                         |
| [`d6b50697`](https://github.com/NixOS/nixpkgs/commit/d6b50697f3a38b2a5e388645567465723f6f8a7b) | `` netsurf.libnsgif: 0.2.1 -> 1.0.0 ``                                           |
| [`474691a8`](https://github.com/NixOS/nixpkgs/commit/474691a84c1b05dad3a409ff26be4cf06a28e28e) | `` netsurf.libnsbmp: 0.1.6 -> 0.1.7 ``                                           |
| [`2f64c17c`](https://github.com/NixOS/nixpkgs/commit/2f64c17cc89f6d94932e09fe911fce7f784b89ee) | `` netsurf.libhubbub: 0.3.7 -> 0.3.8 ``                                          |
| [`ab07a6f9`](https://github.com/NixOS/nixpkgs/commit/ab07a6f9e28ac64d839c2034d7310f6b48ba0e10) | `` netsurf.libdom: 0.4.1 -> 0.4.2 ``                                             |
| [`fb21e1e1`](https://github.com/NixOS/nixpkgs/commit/fb21e1e1c987b4899e0149aff120df556abe3465) | `` netsurf.libcss: 0.9.1 -> 0.9.2 ``                                             |
| [`e39eed24`](https://github.com/NixOS/nixpkgs/commit/e39eed240b2f2347d02a643af7fd11ccab6d2128) | `` bloat: unstable-2023-12-28 -> unstable-2024-02-12 ``                          |
| [`f8f1850c`](https://github.com/NixOS/nixpkgs/commit/f8f1850c68845e1db73725cabfc07148c413b5a2) | `` rizin: add patch to build with tree-sitter 0.20.9 ``                          |
| [`9e2ece56`](https://github.com/NixOS/nixpkgs/commit/9e2ece568106b2e5222f1bc8b7ca83503bbf5bec) | `` terraform: remove "-dev" suffix from `-version` output (#288878) ``           |
| [`ae65dbf8`](https://github.com/NixOS/nixpkgs/commit/ae65dbf892883ce50db1f5bf98dbed2af3e4cdf9) | `` python311Packages.vallox-websocket-api: 4.1.0 -> 4.2.0 ``                     |
| [`05a18536`](https://github.com/NixOS/nixpkgs/commit/05a1853613e639492f2a4c0d653942b21b94e0d6) | `` python311Packages.rns: 0.7.0 -> 0.7.1 ``                                      |
| [`cce29d54`](https://github.com/NixOS/nixpkgs/commit/cce29d540d972628e17ec84099dad353634cee93) | `` python311Packages.boto3-stubs: 1.34.40 -> 1.34.42 ``                          |
| [`42f0f3e6`](https://github.com/NixOS/nixpkgs/commit/42f0f3e655c4f2f608028acdb3d816baa8e5c045) | `` python311Packages.aioautomower: 2024.2.4 -> 2024.2.6 ``                       |
| [`031babe2`](https://github.com/NixOS/nixpkgs/commit/031babe21f9d374b4f2b8b5039169d937ac65d31) | `` scala-cli: 1.1.1 -> 1.1.3 ``                                                  |
| [`2855977d`](https://github.com/NixOS/nixpkgs/commit/2855977dd8250c08e79ee26d3d09329ff9d3a94d) | `` eza: 0.18.2 -> 0.18.3 ``                                                      |
| [`01e64336`](https://github.com/NixOS/nixpkgs/commit/01e6433642233e3aa304f25f2a8a47547f7e9d46) | `` python311Packages.botocore-stubs: 1.34.40 -> 1.34.42 ``                       |
| [`11a28beb`](https://github.com/NixOS/nixpkgs/commit/11a28beb5377739f1e003bc97e0c83febff7feab) | `` openmolcas: bump boost version ``                                             |
| [`0c6a93e4`](https://github.com/NixOS/nixpkgs/commit/0c6a93e45b4d0e562c4a3cf91952200bc196ccb6) | `` plumber: remove unneeded compile flag ``                                      |
| [`3d538ec7`](https://github.com/NixOS/nixpkgs/commit/3d538ec73cafc673a71c47a4b574b7b2e13693e9) | `` qt6: 6.6.1 -> 6.6.2 ``                                                        |
| [`bb208b22`](https://github.com/NixOS/nixpkgs/commit/bb208b22ab7a94d2f785eaaa3aa63148bfbc0f9a) | `` terra: llvmPackages_11 -> llvmPackages ``                                     |
| [`d41e5c00`](https://github.com/NixOS/nixpkgs/commit/d41e5c00b42c7746b9d31a8ee18f04f944adcf96) | `` ibus-engines.typing-booster-unwrapped: 2.25.0 -> 2.25.1 ``                    |
| [`4572f3ec`](https://github.com/NixOS/nixpkgs/commit/4572f3ec59d24d153f6da98945ba39e14f7fe62a) | `` frigate: fix flask 3.0 compat ``                                              |
| [`f3c5273e`](https://github.com/NixOS/nixpkgs/commit/f3c5273e624cc194424d967fa78a3370fafeaae7) | `` flow: 0.228.0 -> 0.229.0 ``                                                   |
| [`d1902fde`](https://github.com/NixOS/nixpkgs/commit/d1902fdede407ae8480f66cf2a7cda80c5f796f1) | `` python312Packages.rokuecp: 0.19.0 -> 0.19.1 ``                                |
| [`3da5f8db`](https://github.com/NixOS/nixpkgs/commit/3da5f8db67eff04c06721925e8255066b0e82071) | `` swagger-codegen3: 3.0.52 -> 3.0.53 ``                                         |
| [`13d341db`](https://github.com/NixOS/nixpkgs/commit/13d341db8089826494253bfe97cd8cdfa176a023) | `` librewolf-unwrapped: 122.0-2 -> 122.0.1-2 ``                                  |
| [`cc492c79`](https://github.com/NixOS/nixpkgs/commit/cc492c796f76a727083bcac0b59c5c09fb0acfc8) | `` newsflash: 3.0.2 -> 3.1.1 ``                                                  |
| [`cb1b73c0`](https://github.com/NixOS/nixpkgs/commit/cb1b73c031ca4b9a13689af6b8353f926ea01507) | `` erlang_24: 24.3.4.15 -> 24.3.4.16 ``                                          |
| [`7920b15a`](https://github.com/NixOS/nixpkgs/commit/7920b15ab455236a02d7f0ba2c0605598812ce55) | `` precice: 2.5.0 -> 3.0.0 ``                                                    |
| [`b8d8ec39`](https://github.com/NixOS/nixpkgs/commit/b8d8ec39dd0a9f388d9680aa525a6bc37e8ff286) | `` knossosnet: init at 1.0.0 ``                                                  |
| [`c5936472`](https://github.com/NixOS/nixpkgs/commit/c593647259a5621263066e4cc31aa01e1d4e4bfe) | `` home-manager: unstable-2024-02-11 -> unstable-2024-02-14 ``                   |
| [`a145fd99`](https://github.com/NixOS/nixpkgs/commit/a145fd99cdb5e4247ba7e086438b109b5c2465d3) | `` python311Packages.pylibjpeg: 1.4.0 -> 2.0.0 ``                                |
| [`f546686f`](https://github.com/NixOS/nixpkgs/commit/f546686f7dabde127d65528c2449777e7acac819) | `` python311Packages.pylibjpeg-libjpeg: 1.3.4 -> 2.02 ``                         |
| [`082387b5`](https://github.com/NixOS/nixpkgs/commit/082387b5e454ef9e72aceb9fe93267c0f8ea76f6) | `` runme: 2.2.6 -> 3.0.0 ``                                                      |
| [`419c8d8b`](https://github.com/NixOS/nixpkgs/commit/419c8d8be5566b79b12cab6ad886cd6a7deb0021) | `` ssmsh: 1.4.8 -> 1.4.9 ``                                                      |
| [`808fb65d`](https://github.com/NixOS/nixpkgs/commit/808fb65d20ad469593ca7acaa191923b395cecde) | `` plantuml: 1.2024.1 -> 1.2024.2 ``                                             |
| [`7e1b918a`](https://github.com/NixOS/nixpkgs/commit/7e1b918a949eef5340643d102b3b7be6c148aacf) | `` plantuml-server: 1.2024.1 -> 1.2024.2 ``                                      |