### PR TITLE
chore(flake/emacs-overlay): `4887a3bf` -> `c3d788a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -193,11 +193,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1708103144,
-        "narHash": "sha256-+HWM66eCCeok8tA1IF4lpSvrreYPcZjayo0i2Vn1RyI=",
+        "lastModified": 1708133394,
+        "narHash": "sha256-XjT+2BCA8Ntp0ZguhID7QyPkwKSwE2uqMwJ4PBfeQYg=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "4887a3bf368f7ba9fe2640c23ce08646918d4414",
+        "rev": "c3d788a49ce7f930194fa1b8e4afef65a34d6cf3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`c3d788a4`](https://github.com/nix-community/emacs-overlay/commit/c3d788a49ce7f930194fa1b8e4afef65a34d6cf3) | `` Updated melpa ``  |
| [`33751916`](https://github.com/nix-community/emacs-overlay/commit/337519167c4ef503a9617a35e95322b10e756f6c) | `` Updated elpa ``   |
| [`c7090a11`](https://github.com/nix-community/emacs-overlay/commit/c7090a11f393071dcfd8a14ef5d803d30f477016) | `` Updated nongnu `` |