### PR TITLE
chore(flake/nh): `36eba281` -> `aa4df097`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -686,11 +686,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1705251288,
-        "narHash": "sha256-TwCR7tZvrjsvz6SmgjWYOne7Qz7J2jn4Cr4Er0Yj+LA=",
+        "lastModified": 1708335499,
+        "narHash": "sha256-ZOAhp3hiJsWdNDSs/SF2EPylluAx5PiZv9aAUwZrKOI=",
         "owner": "viperML",
         "repo": "nh",
-        "rev": "36eba281576afe0f67e5aafb4e7a414f256dba31",
+        "rev": "aa4df097654cdeb15aa74aabd72863a6fb30c7e6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                      | Message                          |
| ------------------------------------------------------------------------------------------- | -------------------------------- |
| [`aa4df097`](https://github.com/viperML/nh/commit/aa4df097654cdeb15aa74aabd72863a6fb30c7e6) | `` fix rev ``                    |
| [`7db2d78d`](https://github.com/viperML/nh/commit/7db2d78ddb8be087544c54a384891b459e3ae88f) | `` Sync package with nixpkgs' `` |