### PR TITLE
chore(flake/home-manager): `3d6791b3` -> `11edf9ca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -452,11 +452,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708031129,
-        "narHash": "sha256-EH20hJfNnc1/ODdDVat9B7aKm0B95L3YtkIRwKLvQG8=",
+        "lastModified": 1708292912,
+        "narHash": "sha256-/DbyiFfipjwrfE/G7/tzpX3U+Og6D63k4I3XvbAid7A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3d6791b3897b526c82920a2ab5f61d71985b3cf8",
+        "rev": "11edf9cad78cce49d09436c8d725ae36b65671dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`11edf9ca`](https://github.com/nix-community/home-manager/commit/11edf9cad78cce49d09436c8d725ae36b65671dc) | `` flake.lock: Update ``                  |
| [`309465d2`](https://github.com/nix-community/home-manager/commit/309465d20993095a1c6ee2d7eda6ef3588f165ff) | `` Translate using Weblate (Ukrainian) `` |
| [`7671ec19`](https://github.com/nix-community/home-manager/commit/7671ec1931daee86161c8da1115515447667545e) | `` Translate using Weblate (Swedish) ``   |
| [`5aec43bc`](https://github.com/nix-community/home-manager/commit/5aec43bc0f647eba521c2fb82135f7c10e2ea500) | `` Translate using Weblate (Turkish) ``   |
| [`f41f54fb`](https://github.com/nix-community/home-manager/commit/f41f54fb224fd47bd19f0786ebed282f241dc71f) | `` Translate using Weblate (Czech) ``     |
| [`bb69e1d4`](https://github.com/nix-community/home-manager/commit/bb69e1d43ea052aa69d884ae751cb9d1999bd8b8) | `` Update translation files ``            |