### PR TITLE
chore(flake/nur): `b878d82e` -> `192aa9b1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -980,11 +980,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708453610,
-        "narHash": "sha256-xKd53jAJVQi0rMUFMEJAegxnGLBABF8dHHwggCQbVlw=",
+        "lastModified": 1708818247,
+        "narHash": "sha256-op6sluExBoA6Y3FdeHtDINEWCXzns4jg2H+xfkjikuI=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "b878d82e0bee71857863aab9e94a95d6ba3cfa00",
+        "rev": "192aa9b134f867b6811ecd0444e994ef941648db",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`192aa9b1`](https://github.com/nix-community/NUR/commit/192aa9b134f867b6811ecd0444e994ef941648db) | `` automatic update `` |
| [`88034533`](https://github.com/nix-community/NUR/commit/8803453381137566c1bc1d91f4c3f8775680a601) | `` automatic update `` |
| [`deb67c14`](https://github.com/nix-community/NUR/commit/deb67c142317827d32256bb0df1fc96be237a177) | `` automatic update `` |
| [`63862fa4`](https://github.com/nix-community/NUR/commit/63862fa406a392b70265a065269d0f5bb9126050) | `` automatic update `` |
| [`78834d86`](https://github.com/nix-community/NUR/commit/78834d86e59d74af591676eeb519f73c2fb1a81c) | `` automatic update `` |
| [`b36b8de8`](https://github.com/nix-community/NUR/commit/b36b8de81d0ae9e20f2c5c190559987ce875884d) | `` automatic update `` |
| [`6eb03949`](https://github.com/nix-community/NUR/commit/6eb0394958661a7b8a16e7e670170d1908631d8f) | `` automatic update `` |
| [`4f24de20`](https://github.com/nix-community/NUR/commit/4f24de20bff7a1b2ccd6f1212756392a09c8f5dd) | `` automatic update `` |
| [`c31e6836`](https://github.com/nix-community/NUR/commit/c31e683648bb756993e914698d7da86a981cac79) | `` automatic update `` |
| [`77bc2584`](https://github.com/nix-community/NUR/commit/77bc25848d0279f03bdfdf3f428750bd04caf4e1) | `` automatic update `` |
| [`d24540b6`](https://github.com/nix-community/NUR/commit/d24540b60bc7f22d530d4f68bc53fab227180b16) | `` automatic update `` |
| [`c535580a`](https://github.com/nix-community/NUR/commit/c535580af90c127bf48d9343fe43518a75e0e233) | `` automatic update `` |
| [`7f0cad37`](https://github.com/nix-community/NUR/commit/7f0cad37958f31e19255fcc50683c638caa3149e) | `` automatic update `` |
| [`91985622`](https://github.com/nix-community/NUR/commit/919856228550477509e5a64e0f5bc8303f5103f6) | `` automatic update `` |
| [`5d874529`](https://github.com/nix-community/NUR/commit/5d874529e3006e19f9928b8a988115af40631554) | `` automatic update `` |
| [`3569087c`](https://github.com/nix-community/NUR/commit/3569087c73e3a145c6c7d9b7791c64c1e56f9317) | `` automatic update `` |
| [`099272d8`](https://github.com/nix-community/NUR/commit/099272d8b84ddafe37e4f451bc27f554e00fca05) | `` automatic update `` |
| [`0ec596e0`](https://github.com/nix-community/NUR/commit/0ec596e0c61b136b668a98051d9f530922be7b7c) | `` automatic update `` |
| [`74a7d74e`](https://github.com/nix-community/NUR/commit/74a7d74e28630535779aa6e43d94504660abedc6) | `` automatic update `` |
| [`be54879f`](https://github.com/nix-community/NUR/commit/be54879f8e138501b38985fa56cf8df92ffc5498) | `` automatic update `` |
| [`ca93af01`](https://github.com/nix-community/NUR/commit/ca93af016d87c2f150a96394f4c3d860d41c67a0) | `` automatic update `` |
| [`9ad79fd0`](https://github.com/nix-community/NUR/commit/9ad79fd0bacc6e0b29e476b1226c2257811115c2) | `` automatic update `` |
| [`15885313`](https://github.com/nix-community/NUR/commit/1588531309e9bd3ed51cb280e66e628b53dfb73f) | `` automatic update `` |
| [`ed0ac081`](https://github.com/nix-community/NUR/commit/ed0ac081d4a5f97dd31a01810593ba483433b020) | `` automatic update `` |
| [`0efe7096`](https://github.com/nix-community/NUR/commit/0efe7096d93ee45892e478c32fd5ee58bb815948) | `` automatic update `` |
| [`d5d88ce2`](https://github.com/nix-community/NUR/commit/d5d88ce2b91a5a3344901620f718899468d33ba7) | `` automatic update `` |
| [`f910d8ab`](https://github.com/nix-community/NUR/commit/f910d8ab283889f9eae8985ab79cec99faf54ee5) | `` automatic update `` |
| [`e08206f6`](https://github.com/nix-community/NUR/commit/e08206f667fa053add91c69ca52770a67732c5fc) | `` automatic update `` |
| [`d9ddb7e1`](https://github.com/nix-community/NUR/commit/d9ddb7e1b789fea42f136a2f04ee20b6edf1cd55) | `` automatic update `` |
| [`e57de8f3`](https://github.com/nix-community/NUR/commit/e57de8f3b903d09d56b763a02f659ddd29413564) | `` automatic update `` |
| [`f36586c0`](https://github.com/nix-community/NUR/commit/f36586c075aadb508c09066261f73ca888cdef4b) | `` automatic update `` |
| [`e2fe470b`](https://github.com/nix-community/NUR/commit/e2fe470ba0e468355422fc639f84f0d94dd28422) | `` automatic update `` |
| [`b6eb0f41`](https://github.com/nix-community/NUR/commit/b6eb0f41fc7f5f9aba88af8b30d98fb9617da4b7) | `` automatic update `` |
| [`676caef6`](https://github.com/nix-community/NUR/commit/676caef6be77d3446e94a47a01e0b1253ad818ca) | `` automatic update `` |
| [`438803a2`](https://github.com/nix-community/NUR/commit/438803a2779eb467495b0dc5c59aac2787992282) | `` automatic update `` |
| [`7d1e2b3f`](https://github.com/nix-community/NUR/commit/7d1e2b3f067ce8f7a1405e38b1835e2f16ff1146) | `` automatic update `` |
| [`c887bb06`](https://github.com/nix-community/NUR/commit/c887bb0661d6e67f42feed9480f968305bc7dcb1) | `` automatic update `` |
| [`f2251c97`](https://github.com/nix-community/NUR/commit/f2251c9702b4152b8a5ea519c28b0a3af00046a2) | `` automatic update `` |
| [`f2dea19f`](https://github.com/nix-community/NUR/commit/f2dea19f00712b55adae54680320368c69303312) | `` automatic update `` |
| [`b2f8bdcb`](https://github.com/nix-community/NUR/commit/b2f8bdcb64f1cde8848fa6f22848d36c472e8290) | `` automatic update `` |
| [`7944446e`](https://github.com/nix-community/NUR/commit/7944446e0031abeb3151dc750672b757088d5220) | `` automatic update `` |
| [`bba66b71`](https://github.com/nix-community/NUR/commit/bba66b7118eb9466eba8309fa2cbc8bb30677e5b) | `` automatic update `` |
| [`033887f2`](https://github.com/nix-community/NUR/commit/033887f2c8ffeab2abfd3bec23a3386d0cc17e70) | `` automatic update `` |
| [`5c4df059`](https://github.com/nix-community/NUR/commit/5c4df0594289335dbe400664a2771969397e7c7f) | `` automatic update `` |
| [`e076e631`](https://github.com/nix-community/NUR/commit/e076e631f5aec5e3ecc8a9d932199095462a10f0) | `` automatic update `` |
| [`3fac564e`](https://github.com/nix-community/NUR/commit/3fac564efbd1224fdebea052380fc64307cb311f) | `` automatic update `` |
| [`52422d24`](https://github.com/nix-community/NUR/commit/52422d2443f60feb5a426ef698c6ab6b544f0e6d) | `` automatic update `` |
| [`e7d31799`](https://github.com/nix-community/NUR/commit/e7d3179956f6054b12efb01f3a998474b48007df) | `` automatic update `` |
| [`0117ec46`](https://github.com/nix-community/NUR/commit/0117ec463a196a476752e07200d853d9841fea6a) | `` automatic update `` |
| [`74865ce6`](https://github.com/nix-community/NUR/commit/74865ce680458a3b48338ab7251de9eae21bd504) | `` automatic update `` |
| [`e25bcec8`](https://github.com/nix-community/NUR/commit/e25bcec8bfbf285498929d6baaaa615001a1ef10) | `` automatic update `` |
| [`54c7e8f8`](https://github.com/nix-community/NUR/commit/54c7e8f806f555e7935a78459347b66ea5b76f86) | `` automatic update `` |
| [`5a0865c2`](https://github.com/nix-community/NUR/commit/5a0865c218fdf4640018cf1f1e11930ecfa44a44) | `` automatic update `` |
| [`9b94a33c`](https://github.com/nix-community/NUR/commit/9b94a33cfb3100f7791273aeec71eb1ec0382a36) | `` automatic update `` |
| [`c511ef9a`](https://github.com/nix-community/NUR/commit/c511ef9abc728c7ef7d8639ea5942933159a0d37) | `` automatic update `` |
| [`f2af010f`](https://github.com/nix-community/NUR/commit/f2af010f46a7eb25cbeef01f6942eb3b14fbd1da) | `` automatic update `` |
| [`6330f5ae`](https://github.com/nix-community/NUR/commit/6330f5ae13c404643d7f2ff83f45e8b6e7952370) | `` automatic update `` |
| [`a2c086ff`](https://github.com/nix-community/NUR/commit/a2c086ffc6cd61ded1e6979fd425e08074e3d7ea) | `` automatic update `` |
| [`f67ac59a`](https://github.com/nix-community/NUR/commit/f67ac59acc731fbc4e584b6d5e319d084bb876e0) | `` automatic update `` |
| [`5b326fa0`](https://github.com/nix-community/NUR/commit/5b326fa01c53a41ea747e3901941a24581b98b4f) | `` automatic update `` |
| [`9ea82ef9`](https://github.com/nix-community/NUR/commit/9ea82ef92cd9ec9e532ad4e4e081a9136890d2a4) | `` automatic update `` |
| [`751ff5df`](https://github.com/nix-community/NUR/commit/751ff5dfb26711c9977ed4cd6f42c8a2d66d2625) | `` automatic update `` |
| [`4fa33164`](https://github.com/nix-community/NUR/commit/4fa331649d6f6f2f41fa5410f97cdea0462ed27c) | `` automatic update `` |
| [`d8ad7ae7`](https://github.com/nix-community/NUR/commit/d8ad7ae793a9e20bc52fc440659c36405f531af1) | `` automatic update `` |
| [`65a4caef`](https://github.com/nix-community/NUR/commit/65a4caef6f81f8c48f24117df7358c200d792d35) | `` automatic update `` |
| [`153fbfc5`](https://github.com/nix-community/NUR/commit/153fbfc53323861b46458ed3a7d5df6b375a6086) | `` automatic update `` |
| [`e7bd3c60`](https://github.com/nix-community/NUR/commit/e7bd3c6040c831aaf6c0fbcfab17f42420129c17) | `` automatic update `` |
| [`4ddaee82`](https://github.com/nix-community/NUR/commit/4ddaee829a77882406085d9c82d972a8a44ca7bd) | `` automatic update `` |
| [`07574526`](https://github.com/nix-community/NUR/commit/0757452695e0d82544e47312e64b2f7a6211abde) | `` automatic update `` |
| [`0f53fded`](https://github.com/nix-community/NUR/commit/0f53fdedb89a2a062f8f10c5de534300277d2ca2) | `` automatic update `` |
| [`15d82702`](https://github.com/nix-community/NUR/commit/15d82702d15e1c9f6a861ed62a72dfa592918a0b) | `` automatic update `` |
| [`90663063`](https://github.com/nix-community/NUR/commit/90663063a0a99e2d27a6f3b9c894fe3810fa6b87) | `` automatic update `` |
| [`99f4a808`](https://github.com/nix-community/NUR/commit/99f4a8084773e933558f2bb1452e3ade1768e087) | `` automatic update `` |
| [`6214db25`](https://github.com/nix-community/NUR/commit/6214db25480d8cb2ffbb54718c871509c206467e) | `` automatic update `` |
| [`cf9b05d5`](https://github.com/nix-community/NUR/commit/cf9b05d5f39c764ed41b1a92d332c3e6b1fd733a) | `` automatic update `` |
| [`33b9e46b`](https://github.com/nix-community/NUR/commit/33b9e46b02305aaf6572c72888e2deee21c920f8) | `` automatic update `` |
| [`ad7aef8a`](https://github.com/nix-community/NUR/commit/ad7aef8a39597c7de4c5daf1c8578584e7a55f8a) | `` automatic update `` |
| [`af5d41d2`](https://github.com/nix-community/NUR/commit/af5d41d230662b1988aca30e3fc2e9e92bdc95dd) | `` automatic update `` |
| [`eefe3b11`](https://github.com/nix-community/NUR/commit/eefe3b1192a4040e4cd1216ec4929eb21bd3376e) | `` automatic update `` |
| [`536a4578`](https://github.com/nix-community/NUR/commit/536a4578760fff9a34274190a19f896087cec1b5) | `` automatic update `` |
| [`47174021`](https://github.com/nix-community/NUR/commit/4717402142372efd49c892d4311dee94c0816295) | `` automatic update `` |
| [`95e5727f`](https://github.com/nix-community/NUR/commit/95e5727f7d65efbb7627706c3bb68d7247d2710c) | `` automatic update `` |
| [`b88fac58`](https://github.com/nix-community/NUR/commit/b88fac587b86f3cc96d031b423bda61d65fe3ff9) | `` automatic update `` |
| [`bb211faf`](https://github.com/nix-community/NUR/commit/bb211faf55e7a4ffaeb25ffbf77cf38df84f4446) | `` automatic update `` |
| [`99386fd5`](https://github.com/nix-community/NUR/commit/99386fd535955464e910b33d75c83d3ddb0d6d42) | `` automatic update `` |
| [`d080c30d`](https://github.com/nix-community/NUR/commit/d080c30d6c656d1bc59abb3f511b32d41f5486e9) | `` automatic update `` |
| [`fe99d068`](https://github.com/nix-community/NUR/commit/fe99d068026b02046a9aae34fe60b4063d457d20) | `` automatic update `` |
| [`ba788ed3`](https://github.com/nix-community/NUR/commit/ba788ed38fa45a8c7fb7f3a2c051e5670c758c97) | `` automatic update `` |
| [`377837e1`](https://github.com/nix-community/NUR/commit/377837e1766b7867d0012f4c88b9858548bbdcda) | `` automatic update `` |
| [`4a06dbfc`](https://github.com/nix-community/NUR/commit/4a06dbfc56df098148d311fd37c74e0363019863) | `` automatic update `` |
| [`2f4e7cb8`](https://github.com/nix-community/NUR/commit/2f4e7cb8e678407800c2685edc12678bf5228d09) | `` automatic update `` |
| [`83fe45c8`](https://github.com/nix-community/NUR/commit/83fe45c89d0a6d1ce3df11288d89280ce2ff6c67) | `` automatic update `` |
| [`b9d06197`](https://github.com/nix-community/NUR/commit/b9d061979fdd29a24e263b20f314d84e7d5cd61e) | `` automatic update `` |
| [`e7e77ef5`](https://github.com/nix-community/NUR/commit/e7e77ef5ce40a07feebc646ccb1a5e209e14691f) | `` automatic update `` |
| [`8c7e9635`](https://github.com/nix-community/NUR/commit/8c7e9635c81242c42d3cf729ccc7cfc40dcee01d) | `` automatic update `` |
| [`3bf1f64e`](https://github.com/nix-community/NUR/commit/3bf1f64e4827a42ec3423f7b77ba654f63525a00) | `` automatic update `` |
| [`f8fd9ce3`](https://github.com/nix-community/NUR/commit/f8fd9ce3260d1a759e0e167fec4cbce67c0240bc) | `` automatic update `` |