### PR TITLE
chore(flake/nur): `2593837c` -> `bacaa8bc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -938,11 +938,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708105507,
-        "narHash": "sha256-OLjuwC6g02i9c3IfbOEywOOcnsNZkqei9DcZ5BY1D2Q=",
+        "lastModified": 1708144369,
+        "narHash": "sha256-onHY3CJXCg3rSpIcdffBCjnJiJj07f14CSvEVH3Gr/w=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "2593837ca8fc3abd462bac0ac002eec451001418",
+        "rev": "bacaa8bc5fd5a6b8c22004ea3851d7485c9c40b6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`bacaa8bc`](https://github.com/nix-community/NUR/commit/bacaa8bc5fd5a6b8c22004ea3851d7485c9c40b6) | `` automatic update `` |
| [`8098cc42`](https://github.com/nix-community/NUR/commit/8098cc42a61d691ec6226b4df2915d720895e0af) | `` automatic update `` |
| [`d966121a`](https://github.com/nix-community/NUR/commit/d966121a8014132fc567dcc058f614a478b6826f) | `` automatic update `` |
| [`9b37d872`](https://github.com/nix-community/NUR/commit/9b37d872c4e92ded39283bfa5984eb51a6b3a3a9) | `` automatic update `` |
| [`9853e8d0`](https://github.com/nix-community/NUR/commit/9853e8d036ef4c4e40bb27d59c3bc4e7a270d090) | `` automatic update `` |
| [`d9743aa6`](https://github.com/nix-community/NUR/commit/d9743aa636d30c6cdcd2f1c7ab7f0e23af3cb1d8) | `` automatic update `` |
| [`37c8d3a4`](https://github.com/nix-community/NUR/commit/37c8d3a4bf5c9e871e76c124c89d8d7a35bd7c5b) | `` automatic update `` |
| [`630c0d00`](https://github.com/nix-community/NUR/commit/630c0d00d4db58867724d4be569f648a4eed730b) | `` automatic update `` |
| [`d717360b`](https://github.com/nix-community/NUR/commit/d717360bac05db6c76907bf8fd822ced1bb32b64) | `` automatic update `` |
| [`9eab660e`](https://github.com/nix-community/NUR/commit/9eab660e8f9fe1b41bca3e198ba96c23270659ab) | `` automatic update `` |
| [`f19cafc4`](https://github.com/nix-community/NUR/commit/f19cafc4479a22f7a643f1e3a2d276a263f1b251) | `` automatic update `` |
| [`65dc4760`](https://github.com/nix-community/NUR/commit/65dc47601e21ec82a8e6e0c0125df12e36475399) | `` automatic update `` |
| [`9d0cccca`](https://github.com/nix-community/NUR/commit/9d0cccca3b91d565977b88938ca9233868fd1bc5) | `` automatic update `` |