### PR TITLE
chore(flake/hyprland): `69a4f08d` -> `13d98548`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1708300923,
-        "narHash": "sha256-TnZ4E2AZbRXcm5tuior9KMNSjruy11Oqic0yc7ySU1U=",
+        "lastModified": 1708452876,
+        "narHash": "sha256-UrFrNfIwd0pcCTZYc6RAppzvpL6icfhelFMgufY5vxU=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "69a4f08dbee6dc08d1e2ce498ce80ab20844e4f3",
+        "rev": "13d985489788fa5349b3457d6eb1c19bad8f37e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                               |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
| [`13d98548`](https://github.com/hyprwm/Hyprland/commit/13d985489788fa5349b3457d6eb1c19bad8f37e9) | `` xdgpopup: fix UAF because of an invalid listener connection ``     |
| [`cd73dda1`](https://github.com/hyprwm/Hyprland/commit/cd73dda16e0e2e3008c87115b34b7c6e054ff5a8) | `` sessionLock: send preferred fractional scale ``                    |
| [`02c9a2d7`](https://github.com/hyprwm/Hyprland/commit/02c9a2d769dc3ae5efb942ad16578eee45a6f6dd) | `` screencopy: damage entire screen on a no-damage request ``         |
| [`7ea37c9d`](https://github.com/hyprwm/Hyprland/commit/7ea37c9dc93b990dc756de45687c125290a74afb) | `` surface: fix damage calcs with a viewport src ``                   |
| [`86be75dd`](https://github.com/hyprwm/Hyprland/commit/86be75dd97b5633b8c0aa6bdcb3346fa871a8480) | `` events: bring back accidentally nuked preConfigReload ``           |
| [`030ed27c`](https://github.com/hyprwm/Hyprland/commit/030ed27cc8dee5712f5d38dff9af0b1b3a97bd9c) | `` crashreporter: Use ~/.cache as cache dir (#4719) ``                |
| [`e793f10b`](https://github.com/hyprwm/Hyprland/commit/e793f10b8bd1685a2e2bbd7cc90063f12bf380c4) | `` screencopy: fix invalid damage being used for final copy in dma `` |
| [`d62e7a51`](https://github.com/hyprwm/Hyprland/commit/d62e7a5125c551fe8a94e076e64d42b702d923b1) | `` renderer: fixup damage_ring rotation ``                            |
| [`fe9c8d87`](https://github.com/hyprwm/Hyprland/commit/fe9c8d8745b42929e8b745f32d1bd4405964ca40) | `` format: fix formatting ``                                          |
| [`df826252`](https://github.com/hyprwm/Hyprland/commit/df82625206b6faffbf02d5d802e857143d656239) | `` hyprctl: reload everything on dynamic source keywords ``           |
| [`17635663`](https://github.com/hyprwm/Hyprland/commit/176356630853a6558b8125726bbdaf6411593488) | `` surface: minor fixes for last logicalDamage calc fix ``            |
| [`e4790e3f`](https://github.com/hyprwm/Hyprland/commit/e4790e3f8e8f3693d924c3d8fc9012e3ab7bbf8f) | `` surface: fix invalid damage tracking in damageSurface ``           |