### PR TITLE
chore(flake/emacs-overlay): `192e23af` -> `6c7eca7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -193,11 +193,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1708189479,
-        "narHash": "sha256-R/n9p78rsBl795Z8OHzvlNSV/Dbm3fszPVO/H8AqyJU=",
+        "lastModified": 1708275876,
+        "narHash": "sha256-GzC+0fJhU/0TnFyVMe309ffmRIyRiMzqQ6zDcmn5s9s=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "192e23af90504ef6514d9255f8ee006d47909e09",
+        "rev": "6c7eca7e41d5d47a0777b045a125a6f076b70c34",
         "type": "github"
       },
       "original": {
@@ -858,11 +858,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1708105575,
-        "narHash": "sha256-sS4AItZeUnAei6v8FqxNlm+/27MPlfoGym/TZP0rmH0=",
+        "lastModified": 1708161998,
+        "narHash": "sha256-6KnemmUorCvlcAvGziFosAVkrlWZGIc6UNT9GUYr0jQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1d1817869c47682a6bee85b5b0a6537b6c0fba26",
+        "rev": "84d981bae8b5e783b3b548de505b22880559515f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`6c7eca7e`](https://github.com/nix-community/emacs-overlay/commit/6c7eca7e41d5d47a0777b045a125a6f076b70c34) | `` Updated emacs ``        |
| [`e3b3b271`](https://github.com/nix-community/emacs-overlay/commit/e3b3b271caf7a4664b51e1a25c16e5a69fe70036) | `` Updated melpa ``        |
| [`af022425`](https://github.com/nix-community/emacs-overlay/commit/af02242510319d4dcb895f4de83b74b461b9cbda) | `` Updated elpa ``         |
| [`4337f34d`](https://github.com/nix-community/emacs-overlay/commit/4337f34dae4a0dc33539852a0e4a52d78605ac81) | `` Updated emacs ``        |
| [`e1d06e86`](https://github.com/nix-community/emacs-overlay/commit/e1d06e86d99e96d1588c291208490c8ee2c08a42) | `` Updated melpa ``        |
| [`9220b65f`](https://github.com/nix-community/emacs-overlay/commit/9220b65fb203554de784267c6a0a9a271888109c) | `` Updated flake inputs `` |
| [`69b18188`](https://github.com/nix-community/emacs-overlay/commit/69b181888ea72d7c8a769c1b1ff6c5cb49d084ed) | `` Updated emacs ``        |
| [`4d106338`](https://github.com/nix-community/emacs-overlay/commit/4d106338574dfb66e16ebb9b8a53b7693da2a787) | `` Updated melpa ``        |
| [`4afdb9d4`](https://github.com/nix-community/emacs-overlay/commit/4afdb9d4384f7e18faf385552899ad948f2601da) | `` Updated elpa ``         |