### PR TITLE
chore(flake/nixpkgs): `35c5863c` -> `fa15b53d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -964,11 +964,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1708232726,
-        "narHash": "sha256-DYuEHWQSBwaJkS2rjLUsKvGgDK8QIVojC3klAUw6uyk=",
+        "lastModified": 1708405701,
+        "narHash": "sha256-E78TXiZiR9irWdYAVltRxZPJ+pMxXPU5PjHwqq6XLtI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "35c5863c29ce81199ded8a3384f4979b7793f5dc",
+        "rev": "fa15b53dbea5028db38d6e09b4cef6eba42aeebb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                     |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
| [`a725d72c`](https://github.com/NixOS/nixpkgs/commit/a725d72ca650d398dffab3d78186dc1aa65e853d) | `` pkgs.gptscript: init at 0.1.1 ``                                         |
| [`256f2c6f`](https://github.com/NixOS/nixpkgs/commit/256f2c6fceef0cf24ca2d97afad4abbe202d35ec) | `` Revert "python311Packages.ical: 6.1.1 -> 7.0.0" ``                       |
| [`2af49615`](https://github.com/NixOS/nixpkgs/commit/2af496159e45a0f171e3bfc57fe8f5e1ed5d0999) | `` wyoming-piper: 1.4.0 -> 1.5.0 ``                                         |
| [`6ac6e5cf`](https://github.com/NixOS/nixpkgs/commit/6ac6e5cfc8b167535906b076b268a38055b5a3ac) | `` python312Packages.snakemake-interface-common: 1.16.0 -> 1.17.0 ``        |
| [`1e23fb97`](https://github.com/NixOS/nixpkgs/commit/1e23fb97732555fa4990e15a6ca16ee81f0d9956) | `` python311Packages.accelerate: make cudatoolkit usage conditional ``      |
| [`7ca821d8`](https://github.com/NixOS/nixpkgs/commit/7ca821d85c2fa86f03649f88c00a797ca7aca249) | `` python312Packages.somajo: 2.4.1 -> 2.4.2 ``                              |
| [`84fbd5b1`](https://github.com/NixOS/nixpkgs/commit/84fbd5b15b6bd272e0b605bbe5fe020b806cbca3) | `` ov: 0.33.2 -> 0.33.3 ``                                                  |
| [`d8b7b491`](https://github.com/NixOS/nixpkgs/commit/d8b7b491c18a57131ba84ed6c72fad9698c89248) | `` steamguard-cli: 0.12.5 -> 0.12.6 ``                                      |
| [`6c97b1f2`](https://github.com/NixOS/nixpkgs/commit/6c97b1f2b0814957269c618f54153604ef2c5f44) | `` python311Packages.pyoctoprintapi: refactor ``                            |
| [`66336d91`](https://github.com/NixOS/nixpkgs/commit/66336d9188c415b5109f48010992b7245f8d74ec) | `` dotslash: init at 0.2.0 ``                                               |
| [`e315f546`](https://github.com/NixOS/nixpkgs/commit/e315f54693775d047ca5c5babc5336787d2fbd73) | `` evcc: 0.124.0 -> 0.124.4 ``                                              |
| [`97d61661`](https://github.com/NixOS/nixpkgs/commit/97d61661762fb246759544e74e6dc408b201f404) | `` nixos/etc: fix payload in build-composefs-dump for the file case ``      |
| [`3e19f5d6`](https://github.com/NixOS/nixpkgs/commit/3e19f5d62f7dd0e83033c5b3fac9bc7f9b9f56b8) | `` c2ffi: remove unused arg ``                                              |
| [`933d1a51`](https://github.com/NixOS/nixpkgs/commit/933d1a51a3ab82d7caa484ce942069ec5a1eaae3) | `` yabai: 6.0.12 -> 6.0.13 ``                                               |
| [`2c630590`](https://github.com/NixOS/nixpkgs/commit/2c63059067e34a3609e9ddf078f2ddc9270e87e4) | `` nano-wallet: fix `gcc-13` build failure ``                               |
| [`64820eca`](https://github.com/NixOS/nixpkgs/commit/64820eca79b3bb0daca9d2aedb94a4d2955b4e68) | `` python311Packages.tensorflow: llvmPackages_11 -> llvmPackages ``         |
| [`6cee6e41`](https://github.com/NixOS/nixpkgs/commit/6cee6e417ec2560d35350425f74a93efe3104325) | `` ldapnomnom: 1.2.0 -> 1.3.0 ``                                            |
| [`b9c8b27f`](https://github.com/NixOS/nixpkgs/commit/b9c8b27f89555ab11128be65de25605a04ead4a3) | `` nixos/budgie: Enable SSH socket support in BCC when needed ``            |
| [`a4b8c1c9`](https://github.com/NixOS/nixpkgs/commit/a4b8c1c9528141601e4cd467ac76a44fd0a4b9df) | `` budgie.budgie-control-center: 1.3.0 -> 1.4.0 ``                          |
| [`98c87e1b`](https://github.com/NixOS/nixpkgs/commit/98c87e1b53969e500913843437269c384278f9c4) | `` diskscan: 0.20 -> 0.21 ``                                                |
| [`93e1c2d0`](https://github.com/NixOS/nixpkgs/commit/93e1c2d08467d1117ebac45689469613a9fe8453) | `` speex: add mingw support ``                                              |
| [`fcb308ec`](https://github.com/NixOS/nixpkgs/commit/fcb308ec7fc45c51d6c7852bb05168a3f2e364d1) | `` cosmic-session: fix xdg-desktop-portal-cosmic path ``                    |
| [`4072f686`](https://github.com/NixOS/nixpkgs/commit/4072f686d75d388a7b19a868392f131205bb99d9) | `` python312Packages.snakemake-interface-storage-plugins: 3.0.0 -> 3.1.0 `` |
| [`6d8ff793`](https://github.com/NixOS/nixpkgs/commit/6d8ff793cc91e75ab36d8d7908959a58b384ad7f) | `` obs-studio-plugins.obs-move-transition: 2.9.8 -> 2.10.0 ``               |
| [`446eee10`](https://github.com/NixOS/nixpkgs/commit/446eee10c29a30929b02ed4b7e261761b645d7dc) | `` signalbackup-tools: 20240210-1 -> 20240219-1 ``                          |
| [`1ce43fef`](https://github.com/NixOS/nixpkgs/commit/1ce43fefef7d0dc7d7570a79f1539bface4366ba) | `` xdg-desktop-portal-cosmic: set `meta.mainProgram` ``                     |
| [`1d759f79`](https://github.com/NixOS/nixpkgs/commit/1d759f79e09bdcff1e288fe00a10d3edfac881af) | `` rqlite: 8.20.1 -> 8.20.3 ``                                              |
| [`d0655c76`](https://github.com/NixOS/nixpkgs/commit/d0655c769e557d158231b36f8fd00846004829f6) | `` authentik: Fix logo path for email stage ``                              |
| [`cc46bc1a`](https://github.com/NixOS/nixpkgs/commit/cc46bc1a2e6b40fe6139b35ff44c186e96ebfc7f) | `` rust-analyzer-unwrapped: 2024-01-29 -> 2024-02-19 ``                     |
| [`2bf0f6c5`](https://github.com/NixOS/nixpkgs/commit/2bf0f6c589ec4af01d9d5faa79806876522f7683) | `` meld: 3.22.0 -> 3.22.1 ``                                                |
| [`56686c3d`](https://github.com/NixOS/nixpkgs/commit/56686c3d685b6fa7f86546b753eb97ab8851f393) | `` python311Packages.optimum: 1.17.0 -> 1.17.1 ``                           |
| [`5c5b6de9`](https://github.com/NixOS/nixpkgs/commit/5c5b6de926b98b875460ea700fac7c543dec83b5) | `` vector: 0.35.0 → 0.36.0 ``                                               |
| [`89195709`](https://github.com/NixOS/nixpkgs/commit/8919570977447feda62377769f3ca2d4ad7439ed) | `` construct: init at 0.1.0 ``                                              |
| [`a3a4dbcc`](https://github.com/NixOS/nixpkgs/commit/a3a4dbcccb16f969b0e4f55743dd8d5ee9e77cc9) | `` firefox-esr-115-unwrapped: 115.7.0esr -> 115.8.0esr ``                   |
| [`91e87d2b`](https://github.com/NixOS/nixpkgs/commit/91e87d2b9a844b1d8c8621e1ad8225cea097e366) | `` firefox-bin-unwrapped: 122.0.1 -> 123.0 ``                               |
| [`42638ed2`](https://github.com/NixOS/nixpkgs/commit/42638ed2b9fcd1df8517d46eb898162aa89f5957) | `` files-cli: 2.12.36 -> 2.12.37 ``                                         |
| [`efe44e32`](https://github.com/NixOS/nixpkgs/commit/efe44e322931ac5e28e9e14b4964c43a48955d80) | `` firefox-unwrapped: 122.0.1 -> 123.0.1 ``                                 |
| [`4646a0c7`](https://github.com/NixOS/nixpkgs/commit/4646a0c7db64b2f886b1de82e42961b640896940) | `` sasview: add changelog to meta ``                                        |
| [`711d3829`](https://github.com/NixOS/nixpkgs/commit/711d382967a5cf1aee14d51dcd2925b2e38320fe) | `` sasview: 5.0.4 -> 5.0.6 ``                                               |
| [`9ee9be8c`](https://github.com/NixOS/nixpkgs/commit/9ee9be8c16f1fe24dfde0b0d0aee298691fa818b) | `` nix-update: 1.0.0 -> 1.2.0 ``                                            |
| [`dbe8fc9e`](https://github.com/NixOS/nixpkgs/commit/dbe8fc9e66707740f027fe87260ff3b03d7270f6) | `` python311Packages.openllm-client: relax hatchling and hatch-vcs ``       |
| [`2bb2dace`](https://github.com/NixOS/nixpkgs/commit/2bb2daceeeb0b59d5db2b16b4ae14a49bdc335f8) | `` gedit: 46.1 → 46.2 ``                                                    |
| [`a3665a7c`](https://github.com/NixOS/nixpkgs/commit/a3665a7c1449aeb04d5f27d14765db4bfc7d5237) | `` python311Packages.bitsandbytes: add changelog to meta ``                 |
| [`560f6dfb`](https://github.com/NixOS/nixpkgs/commit/560f6dfb3e6e4ee5036c1b141e365745baa3efd7) | `` shittier: init at unstable-2023-12-22 ``                                 |
| [`8601ec13`](https://github.com/NixOS/nixpkgs/commit/8601ec1341c53c07981f3f4acc9dc3491b14df3a) | `` pet: 0.6.1 -> 0.6.2 ``                                                   |
| [`238d2445`](https://github.com/NixOS/nixpkgs/commit/238d24459d3050e7554e6c03af84e09dad2a4e0a) | `` python311Packages.plexapi: refactor ``                                   |
| [`3bae4398`](https://github.com/NixOS/nixpkgs/commit/3bae4398e0767b1d4785cd8370394966ede40a8e) | `` python311Packages.plexapi: 4.15.9 -> 4.15.10 ``                          |
| [`9b0e4832`](https://github.com/NixOS/nixpkgs/commit/9b0e483241c1e53e288c22f4c70ac27b590550ec) | `` uv: 0.1.4 -> 0.1.5 ``                                                    |
| [`2ce738fe`](https://github.com/NixOS/nixpkgs/commit/2ce738fea7f2e60b14967b3fcb548cd406275e53) | `` appflowy: 0.4.6 -> 0.4.9 ``                                              |
| [`3823eb0f`](https://github.com/NixOS/nixpkgs/commit/3823eb0f560296681cefe2a3bfb8d6ad4f4e2e6f) | `` python3Packages.wagtail-modeladmin: init at 2.0.0 ``                     |
| [`0c169f66`](https://github.com/NixOS/nixpkgs/commit/0c169f661a0630205e393ec976fd737f9fc83b07) | `` python311Packages.elementpath: refactor ``                               |
| [`df1df13a`](https://github.com/NixOS/nixpkgs/commit/df1df13a2f3a35f041a55197f479aeb6c5c7df17) | `` python311Packages.elementpath: 4.1.5 -> 4.3.0 ``                         |
| [`2544b0e7`](https://github.com/NixOS/nixpkgs/commit/2544b0e7014981e5d99ad2ce4441c53b12d3053f) | `` python312Packages.uqbar: 0.7.2 -> 0.7.3 ``                               |
| [`27c2a605`](https://github.com/NixOS/nixpkgs/commit/27c2a60502a09d79973464c910346ec4f692ad85) | `` python3.pkgs.docstr-coverage: init at 2.3.0 ``                           |
| [`eb20384d`](https://github.com/NixOS/nixpkgs/commit/eb20384d3f6b16d0fbe9080ff779cde96bb64dd5) | `` python312Packages.slack-sdk: refactor ``                                 |
| [`62e3136c`](https://github.com/NixOS/nixpkgs/commit/62e3136cd5f85bad1d503f57b7a1f755601d720d) | `` python311Packages.goodwe: refactor ``                                    |
| [`e236b838`](https://github.com/NixOS/nixpkgs/commit/e236b838c71d2aff275356ade8104bbdef422117) | `` linux-rt_5_15: 5.15.145-rt73 -> 5.15.148-rt74 ``                         |
| [`7c0bad83`](https://github.com/NixOS/nixpkgs/commit/7c0bad83b819fb62d3bd9b83180fe1a1dd4c4183) | `` linux_testing: 6.8-rc4 -> 6.8-rc5 ``                                     |
| [`906e2525`](https://github.com/NixOS/nixpkgs/commit/906e25257aa64906a1ec8e375ffaf073469ce239) | `` shell-genie: relax openai ``                                             |
| [`cb2de4b1`](https://github.com/NixOS/nixpkgs/commit/cb2de4b1cbf8295745e0a38a9149b18ab35c1d88) | `` python311Packages.goodwe: 0.3.0 -> 0.3.1 ``                              |
| [`31f6e6fa`](https://github.com/NixOS/nixpkgs/commit/31f6e6fa0144938eb50dcc8bd74f9f7e12898332) | `` python311Packages.primer3: refactor ``                                   |
| [`38643778`](https://github.com/NixOS/nixpkgs/commit/386437784fc77e85efddf0fa40a06c15d9134f92) | `` zfs-replicate: 3.2.7 -> 3.2.8 ``                                         |
| [`5deda288`](https://github.com/NixOS/nixpkgs/commit/5deda288bedda45452dcbc1807c2e65edadecd91) | `` python311Packages.tplink-omada-client: refactor ``                       |