### PR TITLE
chore(flake/home-manager): `a54e05bc` -> `517601b3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -452,11 +452,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708294481,
-        "narHash": "sha256-DZtxmeb4OR7iCaKUUuq05ADV2rX8WReZEF7Tq//W0+Y=",
+        "lastModified": 1708451036,
+        "narHash": "sha256-tgZ38NummEdnXvxj4D0StHBzXgceAw8CptytHljH790=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a54e05bc12d88ff2df941d0dc1183cb5235fa438",
+        "rev": "517601b37c6d495274454f63c5a483c8e3ca6be1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`517601b3`](https://github.com/nix-community/home-manager/commit/517601b37c6d495274454f63c5a483c8e3ca6be1) | `` jujutsu: remove shell completion `` |