### PR TITLE
chore(flake/nur): `ccc244cf` -> `4bf696bd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -938,11 +938,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708213449,
-        "narHash": "sha256-m1H5SvWlIldAzQrvzOSxhoxNJjodIZZBY34F/Iu7id4=",
+        "lastModified": 1708292691,
+        "narHash": "sha256-UTxexgE4NHxU03IqSdyjezjocrOmqZCDoTtlbhOSBAU=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "ccc244cf9a517cdfccfd6a7a8b47083a5f926a0e",
+        "rev": "4bf696bd6382375d823656324ccd33c2037c20f9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`4bf696bd`](https://github.com/nix-community/NUR/commit/4bf696bd6382375d823656324ccd33c2037c20f9) | `` automatic update `` |
| [`cffaf8c8`](https://github.com/nix-community/NUR/commit/cffaf8c87a877a77f790cfef31e2ad916939a708) | `` automatic update `` |
| [`7e3beaca`](https://github.com/nix-community/NUR/commit/7e3beacae3fbe1bb6657057d1af31f209a2f1ce0) | `` automatic update `` |
| [`546e675e`](https://github.com/nix-community/NUR/commit/546e675eb1d9a332dc04e8fb3ecc0a35b8101572) | `` automatic update `` |
| [`fc843cb9`](https://github.com/nix-community/NUR/commit/fc843cb9767ccbd850aa3a823d071874e6f8a4f2) | `` automatic update `` |
| [`78167236`](https://github.com/nix-community/NUR/commit/781672361ff1a08f668b1f31dfa571735c964ca8) | `` automatic update `` |
| [`c4296c55`](https://github.com/nix-community/NUR/commit/c4296c55625e5394c142d5c07c00cddb76d5241b) | `` automatic update `` |
| [`9ecc159c`](https://github.com/nix-community/NUR/commit/9ecc159caae52d9df3486570dcaf84b1bc4f727e) | `` automatic update `` |
| [`7cf9aa5a`](https://github.com/nix-community/NUR/commit/7cf9aa5a48b01934164cbe28e38b4cb744d9e412) | `` automatic update `` |
| [`82d83574`](https://github.com/nix-community/NUR/commit/82d83574b9eb036f268c6a218f68f3ebbb44c482) | `` automatic update `` |
| [`507abb80`](https://github.com/nix-community/NUR/commit/507abb80942a552e20305208f9e98208bce01bf1) | `` automatic update `` |
| [`6dde857e`](https://github.com/nix-community/NUR/commit/6dde857e083df1fa28dc7264eab681456fa68430) | `` automatic update `` |
| [`748255c3`](https://github.com/nix-community/NUR/commit/748255c325b79a54b82b7f7e9292ff48f715b908) | `` automatic update `` |
| [`250e8938`](https://github.com/nix-community/NUR/commit/250e893814c620c9a87e5c007751dd98daa594ee) | `` automatic update `` |
| [`ddb349d1`](https://github.com/nix-community/NUR/commit/ddb349d1ed90658ca10da0d2158ff9732c8c635c) | `` automatic update `` |
| [`36b4ceb5`](https://github.com/nix-community/NUR/commit/36b4ceb52a68f5bc5f0cb711b418327e3b127cfa) | `` automatic update `` |
| [`71314f0e`](https://github.com/nix-community/NUR/commit/71314f0e287bb7c7d301f3a5c19f6cc4f5a1f8c1) | `` automatic update `` |
| [`61e4ca30`](https://github.com/nix-community/NUR/commit/61e4ca30feac8b3cbc260a9b4fc0194e9056f0f5) | `` automatic update `` |
| [`acf217e8`](https://github.com/nix-community/NUR/commit/acf217e874c1ad38e0b93290448813ea34cb152c) | `` automatic update `` |
| [`149248e3`](https://github.com/nix-community/NUR/commit/149248e3c6ed196b6c67b7d8542d54dbee62c86f) | `` automatic update `` |
| [`8d232f6a`](https://github.com/nix-community/NUR/commit/8d232f6aee3d466492104a4c27b2f23827549bab) | `` automatic update `` |
| [`47ce279b`](https://github.com/nix-community/NUR/commit/47ce279ba92857948eb790ee2e29c2498bad5819) | `` automatic update `` |
| [`9758b25f`](https://github.com/nix-community/NUR/commit/9758b25ffc7b95025d9530a3a833563210ad1206) | `` automatic update `` |