### PR TITLE
chore(flake/nur): `e0f255fb` -> `b878d82e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -980,11 +980,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708303815,
-        "narHash": "sha256-PK/VjNcVV/4PTNBQgy6nDNdqKOvXfQ3X1wvjbicG+aE=",
+        "lastModified": 1708453610,
+        "narHash": "sha256-xKd53jAJVQi0rMUFMEJAegxnGLBABF8dHHwggCQbVlw=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "e0f255fb5a973abde0287278b9d66dc210c7b753",
+        "rev": "b878d82e0bee71857863aab9e94a95d6ba3cfa00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`b878d82e`](https://github.com/nix-community/NUR/commit/b878d82e0bee71857863aab9e94a95d6ba3cfa00) | `` automatic update `` |
| [`8376fb9d`](https://github.com/nix-community/NUR/commit/8376fb9d580aceae3f717a31b9d897aeb427de49) | `` automatic update `` |
| [`30083548`](https://github.com/nix-community/NUR/commit/30083548b4ac11731dee0d101c4717bd6005fa9e) | `` automatic update `` |
| [`1b9b8c8d`](https://github.com/nix-community/NUR/commit/1b9b8c8d29f7327e3adf76f9a0d413b2fced9e81) | `` automatic update `` |
| [`f33b8119`](https://github.com/nix-community/NUR/commit/f33b8119a722cc1f017cb46f2dfb2c69a2fbe319) | `` automatic update `` |
| [`438fbf45`](https://github.com/nix-community/NUR/commit/438fbf450419f20d98855f863b1808cd058239f2) | `` automatic update `` |
| [`5ace0fe0`](https://github.com/nix-community/NUR/commit/5ace0fe042e5b86f2dbce82a173ee8d58a3b9107) | `` automatic update `` |
| [`0b52287d`](https://github.com/nix-community/NUR/commit/0b52287d9b265cb18bd303684698f99fb2907772) | `` automatic update `` |
| [`d16ac714`](https://github.com/nix-community/NUR/commit/d16ac7142e433fb51cfb23ac579e9efc3d493f6d) | `` automatic update `` |
| [`fc37563c`](https://github.com/nix-community/NUR/commit/fc37563cdb6a232329dd48873449706cab888fa1) | `` automatic update `` |
| [`071a40f7`](https://github.com/nix-community/NUR/commit/071a40f774c8ffb78c97cdceae46403f74974929) | `` automatic update `` |
| [`c825ba23`](https://github.com/nix-community/NUR/commit/c825ba23aaa2fcb8162a4345dc62058b29f425f6) | `` automatic update `` |
| [`034cf7dc`](https://github.com/nix-community/NUR/commit/034cf7dc073f5d18921016cf9bbfec436b97eff2) | `` automatic update `` |
| [`37e2a583`](https://github.com/nix-community/NUR/commit/37e2a5836ece4dd373530656ec7d41c0aeee3ff1) | `` automatic update `` |
| [`b3847d02`](https://github.com/nix-community/NUR/commit/b3847d02db51d11a0dfaf9c9460a58bcbdc124f9) | `` automatic update `` |
| [`5b6a3b89`](https://github.com/nix-community/NUR/commit/5b6a3b89bf6be167401f0c3e840e0f34dd1c0e11) | `` automatic update `` |
| [`a8a56419`](https://github.com/nix-community/NUR/commit/a8a5641924c0f1c803beb3063b6cadc3698492d2) | `` automatic update `` |
| [`b5f8982b`](https://github.com/nix-community/NUR/commit/b5f8982bb3e4adbd328fcc5113f72daa308183d2) | `` automatic update `` |
| [`65134bef`](https://github.com/nix-community/NUR/commit/65134beff1e6963fdd20c5f7188fc547a2243519) | `` automatic update `` |
| [`49ed1c11`](https://github.com/nix-community/NUR/commit/49ed1c11041345b7b6e98492701b751cfc864ee3) | `` automatic update `` |
| [`5da2163c`](https://github.com/nix-community/NUR/commit/5da2163c458a41bb23912371c3590f2e979e7b34) | `` automatic update `` |
| [`9424846e`](https://github.com/nix-community/NUR/commit/9424846e1a01bedbb67cb032237d4c59d5d298c4) | `` automatic update `` |
| [`091efa6b`](https://github.com/nix-community/NUR/commit/091efa6b9f2b766b3032a3abab55fdb4c5fac775) | `` automatic update `` |
| [`93957e28`](https://github.com/nix-community/NUR/commit/93957e283193a59458733c3018565b61928950cf) | `` automatic update `` |
| [`10d980ad`](https://github.com/nix-community/NUR/commit/10d980ad818fd86f3805be62b90832c6f2404efe) | `` automatic update `` |
| [`dba6c8fa`](https://github.com/nix-community/NUR/commit/dba6c8fa776e83f7d02921c097569cfb7cf2b6d6) | `` automatic update `` |
| [`393fab70`](https://github.com/nix-community/NUR/commit/393fab7036bd90aea269f2b8c105e5cb8ba553c0) | `` automatic update `` |
| [`36094357`](https://github.com/nix-community/NUR/commit/36094357acac74c8f63f2d828f2a67739df2ef70) | `` automatic update `` |
| [`fc9ef331`](https://github.com/nix-community/NUR/commit/fc9ef331eab10a5c1d626b2d34951b9efc8e3f89) | `` automatic update `` |
| [`0746498e`](https://github.com/nix-community/NUR/commit/0746498eec8c0a0b2ac98fe835d6af996b719531) | `` automatic update `` |
| [`c7d6638c`](https://github.com/nix-community/NUR/commit/c7d6638ca9e5bd42a4dfc7aa3992a2b655e616d0) | `` automatic update `` |
| [`b2b511e7`](https://github.com/nix-community/NUR/commit/b2b511e7ee918392ce4c40cecb19e29e76ad15f5) | `` automatic update `` |
| [`5b8eb19f`](https://github.com/nix-community/NUR/commit/5b8eb19f8db38405e9e1a12ee08737249950609b) | `` automatic update `` |
| [`7e39029b`](https://github.com/nix-community/NUR/commit/7e39029bd978da19b84621faec3d129fe8475de9) | `` automatic update `` |
| [`8df08698`](https://github.com/nix-community/NUR/commit/8df08698ebbd2486e420f0c809f7be1a49898959) | `` automatic update `` |
| [`23f3523d`](https://github.com/nix-community/NUR/commit/23f3523da4d2617ed37a3175362fc8f62b550af5) | `` automatic update `` |
| [`e17ac139`](https://github.com/nix-community/NUR/commit/e17ac139d5903c021aff79b52d659bf90145cbb2) | `` automatic update `` |
| [`119ba100`](https://github.com/nix-community/NUR/commit/119ba100d25078d371915db9b8598a5e68cd874f) | `` automatic update `` |
| [`921e579a`](https://github.com/nix-community/NUR/commit/921e579ab60c27430d7216a7572e8ad44d8e108b) | `` automatic update `` |
| [`fd43dfae`](https://github.com/nix-community/NUR/commit/fd43dfae1582df05931053e5890cb8aa03a2f492) | `` automatic update `` |
| [`a8d1fb94`](https://github.com/nix-community/NUR/commit/a8d1fb94a4cdca7ac79b16456fefa9609b5bce4a) | `` automatic update `` |
| [`a21632ce`](https://github.com/nix-community/NUR/commit/a21632ce1fbd608f389449948024a902dc4328b4) | `` automatic update `` |
| [`decd2652`](https://github.com/nix-community/NUR/commit/decd2652eef53bf0323bb362cd06b166e224efc9) | `` automatic update `` |
| [`bb450ee8`](https://github.com/nix-community/NUR/commit/bb450ee88394da9c39c4ee1edc316fca8a91bd01) | `` automatic update `` |