### PR TITLE
chore(flake/treefmt-nix): `ac599dab` -> `e5046212`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1202,11 +1202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707300477,
-        "narHash": "sha256-qQF0fEkHlnxHcrKIMRzOETnRBksUK048MXkX0SOmxvA=",
+        "lastModified": 1708335038,
+        "narHash": "sha256-ETLZNFBVCabo7lJrpjD6cAbnE11eDOjaQnznmg/6hAE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "ac599dab59a66304eb511af07b3883114f061b9d",
+        "rev": "e504621290a1fd896631ddbc5e9c16f4366c9f65",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                  |
| ---------------------------------------------------------------------------------------------------- | ------------------------ |
| [`e5046212`](https://github.com/numtide/treefmt-nix/commit/e504621290a1fd896631ddbc5e9c16f4366c9f65) | `` add jsonfmt (#158) `` |