### PR TITLE
chore(flake/hyprland): `683a4b07` -> `301b48b7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -468,17 +468,18 @@
     "hyprland": {
       "inputs": {
         "hyprland-protocols": "hyprland-protocols",
+        "hyprlang": "hyprlang",
         "nixpkgs": "nixpkgs_2",
         "systems": "systems_3",
         "wlroots": "wlroots",
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1708215223,
-        "narHash": "sha256-5z+NPNoiWKoaz3M4LZJ2fP+N7Vl9XGwr4QAV8rh4l4o=",
+        "lastModified": 1708272248,
+        "narHash": "sha256-EMGPzNg9422NEoFJUfidRHPokX2+UWErX9qSghpfS/g=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "683a4b07c514fa3c13cdf09e475283a69fcc7653",
+        "rev": "301b48b74087cc59753ffa144b215540e6f82831",
         "type": "github"
       },
       "original": {
@@ -513,6 +514,27 @@
       }
     },
     "hyprlang": {
+      "inputs": {
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1708005943,
+        "narHash": "sha256-9TT3xk++LI5/SPYgjYX34xZ4ebR93c1uerIq+SE/ues=",
+        "owner": "hyprwm",
+        "repo": "hyprlang",
+        "rev": "aeb3e012adc7b3235335c540b214b82267c2b983",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprlang",
+        "type": "github"
+      }
+    },
+    "hyprlang_2": {
       "inputs": {
         "nixpkgs": [
           "hyprland",
@@ -1197,7 +1219,7 @@
           "hyprland",
           "hyprland-protocols"
         ],
-        "hyprlang": "hyprlang",
+        "hyprlang": "hyprlang_2",
         "nixpkgs": [
           "hyprland",
           "nixpkgs"


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                 |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------- |
| [`301b48b7`](https://github.com/hyprwm/Hyprland/commit/301b48b74087cc59753ffa144b215540e6f82831) | `` renderer: fix invalid damage accumulation with invalid buffer_age `` |
| [`fae47ef4`](https://github.com/hyprwm/Hyprland/commit/fae47ef462d1d7969afe001070839391ba6dbaa8) | `` config: fix errors in default config ``                              |
| [`5fc0b772`](https://github.com/hyprwm/Hyprland/commit/5fc0b772c72ce23f3d31fec31fa3688f7ed1afff) | `` config: update default config for hyprlang migration ``              |
| [`13f6f0b9`](https://github.com/hyprwm/Hyprland/commit/13f6f0b923ff3ec94a3bec886c28b90402ceef91) | `` Migrate the config to hyprlang (#4656) ``                            |
| [`7e8bcd67`](https://github.com/hyprwm/Hyprland/commit/7e8bcd675de15ee2498f1aa15c5b335e9a9a55f0) | `` monitors: fix outputmgr nullptr crash (#4738) ``                     |