### PR TITLE
chore(flake/nix-index-database): `0cb43457` -> `17352eb2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -760,11 +760,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707620986,
-        "narHash": "sha256-XE0tCSkSVBeJDWhjFwusNInwAhrnp+TloUNUpvnTiLw=",
+        "lastModified": 1708225687,
+        "narHash": "sha256-NJBDfvknI26beOFmjO2coeJMTTUCCtw2Iu+rvJ1Zb9k=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "0cb4345704123492e6d1f1068629069413c80de0",
+        "rev": "17352eb241a8d158c4ac523b19d8d2a6c8efe127",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`17352eb2`](https://github.com/nix-community/nix-index-database/commit/17352eb241a8d158c4ac523b19d8d2a6c8efe127) | `` update packages.nix to release 2024-02-18-030707 `` |
| [`c52e2960`](https://github.com/nix-community/nix-index-database/commit/c52e2960c521613ba8ca180f476ea064e47db48e) | `` flake.lock: Update ``                               |