### PR TITLE
chore(flake/spicetify-nix): `e70958c9` -> `dc12e982`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1122,11 +1122,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708402307,
-        "narHash": "sha256-TvkyfZduvaridstQHOa4r74XFU4oUJYfJrvFDxjAN1Q=",
+        "lastModified": 1708747934,
+        "narHash": "sha256-yfdQZYjxvkjwVF3Fl4CmJv2l/f4uk49x1EcI9iRCyBk=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "e70958c9943b7ed2f20b60c8f09a886eaeea3c2d",
+        "rev": "dc12e982d81512e658d9ca4e30cdf5b846a8c160",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`dc12e982`](https://github.com/Gerg-L/spicetify-nix/commit/dc12e982d81512e658d9ca4e30cdf5b846a8c160) | `` CI update 2024-02-24 (#81) `` |
| [`e63a1a2a`](https://github.com/Gerg-L/spicetify-nix/commit/e63a1a2a1d215e6a39f41c59d65a81d02806309a) | `` CI update 2024-02-22 (#80) `` |
| [`c19e1d31`](https://github.com/Gerg-L/spicetify-nix/commit/c19e1d31b497929c16fdc16b211db01d6cc61289) | `` CI update 2024-02-21 (#79) `` |