### PR TITLE
chore(flake/nixpkgs): `28d6a724` -> `35c5863c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -922,11 +922,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1708189888,
-        "narHash": "sha256-gnsICW7R6rFF2WDg5GfimE4XdIfZpLluyEFXx+8K7bY=",
+        "lastModified": 1708232726,
+        "narHash": "sha256-DYuEHWQSBwaJkS2rjLUsKvGgDK8QIVojC3klAUw6uyk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "28d6a724f54085377102db7c3278ba82a0a5255f",
+        "rev": "35c5863c29ce81199ded8a3384f4979b7793f5dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                            |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
| [`ac637ef2`](https://github.com/NixOS/nixpkgs/commit/ac637ef21ecc2f0a1a0987fe9ce1d7f0d7f42fca) | `` Revert "openobserve: 0.7.2 -> 0.8.1" ``                                                         |
| [`51e918d4`](https://github.com/NixOS/nixpkgs/commit/51e918d474e2a69e5de0c2295556c32b84a57c8b) | `` uv: 0.1.3 -> 0.1.4 ``                                                                           |
| [`d19ef2a0`](https://github.com/NixOS/nixpkgs/commit/d19ef2a03c1f97af0c7d3b55f11933ad1c8f5346) | `` ruff: 0.2.1 -> 0.2.2 ``                                                                         |
| [`94cce576`](https://github.com/NixOS/nixpkgs/commit/94cce57664084defbb9d955ab4a651a7c9c46cd0) | `` zfs-replicate: update pyproject format ``                                                       |
| [`811da6b0`](https://github.com/NixOS/nixpkgs/commit/811da6b02c34a3cb57846f0656f3fdba15f49660) | `` renode-dts2repl: unstable-2024-02-14 -> unstable-2024-02-16 ``                                  |
| [`4fd97d0d`](https://github.com/NixOS/nixpkgs/commit/4fd97d0da606fa06982a664baa929aa53dd1fd94) | `` python311Packages.pypandoc: 1.10 -> 1.13 ``                                                     |
| [`8a131f25`](https://github.com/NixOS/nixpkgs/commit/8a131f25c85084c544af62152e9fcbbc648a8949) | `` libcifpp: 6.1.0 -> 7.0.0 ``                                                                     |
| [`cb6f36e8`](https://github.com/NixOS/nixpkgs/commit/cb6f36e8ffabf98238240106cbe5b3f6f1fae854) | `` xrootd: fix plugin loading on Linux (#289140) ``                                                |
| [`6ffd74b5`](https://github.com/NixOS/nixpkgs/commit/6ffd74b5365403c7cc1b2f670f89ba52d7303baf) | `` python3Packages.rerun-sdk: init at 0.13.0 ``                                                    |
| [`135fd532`](https://github.com/NixOS/nixpkgs/commit/135fd532b758d9f113df64acf8b735a02582a30a) | `` rerun: init at 0.13.0 ``                                                                        |
| [`1234093a`](https://github.com/NixOS/nixpkgs/commit/1234093ac6f10e77e24aa482379d68c06cf50ebc) | `` tokyo-night-gtk: fix version number ``                                                          |
| [`a61fe84e`](https://github.com/NixOS/nixpkgs/commit/a61fe84e8854b7191652ae073f13cbc7f1fda041) | `` tokyo-night-gtk: change package name ``                                                         |
| [`c8d47d0b`](https://github.com/NixOS/nixpkgs/commit/c8d47d0be31e110321c7a36d15527c72053acdbf) | `` circleci-cli: 0.1.30084 -> 0.1.30163 ``                                                         |
| [`0622dc3d`](https://github.com/NixOS/nixpkgs/commit/0622dc3d27d969b49dd07ed9b16d23199548445a) | `` resvg: 0.39.0 -> 0.40.0 ``                                                                      |
| [`5486165e`](https://github.com/NixOS/nixpkgs/commit/5486165eea37c867ef5a56a61dc1683dc3486fe5) | `` door-knocker: 0.4.3 -> 0.4.4 ``                                                                 |
| [`2eed715f`](https://github.com/NixOS/nixpkgs/commit/2eed715fbfd05a536d9f9756c656ba242fd0800a) | `` nixos/go-camo: init ``                                                                          |
| [`9549489e`](https://github.com/NixOS/nixpkgs/commit/9549489ed6140383921eea49353ac5be950b0564) | `` darktable: 4.6.0 -> 4.6.1 ``                                                                    |
| [`39b9512f`](https://github.com/NixOS/nixpkgs/commit/39b9512fec9384f6c46a5f26c65b06dc2f5b7203) | `` postgresql12JitPackages.pgroonga: 3.1.6 -> 3.1.7 ``                                             |
| [`3c792aa7`](https://github.com/NixOS/nixpkgs/commit/3c792aa73aedc3e2dff3e653ba017b37a79ec3b6) | `` python312Packages.geant4: 11.2.0 -> 11.2.1 ``                                                   |
| [`71597836`](https://github.com/NixOS/nixpkgs/commit/715978361af5ddad55b5cf806853a90779127942) | `` natscli: refactor ``                                                                            |
| [`cb51ceee`](https://github.com/NixOS/nixpkgs/commit/cb51ceeee5932cf157d148787b0c6c525576d455) | `` natscli: 0.1.1 -> 0.1.3 ``                                                                      |
| [`92d048ae`](https://github.com/NixOS/nixpkgs/commit/92d048aec6be0477c8e3e29cde9081b839ddf9be) | `` bat-extras: 2023.06.15 -> 2024.02.12 ``                                                         |
| [`5d88c92a`](https://github.com/NixOS/nixpkgs/commit/5d88c92a40e28afdc3aeefa173be02c070124f4d) | `` newsflash: 3.1.1 -> 3.1.3 ``                                                                    |
| [`40f3ae06`](https://github.com/NixOS/nixpkgs/commit/40f3ae06340e5e1d148ac13ad7fcac32958cb31b) | `` dracula-theme: unstable-2024-02-08 -> unstable-2024-02-16 ``                                    |
| [`288dac97`](https://github.com/NixOS/nixpkgs/commit/288dac975724d22de028b3c2db8c6aa3c3af49c7) | `` python311Packages.clarifai-grpc: 10.1.3 -> 10.1.4 ``                                            |
| [`21bb17ff`](https://github.com/NixOS/nixpkgs/commit/21bb17ff23df8ba1823ef543a1f085a1786ca05c) | `` microsoft-edge: 121.0.2277.113 -> 121.0.2277.128 ``                                             |
| [`be1584dd`](https://github.com/NixOS/nixpkgs/commit/be1584dddde7abb59aba39475f5577a6557ea1cd) | `` python312Packages.aiopegelonline: 0.0.8 -> 0.0.9 ``                                             |
| [`88188439`](https://github.com/NixOS/nixpkgs/commit/88188439fb1d82f335c41fe0e442dab198506a56) | `` gotosocial: skip flaky test ``                                                                  |
| [`0f6c7ff0`](https://github.com/NixOS/nixpkgs/commit/0f6c7ff04a64ebe1e88aec2319244fe9f7a0d319) | `` streamlink: 6.5.1 -> 6.6.1 ``                                                                   |
| [`09e2db48`](https://github.com/NixOS/nixpkgs/commit/09e2db488c071a404968675a963ec7db3611a295) | `` figurine: init at 1.3.0 ``                                                                      |
| [`962cceda`](https://github.com/NixOS/nixpkgs/commit/962cceda8eb192453247dcc5a8ff32c10966197d) | `` python311Packages.openai-triton: add import-triton passthru test ``                             |
| [`ba0457c2`](https://github.com/NixOS/nixpkgs/commit/ba0457c26f3104874293ef664fb4943baf6ff0ee) | `` python311Packages.openai-triton: propagate setuptools dependency ``                             |
| [`e0f4814f`](https://github.com/NixOS/nixpkgs/commit/e0f4814f0e5304ace3fb7632ecf31bf16f965f75) | `` python311Packages.openai-triton: remove ptxas --version call when built without cuda support `` |
| [`8979c170`](https://github.com/NixOS/nixpkgs/commit/8979c1703195e3871d9cd58b2ec6b5d0531937ba) | `` openobserve: use more appropriate meta.description ``                                           |
| [`a8a7369c`](https://github.com/NixOS/nixpkgs/commit/a8a7369c36120acb9ca43376504b6e9babed7261) | `` openobserve: 0.7.2 -> 0.8.1 ``                                                                  |
| [`96294a04`](https://github.com/NixOS/nixpkgs/commit/96294a048d993610633732493d9d6092b2f5b157) | `` scrounge-ntfs: init at 0.9 ``                                                                   |
| [`baed3bc2`](https://github.com/NixOS/nixpkgs/commit/baed3bc2a04ae820583554f8ff9e196e8ccc337b) | `` micropython: 1.21.0 -> 1.22.1 ``                                                                |
| [`a5e96f61`](https://github.com/NixOS/nixpkgs/commit/a5e96f619fb936cc101ba087807f8eb3318fafdb) | `` argocd: 2.9.6 -> 2.10.1 ``                                                                      |
| [`e23b9013`](https://github.com/NixOS/nixpkgs/commit/e23b9013214a82ccb85bf42c10ff52253b6dd126) | `` python3.hooks: Dont completely overwrite passthru when creating setup hook ``                   |
| [`48a49f76`](https://github.com/NixOS/nixpkgs/commit/48a49f76d77375018dbdb719b59fc6d8ed52104d) | `` python3.pkgs.pypaBuildHook: Fix passthru.tests ``                                               |
| [`db8ddf0b`](https://github.com/NixOS/nixpkgs/commit/db8ddf0b80b5928a9f490a8d637db4c657ff675e) | `` python312Packages.trimesh: 4.1.3 -> 4.1.4 ``                                                    |
| [`5764e7e4`](https://github.com/NixOS/nixpkgs/commit/5764e7e457ba2b7bae730006e6e05c2bdd9a6151) | `` envio: 0.5.0 -> 0.5.1 ``                                                                        |
| [`a9ae08ce`](https://github.com/NixOS/nixpkgs/commit/a9ae08ce3d8cb586347ddaedeec127cd231f9966) | `` gerbolyze: init at v3.1.7 ``                                                                    |
| [`c7f3dbe0`](https://github.com/NixOS/nixpkgs/commit/c7f3dbe04468220139a9230a27c8381a30a1fd18) | `` python311Packages.cohere: 4.37 -> 4.47 ``                                                       |
| [`19218e30`](https://github.com/NixOS/nixpkgs/commit/19218e302712afda1d46c1a9711d67beb1fd82c5) | `` python311Packages.ihm: 0.43 -> 1.0 ``                                                           |
| [`6a1634c0`](https://github.com/NixOS/nixpkgs/commit/6a1634c0b4313f8499878a8c8e4af29bbd2235e1) | `` pyxel: init at 2.0.7 ``                                                                         |
| [`cba91a90`](https://github.com/NixOS/nixpkgs/commit/cba91a90cc09c8d81ec83ee50f08944c660d14bb) | `` typos-lsp: init at 0.1.12 ``                                                                    |
| [`05c554df`](https://github.com/NixOS/nixpkgs/commit/05c554dfc5cb928e155eb21342ecd24c13a98908) | `` api-linter: 1.63.3 -> 1.63.4 ``                                                                 |
| [`800d6902`](https://github.com/NixOS/nixpkgs/commit/800d69029b388971e63fa0428e083fa517593554) | `` maintainers: add ironicbadger ``                                                                |
| [`9200a55a`](https://github.com/NixOS/nixpkgs/commit/9200a55a98b406335d93daaf54b7613d05745ccc) | `` polylith: 0.2.18 -> 0.2.19 ``                                                                   |
| [`4de6f320`](https://github.com/NixOS/nixpkgs/commit/4de6f32046c9c294a9310256506ca3ae3f405022) | `` pa-notify: init at 1.5.0 ``                                                                     |
| [`a7019986`](https://github.com/NixOS/nixpkgs/commit/a7019986fe97594a95e44d832f904c810be55aac) | `` maintainers: add juancmuller ``                                                                 |
| [`9c3c63a1`](https://github.com/NixOS/nixpkgs/commit/9c3c63a10d6fdb82c3fa37a171fd4fd386420e85) | `` python311Packages.argparse-manpage: init at 4.5 ``                                              |
| [`0b791e61`](https://github.com/NixOS/nixpkgs/commit/0b791e61e30d7ed28c32b914b78052b51457c95a) | `` mongoc: 1.25.4 -> 1.26.0 ``                                                                     |
| [`75593f50`](https://github.com/NixOS/nixpkgs/commit/75593f50633c9e0a20c6741c2e8b8441fdf54240) | `` bfs: 3.0.4 -> 3.1.1 ``                                                                          |
| [`4b1db646`](https://github.com/NixOS/nixpkgs/commit/4b1db64688b1f3b24f4620011f1f0dd8a59a697a) | `` files-cli: 2.12.31 -> 2.12.36 ``                                                                |
| [`47281231`](https://github.com/NixOS/nixpkgs/commit/47281231f3c83cfd0d3a6165da65c1c51e87adfb) | `` rPackages.GPBayes: added dependency ``                                                          |
| [`2da65488`](https://github.com/NixOS/nixpkgs/commit/2da65488de2d6876f0592e07a6167818d8c03cc7) | `` flyctl: 0.1.148 -> 0.2.6 ``                                                                     |
| [`7a358562`](https://github.com/NixOS/nixpkgs/commit/7a3585629410f6a602fe8aa91553c4c115319bbc) | `` pocketbase: 0.21.2 -> 0.21.3 ``                                                                 |
| [`1a5fce43`](https://github.com/NixOS/nixpkgs/commit/1a5fce43cf3ebb9ddf64b7975ce3eb25b375f711) | `` maintainers: add tarantoj ``                                                                    |
| [`f0962ef6`](https://github.com/NixOS/nixpkgs/commit/f0962ef6a559bdebf697747f0ec750f3c4bd976b) | `` gerbonara: init at v1.2.0 ``                                                                    |
| [`8d68f17f`](https://github.com/NixOS/nixpkgs/commit/8d68f17f174eea65273d8781a952ed58bb96b5cf) | `` python311Packages.anova-wifi: 0.11.6 -> 0.11.7 ``                                               |
| [`c6da6fdd`](https://github.com/NixOS/nixpkgs/commit/c6da6fdd8abfe6f7389d43dfd2262688d05e80cf) | `` python311Packages.streamlit: 1.30.0 -> 1.31.1 ``                                                |
| [`3fdbe2ef`](https://github.com/NixOS/nixpkgs/commit/3fdbe2ef9ff4fac3ac06be4943b2c635c52cdce6) | `` csvkit: 1.3.0 -> 1.4.0 ``                                                                       |
| [`8b2d667e`](https://github.com/NixOS/nixpkgs/commit/8b2d667ecc9c7532d063a3f361045cfc529ce705) | `` python311Packages.kaggle: 1.6.3 -> 1.6.6 ``                                                     |
| [`eb2be110`](https://github.com/NixOS/nixpkgs/commit/eb2be1102c5fda9670f72f1a99bceba26ad6aabd) | `` python312Packages.aws-sam-translator: don't fail when pytest/pluggy, skip slow tests ``         |
| [`c6f4ab4b`](https://github.com/NixOS/nixpkgs/commit/c6f4ab4b5440d80bc55254fc1f6396ea7203ae44) | `` roslyn-ls: init at 4.10.0-2.24102.11 ``                                                         |
| [`35b2e97c`](https://github.com/NixOS/nixpkgs/commit/35b2e97c996d8247dd144e53eab9cf1dfb119491) | `` zfs-replicate: 3.2.6 -> 3.2.7 ``                                                                |
| [`7a401d46`](https://github.com/NixOS/nixpkgs/commit/7a401d46b62bd5e640532cf11be75539d0108249) | `` cloudflared: 2024.1.5 -> 2024.2.0 ``                                                            |
| [`45a31d17`](https://github.com/NixOS/nixpkgs/commit/45a31d17c97f07e449a32f35aa8b6c213afd89ae) | `` ddev: 1.22.6 -> 1.22.7 ``                                                                       |
| [`31ca7ca2`](https://github.com/NixOS/nixpkgs/commit/31ca7ca2418de76468018eca1c49f8387a5c99bc) | `` istioctl: 1.20.2 -> 1.20.3 ``                                                                   |
| [`b10b9598`](https://github.com/NixOS/nixpkgs/commit/b10b9598278efd76b7219e01eed6096d125790d8) | `` bash-language-server: Add shellcheck to bin path ``                                             |
| [`1c2a4b97`](https://github.com/NixOS/nixpkgs/commit/1c2a4b971eb0e683a85d1adcc97acd6f9b51e65b) | `` srht-gen-oauth-tok: init at 0.1 ``                                                              |
| [`95a2ac0f`](https://github.com/NixOS/nixpkgs/commit/95a2ac0fd9938b30273148ae660eba72116727ac) | `` microsoft-edge: Change update script to have consistent ordering of versions ``                 |
| [`147cc406`](https://github.com/NixOS/nixpkgs/commit/147cc4061eed12dc418ec753def00a1f9544fc23) | `` nixos/sourcehut: ensure that the repos directory exists ``                                      |
| [`195cbfc0`](https://github.com/NixOS/nixpkgs/commit/195cbfc0124ea3d5e4b6469cdd3efb42840d32eb) | `` nixosTests.sourcehut: split tests belonging to different services ``                            |
| [`2382d423`](https://github.com/NixOS/nixpkgs/commit/2382d423f427a2dc30ea6cee8b0b4c615c6f5cb3) | `` nixosTests.sourcehut: factor-out node configuration ``                                          |
| [`6eb86e3c`](https://github.com/NixOS/nixpkgs/commit/6eb86e3c19312c4b585141848923d5594ab26e5e) | `` nixosTests.sourcehut: refactor script to use subtests ``                                        |
| [`262cb39d`](https://github.com/NixOS/nixpkgs/commit/262cb39d4fc51471d4eeff339c9d107417fc09f8) | `` nixosTests.sourcehut: add myself as maintainer ``                                               |
| [`8f6a3420`](https://github.com/NixOS/nixpkgs/commit/8f6a342064eaa4ea1444058e186dcb661c0eecce) | `` nixosTests.sourcehut: test repository download ``                                               |
| [`7d7cc717`](https://github.com/NixOS/nixpkgs/commit/7d7cc717ebc36758c1e733b44a218d8426bf410b) | `` nixosTests.sourcehut: test pushing Git repositories ``                                          |
| [`effb6bd7`](https://github.com/NixOS/nixpkgs/commit/effb6bd756dfff8c88d635f346415cea6f4ddf96) | `` nixosTests.sourcehut: configure Hut for direct API interaction ``                               |
| [`577bb277`](https://github.com/NixOS/nixpkgs/commit/577bb277aa3ccab68942424aca71cf44b03b39df) | `` nixos/vte: use vte without any GUI dependencies ``                                              |
| [`8cd995ce`](https://github.com/NixOS/nixpkgs/commit/8cd995ce1341e90e7433568d1c98d657276beceb) | `` nixos/no-x-libs: add vte ``                                                                     |
| [`fece49bd`](https://github.com/NixOS/nixpkgs/commit/fece49bd62f4dc0636c0816a65733e260433035b) | `` vte: allow to build without any gtk ``                                                          |
| [`89278c98`](https://github.com/NixOS/nixpkgs/commit/89278c9846a88d51ec00b0b1f044070deb93a79f) | `` nixosTests.sourcehut: run tests within a production environment ``                              |
| [`33c13e9e`](https://github.com/NixOS/nixpkgs/commit/33c13e9e4d1a6b5ff50fe33edbd0835ef254b236) | `` nixosTests.sourcehut: listen on port 80, as well ``                                             |
| [`3943aa57`](https://github.com/NixOS/nixpkgs/commit/3943aa57c0a1c346a15fae7b911a358c5da3364d) | `` nixosTests.sourcehut: test user creation and OAuth token generation ``                          |
| [`ab1ad2b0`](https://github.com/NixOS/nixpkgs/commit/ab1ad2b066ad1d2a0edf1ded067fb451843418fa) | `` nixosTests.sourcehut: remove unused VM image specifications ``                                  |
| [`1bcd510d`](https://github.com/NixOS/nixpkgs/commit/1bcd510dcc410f3f222e435384eda4f2c99a8de7) | `` netproxrc: init at 1.1.0 ``                                                                     |