### PR TITLE
chore(flake/hyprland): `d9757b61` -> `f534ac3f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -475,11 +475,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1708623203,
-        "narHash": "sha256-4/q2/O+A8o/UO1D9fOU8Q/c+JacZkFJb2noFjN6K66c=",
+        "lastModified": 1708817736,
+        "narHash": "sha256-GZEoru+4uNIGEZ8j1TPaxZwM+ApIngHU/iX3sIGgUO4=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "d9757b61bfb7dcfaf3d903092435a1aaff52b7ed",
+        "rev": "f534ac3fc462d8af923d2a1ab8ef58f62639a1ea",
         "type": "github"
       },
       "original": {
@@ -518,36 +518,18 @@
         "nixpkgs": [
           "hyprland",
           "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1708005943,
-        "narHash": "sha256-9TT3xk++LI5/SPYgjYX34xZ4ebR93c1uerIq+SE/ues=",
-        "owner": "hyprwm",
-        "repo": "hyprlang",
-        "rev": "aeb3e012adc7b3235335c540b214b82267c2b983",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprlang",
-        "type": "github"
-      }
-    },
-    "hyprlang_2": {
-      "inputs": {
-        "nixpkgs": [
+        ],
+        "systems": [
           "hyprland",
-          "xdph",
-          "nixpkgs"
+          "systems"
         ]
       },
       "locked": {
-        "lastModified": 1704287638,
-        "narHash": "sha256-TuRXJGwtK440AXQNl5eiqmQqY4LZ/9+z/R7xC0ie3iA=",
+        "lastModified": 1708681732,
+        "narHash": "sha256-ULZZLZ9C33G13IaXLuAc4oTzHUvnATI8Fj2u6gzMfT0=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "6624f2bb66d4d27975766e81f77174adbe58ec97",
+        "rev": "f4466367ef0a92a6425d482050dc2b8840c0e644",
         "type": "github"
       },
       "original": {
@@ -932,11 +914,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1707546158,
-        "narHash": "sha256-nYYJTpzfPMDxI8mzhQsYjIUX+grorqjKEU9Np6Xwy/0=",
+        "lastModified": 1708475490,
+        "narHash": "sha256-g1v0TsWBQPX97ziznfJdWhgMyMGtoBFs102xSYO4syU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d934204a0f8d9198e1e4515dd6fec76a139c87f0",
+        "rev": "0e74ca98a74bc7270d28838369593635a5db3260",
         "type": "github"
       },
       "original": {
@@ -1240,7 +1222,10 @@
           "hyprland",
           "hyprland-protocols"
         ],
-        "hyprlang": "hyprlang_2",
+        "hyprlang": [
+          "hyprland",
+          "hyprlang"
+        ],
         "nixpkgs": [
           "hyprland",
           "nixpkgs"
@@ -1251,11 +1236,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706521509,
-        "narHash": "sha256-AInZ50acOJ3wzUwGzNr1TmxGTMx+8j6oSTzz4E7Vbp8=",
+        "lastModified": 1708696469,
+        "narHash": "sha256-shh5wmpeYy3MmsBfkm4f76yPsBDGk6OLYRVG+ARy2F0=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "c06fd88b3da492b8f9067be021b9184f7012b5a8",
+        "rev": "1b713911c2f12b96c2574474686e4027ac4bf826",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                           |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
| [`f534ac3f`](https://github.com/hyprwm/Hyprland/commit/f534ac3fc462d8af923d2a1ab8ef58f62639a1ea) | `` hyprctl: add missing newline in error case of missing `HYPRLAND_INSTANCE_SIGNATURE` (#4832) `` |
| [`9103af31`](https://github.com/hyprwm/Hyprland/commit/9103af317ec7c6d46d4be561eee855d5337c9e8c) | `` hyprctl: ignore non-lock files for instances ``                                                |
| [`5824b0f3`](https://github.com/hyprwm/Hyprland/commit/5824b0f305e95132184241832653d528b12c75e2) | `` hyprctl: fix showing invalid instances ``                                                      |
| [`e9528fc2`](https://github.com/hyprwm/Hyprland/commit/e9528fc214bb3d807a4fcb6d35894f59760fba51) | `` config: fix layout invalidation for keyword commands (#4826) ``                                |
| [`6f838560`](https://github.com/hyprwm/Hyprland/commit/6f838560252045be5bac2e7492ff8d1e250cf937) | `` hyprctl: add -r argument ``                                                                    |
| [`d92da795`](https://github.com/hyprwm/Hyprland/commit/d92da7959a1d271c585d0a7de4c75a389bd1ac05) | `` core: Fix SEGV/ABRT core dump when exiting (#4823) ``                                          |
| [`f27054c1`](https://github.com/hyprwm/Hyprland/commit/f27054c13e72598e43771cb3f8bfad8ac6c6668f) | `` flake.nix: override inputs for xdph and hyprlang ``                                            |
| [`bdbd8d96`](https://github.com/hyprwm/Hyprland/commit/bdbd8d965d4f1a13129c72505bb556445ce0bc90) | `` hyprctl: jsonify new gaps ``                                                                   |
| [`bfb1e876`](https://github.com/hyprwm/Hyprland/commit/bfb1e876a87d80256f7c29d24cbda704c5eefaa1) | `` config: add opengl:force_introspection ``                                                      |
| [`ca59bd57`](https://github.com/hyprwm/Hyprland/commit/ca59bd57393a386c9c6c9707ef6a9de4a9235fe1) | `` opengl: check bottom/bg layers for required introspection ``                                   |
| [`f389f770`](https://github.com/hyprwm/Hyprland/commit/f389f77015ebeee30a2527b8eb7488879dd626e0) | `` core: Try to fix the exit hang (#4811) ``                                                      |
| [`8c361363`](https://github.com/hyprwm/Hyprland/commit/8c3613632a6ccebf9fb797ec756ecfce99514eec) | `` renderer: nuke lastFrameDamage and rework finalDamage ``                                       |
| [`c1ef361e`](https://github.com/hyprwm/Hyprland/commit/c1ef361e02e4c4a52fbc5dbd9e67b79e0afab4f3) | `` renderer: fix logs ``                                                                          |
| [`35e80a64`](https://github.com/hyprwm/Hyprland/commit/35e80a64a6a0e4765949bb6a6038b8a66db46209) | `` renderer: add more logging for fails in beginRender ``                                         |
| [`e83bf4f7`](https://github.com/hyprwm/Hyprland/commit/e83bf4f7b72aff7ae8a7968eaf24718fa94dd62b) | `` core: add env to disable crash reporter ``                                                     |
| [`c353b7c4`](https://github.com/hyprwm/Hyprland/commit/c353b7c4f75e53af006bc2cf686b02c9a6495b60) | `` renderer: minor fixes for introspection detection ``                                           |