### PR TITLE
chore(flake/nur): `bacaa8bc` -> `ccc244cf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -938,11 +938,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708144369,
-        "narHash": "sha256-onHY3CJXCg3rSpIcdffBCjnJiJj07f14CSvEVH3Gr/w=",
+        "lastModified": 1708213449,
+        "narHash": "sha256-m1H5SvWlIldAzQrvzOSxhoxNJjodIZZBY34F/Iu7id4=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "bacaa8bc5fd5a6b8c22004ea3851d7485c9c40b6",
+        "rev": "ccc244cf9a517cdfccfd6a7a8b47083a5f926a0e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`ccc244cf`](https://github.com/nix-community/NUR/commit/ccc244cf9a517cdfccfd6a7a8b47083a5f926a0e) | `` automatic update `` |
| [`8199a4b8`](https://github.com/nix-community/NUR/commit/8199a4b8d5d6074db7b10a725d880630e5c37637) | `` automatic update `` |
| [`0453b074`](https://github.com/nix-community/NUR/commit/0453b0745100cee220ff5b1be71c8806aaa07547) | `` automatic update `` |
| [`d46453dc`](https://github.com/nix-community/NUR/commit/d46453dcb1bd9aec9ecfa8a0ad8027308c643606) | `` automatic update `` |
| [`19370e44`](https://github.com/nix-community/NUR/commit/19370e44d2d001f6412b52ca28f5003c7e48a3b1) | `` automatic update `` |
| [`9960edd0`](https://github.com/nix-community/NUR/commit/9960edd041c77e7041f2016abfc9ed9e44f32166) | `` automatic update `` |
| [`59988ea4`](https://github.com/nix-community/NUR/commit/59988ea4f710e875f025914d6de2afe5dab79647) | `` automatic update `` |
| [`d8f26b89`](https://github.com/nix-community/NUR/commit/d8f26b89cb7e1a4a893f5bc9d4878e2190d30d4d) | `` automatic update `` |
| [`55ddee9a`](https://github.com/nix-community/NUR/commit/55ddee9a45eb054748d85b4db2185d25d7fe0409) | `` automatic update `` |
| [`a0543345`](https://github.com/nix-community/NUR/commit/a0543345ddda9db58d930675085c9d1a52af4ca1) | `` automatic update `` |
| [`e9c855dd`](https://github.com/nix-community/NUR/commit/e9c855dd90924f6a0e072ebe22660b36e84a2b54) | `` automatic update `` |
| [`0799ad07`](https://github.com/nix-community/NUR/commit/0799ad071162f5b534cc55722491f94b61832993) | `` automatic update `` |
| [`eac4d04d`](https://github.com/nix-community/NUR/commit/eac4d04d8d02703dafa012540209ad34a0bff559) | `` automatic update `` |
| [`4505aa08`](https://github.com/nix-community/NUR/commit/4505aa081f915ea31046fed4b10014b740c219c0) | `` automatic update `` |
| [`96ec1f30`](https://github.com/nix-community/NUR/commit/96ec1f30b8caf822d50d75ec30f8ad9949d50584) | `` automatic update `` |
| [`866edeb7`](https://github.com/nix-community/NUR/commit/866edeb74fbb7b2ebcdc98d394da340f264f2135) | `` automatic update `` |
| [`5e8adec2`](https://github.com/nix-community/NUR/commit/5e8adec22987489f1a0c94529559ba1af24426dd) | `` automatic update `` |
| [`fe2a92e5`](https://github.com/nix-community/NUR/commit/fe2a92e50ae1f324551eb240b89d71baee10ce38) | `` automatic update `` |