### PR TITLE
chore(flake/hyprland): `fbf5ba87` -> `cdcc5aba`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -474,11 +474,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1708018354,
-        "narHash": "sha256-MlbqBzAjiz4Va2M/AvLN96Wq+jsCbEedhfMs5wW1yFM=",
+        "lastModified": 1708138027,
+        "narHash": "sha256-xTOrKOamqdVtW+v7j0bUTed8nqfijEMahJ7edgFtWL0=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "fbf5ba87ce57752653f3bebf6e2be090c702836e",
+        "rev": "cdcc5aba06f20005842cf966b23af50456dc7142",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                   |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
| [`cdcc5aba`](https://github.com/hyprwm/Hyprland/commit/cdcc5aba06f20005842cf966b23af50456dc7142) | `` xwayland: ignore OR activate requests if surface doesn't want focus `` |
| [`e3e7e1fd`](https://github.com/hyprwm/Hyprland/commit/e3e7e1fdda7660a70bd206aa3ed6a45bb4000376) | `` monitor: don't damage twice (#4727) ``                                 |