### PR TITLE
chore(flake/hyprland): `cdcc5aba` -> `683a4b07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -474,11 +474,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1708138027,
-        "narHash": "sha256-xTOrKOamqdVtW+v7j0bUTed8nqfijEMahJ7edgFtWL0=",
+        "lastModified": 1708215223,
+        "narHash": "sha256-5z+NPNoiWKoaz3M4LZJ2fP+N7Vl9XGwr4QAV8rh4l4o=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "cdcc5aba06f20005842cf966b23af50456dc7142",
+        "rev": "683a4b07c514fa3c13cdf09e475283a69fcc7653",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                             |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
| [`683a4b07`](https://github.com/hyprwm/Hyprland/commit/683a4b07c514fa3c13cdf09e475283a69fcc7653) | `` rules: ignore static tile/float rules in dynamic gets ``                         |
| [`5261a8df`](https://github.com/hyprwm/Hyprland/commit/5261a8df81c1aad07b582bce82d164801de533b0) | `` keybinds: Add an option to pass a window argument to moveoutofgroup (#4724) ``   |
| [`289d952a`](https://github.com/hyprwm/Hyprland/commit/289d952a6ee02f6d54a0899870bbec52ff9a53df) | `` dispatchers: add Fullscreen without sending fullscreen to application (#4720) `` |
| [`294e51a8`](https://github.com/hyprwm/Hyprland/commit/294e51a857d158ce0b03c5fd752bbd05e67f6bc9) | `` input: refocus on completed drags ``                                             |