### PR TITLE
chore(flake/emacs-overlay): `5d4f6efc` -> `eca18f04`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -193,11 +193,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1708306312,
-        "narHash": "sha256-3PuZKecNdBY2O3CcJWuHfbP1v7IEmDbTTOmcUI+K9TY=",
+        "lastModified": 1708448970,
+        "narHash": "sha256-aElcEUsNTGC9q5VdwA+XsgprcRup0w6y+eOKyFbUWfk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5d4f6efc7e8a34ba84eb7248fccf17bab25e1884",
+        "rev": "eca18f048a96d077a72881ced8949e1e8dcee4b5",
         "type": "github"
       },
       "original": {
@@ -900,11 +900,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1708161998,
-        "narHash": "sha256-6KnemmUorCvlcAvGziFosAVkrlWZGIc6UNT9GUYr0jQ=",
+        "lastModified": 1708294118,
+        "narHash": "sha256-evZzmLW7qoHXf76VCepvun1esZDxHfVRFUJtumD7L2M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "84d981bae8b5e783b3b548de505b22880559515f",
+        "rev": "e0da498ad77ac8909a980f07eff060862417ccf7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`eca18f04`](https://github.com/nix-community/emacs-overlay/commit/eca18f048a96d077a72881ced8949e1e8dcee4b5) | `` Updated emacs ``        |
| [`7b175193`](https://github.com/nix-community/emacs-overlay/commit/7b1751931dee4af2f8ca14c3958b45c2704ba4ee) | `` Updated melpa ``        |
| [`6879e098`](https://github.com/nix-community/emacs-overlay/commit/6879e098c576b2e386fe84a464a5a4bad5bff41e) | `` Updated elpa ``         |
| [`db8898a6`](https://github.com/nix-community/emacs-overlay/commit/db8898a6db80f8dc07056fd1f449f3a4b65c45f9) | `` Updated nongnu ``       |
| [`c83e29d6`](https://github.com/nix-community/emacs-overlay/commit/c83e29d619b19fea300c93cb506bbc99c6599b98) | `` Updated melpa ``        |
| [`34775297`](https://github.com/nix-community/emacs-overlay/commit/347752976096227aed7d06226e1045b5f0112386) | `` Updated emacs ``        |
| [`5c1b7b8a`](https://github.com/nix-community/emacs-overlay/commit/5c1b7b8aafcb9e98a7244e5b2d1490844537045b) | `` Updated melpa ``        |
| [`da95bd8d`](https://github.com/nix-community/emacs-overlay/commit/da95bd8d883d0e2a4bd5bdc7aad18a7cd2becb9f) | `` Updated elpa ``         |
| [`a1434c43`](https://github.com/nix-community/emacs-overlay/commit/a1434c437d2c9eb4b638918cfb25729f42bf30b4) | `` Updated flake inputs `` |
| [`a097d639`](https://github.com/nix-community/emacs-overlay/commit/a097d6392a1959ed28cdd1717b729437a1e7c4fe) | `` Updated emacs ``        |
| [`8f5a6a1f`](https://github.com/nix-community/emacs-overlay/commit/8f5a6a1f3e127fc8c0671f4abfce2d24ea2ea70c) | `` Updated melpa ``        |
| [`7d9b3079`](https://github.com/nix-community/emacs-overlay/commit/7d9b30798766d3f6cd7d099e51e21a65d537e71c) | `` Updated elpa ``         |
| [`3334b307`](https://github.com/nix-community/emacs-overlay/commit/3334b307419cd56f0c4451ab601e20845431946d) | `` Updated flake inputs `` |
| [`cc90958e`](https://github.com/nix-community/emacs-overlay/commit/cc90958e2418d9c9bd8cd0bfbc92ed37ce6c2195) | `` Updated emacs ``        |
| [`58625c8f`](https://github.com/nix-community/emacs-overlay/commit/58625c8f881f1d8dc996eb4cdef7327658912306) | `` Updated melpa ``        |