### PR TITLE
chore(flake/treefmt-nix): `e5046212` -> `36fd6923`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1202,11 +1202,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708335038,
-        "narHash": "sha256-ETLZNFBVCabo7lJrpjD6cAbnE11eDOjaQnznmg/6hAE=",
+        "lastModified": 1708681819,
+        "narHash": "sha256-+YIvy0dDZw8KIFVPS9i+mTHf2RqSJ0+dBB9AXBvDTks=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e504621290a1fd896631ddbc5e9c16f4366c9f65",
+        "rev": "36fd6923c122a983bc3915692e6cb3ff341ef083",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                    |
| ---------------------------------------------------------------------------------------------------- | -------------------------- |
| [`36fd6923`](https://github.com/numtide/treefmt-nix/commit/36fd6923c122a983bc3915692e6cb3ff341ef083) | `` add fantomas (#159) ``  |
| [`8bffa0f5`](https://github.com/numtide/treefmt-nix/commit/8bffa0f55a0429837ebaaf9fe55114df21e15129) | `` flake update ``         |
| [`6e11dcbe`](https://github.com/numtide/treefmt-nix/commit/6e11dcbed37d527eb614bc26e5aa4f4ab93fffc2) | `` add nixfmt-rfc-style `` |