### PR TITLE
chore(flake/home-manager): `517601b3` -> `4ee704cb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -452,11 +452,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708451036,
-        "narHash": "sha256-tgZ38NummEdnXvxj4D0StHBzXgceAw8CptytHljH790=",
+        "lastModified": 1708806879,
+        "narHash": "sha256-MSbxtF3RThI8ANs/G4o1zIqF5/XlShHvwjl9Ws0QAbI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "517601b37c6d495274454f63c5a483c8e3ca6be1",
+        "rev": "4ee704cb13a5a7645436f400b9acc89a67b9c08a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                 |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
| [`4ee704cb`](https://github.com/nix-community/home-manager/commit/4ee704cb13a5a7645436f400b9acc89a67b9c08a) | `` xscreensaver: add package option ``                  |
| [`ae7a3b51`](https://github.com/nix-community/home-manager/commit/ae7a3b5137ca3522f2802b3183de8fe5287b13d2) | `` hyprland: fix reloading ``                           |
| [`4e6d25a5`](https://github.com/nix-community/home-manager/commit/4e6d25a51bb3035af7db54cc8f7fcac23e9467dc) | `` lorri: systemd allow access to cache directories ``  |
| [`0e0e9669`](https://github.com/nix-community/home-manager/commit/0e0e9669547e45ea6cca2de4044c1a384fd0fe55) | `` zsh: fix broken ZDOTDIR when path contains spaces `` |
| [`0b69d574`](https://github.com/nix-community/home-manager/commit/0b69d574162cfa6eb7919d5614a48d0185550891) | `` Translate using Weblate (Spanish) ``                 |
| [`3dda8e79`](https://github.com/nix-community/home-manager/commit/3dda8e795f12a4f67c287cef155939e1c5fbd0a3) | `` river: add module ``                                 |