### PR TITLE
chore(flake/emacs-overlay): `eca18f04` -> `299398be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -193,11 +193,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1708448970,
-        "narHash": "sha256-aElcEUsNTGC9q5VdwA+XsgprcRup0w6y+eOKyFbUWfk=",
+        "lastModified": 1708794236,
+        "narHash": "sha256-DTmyCeySQjFOuSNRUFpA2Jxkqo7bMXvSn2tXSVk3RpQ=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "eca18f048a96d077a72881ced8949e1e8dcee4b5",
+        "rev": "299398be3c27d885cf17ff8310944b307a1449e9",
         "type": "github"
       },
       "original": {
@@ -900,11 +900,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1708294118,
-        "narHash": "sha256-evZzmLW7qoHXf76VCepvun1esZDxHfVRFUJtumD7L2M=",
+        "lastModified": 1708702655,
+        "narHash": "sha256-qxT5jSLhelfLhQ07+AUxSTm1VnVH+hQxDkQSZ/m/Smo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e0da498ad77ac8909a980f07eff060862417ccf7",
+        "rev": "c5101e457206dd437330d283d6626944e28794b3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                                                                     |
| ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
| [`299398be`](https://github.com/nix-community/emacs-overlay/commit/299398be3c27d885cf17ff8310944b307a1449e9) | `` Updated emacs ``                                                         |
| [`92a5d3e7`](https://github.com/nix-community/emacs-overlay/commit/92a5d3e756ba99247a2dbe9d1d43e924318a4770) | `` Updated melpa ``                                                         |
| [`acd01488`](https://github.com/nix-community/emacs-overlay/commit/acd01488bd5f491e28cc2051ac48ef220ec0d64d) | `` Updated elpa ``                                                          |
| [`62a3839a`](https://github.com/nix-community/emacs-overlay/commit/62a3839a94055a0276b8828445ac29f97316bd9d) | `` Updated nongnu ``                                                        |
| [`c41feea3`](https://github.com/nix-community/emacs-overlay/commit/c41feea3fa9090592395720647822ffe5dc981bc) | `` Updated flake inputs ``                                                  |
| [`a793a085`](https://github.com/nix-community/emacs-overlay/commit/a793a0854929c608cf219792695fe45321a72782) | `` Updated emacs ``                                                         |
| [`93582973`](https://github.com/nix-community/emacs-overlay/commit/93582973727a642498036486b8fc908dc89ac752) | `` Updated melpa ``                                                         |
| [`0a9f2206`](https://github.com/nix-community/emacs-overlay/commit/0a9f2206463dcf4f54d11d2edd98482e7154489d) | `` Revert "Use --replace-warn instead of --replace in substituteInPlace" `` |
| [`a34163ae`](https://github.com/nix-community/emacs-overlay/commit/a34163aecd2197823601eadeca2d4f0f2ef1eeb6) | `` Updated emacs ``                                                         |
| [`69186537`](https://github.com/nix-community/emacs-overlay/commit/691865378410dab4c6ed7abdcd9658b4919d0adf) | `` Updated melpa ``                                                         |
| [`9384a2fe`](https://github.com/nix-community/emacs-overlay/commit/9384a2fe1256dd5827c46cceb81f8418da781aa7) | `` Updated elpa ``                                                          |
| [`c22ec71c`](https://github.com/nix-community/emacs-overlay/commit/c22ec71c2ea3138f3979467c039f88846934c518) | `` Updated flake inputs ``                                                  |
| [`4e1e5405`](https://github.com/nix-community/emacs-overlay/commit/4e1e5405aa869da8bf98b2af7a99873586a01fbc) | `` Updated emacs ``                                                         |
| [`53c07ac2`](https://github.com/nix-community/emacs-overlay/commit/53c07ac2da8d7afd90a2984241eeebfc6177b183) | `` Updated melpa ``                                                         |
| [`fef9f0a6`](https://github.com/nix-community/emacs-overlay/commit/fef9f0a62e64b2d4342a69ec116627963f5eb8ae) | `` Updated elpa ``                                                          |
| [`841abef0`](https://github.com/nix-community/emacs-overlay/commit/841abef01afbd293aa80130bcbd811e4102d5770) | `` Updated emacs ``                                                         |
| [`8c960d16`](https://github.com/nix-community/emacs-overlay/commit/8c960d16f0397375d706757635a6b1c437d75fdb) | `` Updated melpa ``                                                         |
| [`eab05784`](https://github.com/nix-community/emacs-overlay/commit/eab0578469312efc175332bc8ec405d6d7a765a0) | `` Updated flake inputs ``                                                  |
| [`8bcb0f18`](https://github.com/nix-community/emacs-overlay/commit/8bcb0f18ef0e77012d8ade7cdb97e897774a179c) | `` Updated emacs ``                                                         |
| [`3b9569f7`](https://github.com/nix-community/emacs-overlay/commit/3b9569f7f88449ab2f4f016238232b90041fbac8) | `` Updated melpa ``                                                         |
| [`0a8c849a`](https://github.com/nix-community/emacs-overlay/commit/0a8c849ac931e30a752a151a6ac9b1f521e716f1) | `` Updated elpa ``                                                          |
| [`761171bc`](https://github.com/nix-community/emacs-overlay/commit/761171bc1702963573131b427893ed08de955463) | `` Updated nongnu ``                                                        |
| [`ab98cf0c`](https://github.com/nix-community/emacs-overlay/commit/ab98cf0c6ddaf60cb1ef95e4e983695c7e8245e7) | `` Updated emacs ``                                                         |
| [`ab74faf9`](https://github.com/nix-community/emacs-overlay/commit/ab74faf9e9930fa1785f8a6a0005cf2c17188d5c) | `` Updated melpa ``                                                         |
| [`dfe78231`](https://github.com/nix-community/emacs-overlay/commit/dfe78231595f36e4f25aee6a861feff5b077862a) | `` Updated elpa ``                                                          |
| [`9657a4d4`](https://github.com/nix-community/emacs-overlay/commit/9657a4d41b7efd275488613a3c408765b4d55e5b) | `` Use --replace-warn instead of --replace in substituteInPlace ``          |
| [`7f463b6a`](https://github.com/nix-community/emacs-overlay/commit/7f463b6ae783990b87a2821491df823f75f89f9c) | `` Updated emacs ``                                                         |
| [`1e5be0a6`](https://github.com/nix-community/emacs-overlay/commit/1e5be0a6a9e14ece938f8882f670eb44428db059) | `` Updated melpa ``                                                         |
| [`6e1f5e6d`](https://github.com/nix-community/emacs-overlay/commit/6e1f5e6da33486d1f56d98f97949f961dd621479) | `` Updated emacs ``                                                         |
| [`4735a15b`](https://github.com/nix-community/emacs-overlay/commit/4735a15b5329c87554a8d54873acddbc846e8753) | `` Updated melpa ``                                                         |
| [`54d05956`](https://github.com/nix-community/emacs-overlay/commit/54d0595648c17dd7e782eef6242ccb2295a2a054) | `` Updated elpa ``                                                          |
| [`0b46b54c`](https://github.com/nix-community/emacs-overlay/commit/0b46b54cbbf135a1e6924b0a7ca22dcfd98f0cc6) | `` Updated emacs ``                                                         |
| [`243457f5`](https://github.com/nix-community/emacs-overlay/commit/243457f5cf17fd1c3723889b474924afbe0789bf) | `` Updated melpa ``                                                         |
| [`5bcb462a`](https://github.com/nix-community/emacs-overlay/commit/5bcb462ac3c818ca56389bf0c47346ee6b77cb6c) | `` Updated elpa ``                                                          |
| [`acbcd811`](https://github.com/nix-community/emacs-overlay/commit/acbcd8110648411631b60b633b5d0c77bb61b20a) | `` Updated flake inputs ``                                                  |
| [`39a63475`](https://github.com/nix-community/emacs-overlay/commit/39a63475945fea0d8b4e4aeb351f392c1c3beeab) | `` Updated emacs ``                                                         |
| [`cf4080f0`](https://github.com/nix-community/emacs-overlay/commit/cf4080f0f4e0e7eb3223b723b7617e34d6a1239c) | `` Updated melpa ``                                                         |
| [`965e4460`](https://github.com/nix-community/emacs-overlay/commit/965e446000282dda9bce8fc5fcf65a5ef038f396) | `` Updated emacs ``                                                         |
| [`7523288d`](https://github.com/nix-community/emacs-overlay/commit/7523288d4a7691c719d168f74bf88404cded497f) | `` Updated melpa ``                                                         |
| [`46a27ccf`](https://github.com/nix-community/emacs-overlay/commit/46a27ccfdce3c14f8cc79250c6a27b5abc75832d) | `` Updated elpa ``                                                          |
| [`0a5f33bc`](https://github.com/nix-community/emacs-overlay/commit/0a5f33bc21d5a2b594208da4d41cad7e19f29366) | `` Updated nongnu ``                                                        |
| [`825ce34a`](https://github.com/nix-community/emacs-overlay/commit/825ce34adf294e5f2b2de7e1606349cf07caa3f2) | `` make extraEmacsPackages available when building init file ``             |