### PR TITLE
chore(flake/spicetify-nix): `06d03b87` -> `b1a7ee96`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1079,11 +1079,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708143113,
-        "narHash": "sha256-NkA5yii1FRLP8ApykQu9t2ImilZabLC+DDkIZyPSJds=",
+        "lastModified": 1708229365,
+        "narHash": "sha256-resA0bQLwcF1d4oUeAgqiPCXqNZHDzkIPBBePdOn8mE=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "06d03b879c9a0a6577bec739bf99a551ca0c5f6b",
+        "rev": "b1a7ee96a64b1755a7ddd46b3e73c5442a76e45f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`b1a7ee96`](https://github.com/Gerg-L/spicetify-nix/commit/b1a7ee96a64b1755a7ddd46b3e73c5442a76e45f) | `` CI update 2024-02-18 (#76) `` |