### PR TITLE
chore(flake/nixpkgs): `fa15b53d` -> `6d8aba54`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -964,11 +964,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1708405701,
-        "narHash": "sha256-E78TXiZiR9irWdYAVltRxZPJ+pMxXPU5PjHwqq6XLtI=",
+        "lastModified": 1708807027,
+        "narHash": "sha256-NhM8lJRS0jr1uMXQGeUUC+7zd2PSz6TdDMxZWUz98nI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fa15b53dbea5028db38d6e09b4cef6eba42aeebb",
+        "rev": "6d8aba54f305eb12a57d92ad4eaeb42049961f19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`c37cffdd`](https://github.com/NixOS/nixpkgs/commit/c37cffdda5ccc4999593c78c67db37b8f8d0ecde) | `` urlwatch: cherry-pick lxml 5 compatibility fix ``                       |
| [`4dbe5e70`](https://github.com/NixOS/nixpkgs/commit/4dbe5e70abe5f35508ef34060eac49cf73d1083a) | `` python312Packages.oelint-parser: 3.2.1 -> 3.2.2 ``                      |
| [`51945608`](https://github.com/NixOS/nixpkgs/commit/519456082e43c2f9445537e24697fb4e5e9039a3) | `` zabbix40: remove vestiges in package-config.nix ``                      |
| [`2c27aae1`](https://github.com/NixOS/nixpkgs/commit/2c27aae178371bb66009cb164d1fdc3c120db5f1) | `` sing-box: 1.8.5 -> 1.8.6 ``                                             |
| [`03a55185`](https://github.com/NixOS/nixpkgs/commit/03a55185193630e4f50eeaef8b429423195c2cb0) | `` freetube: 0.19.1 -> 0.19.2 ``                                           |
| [`89544168`](https://github.com/NixOS/nixpkgs/commit/89544168945235d40303004b688e0b5dcb0df8a2) | `` goflow: 3.4.4 -> 3.4.5 ``                                               |
| [`07ff912d`](https://github.com/NixOS/nixpkgs/commit/07ff912d63f998aeee1aa3b99cc10cb9f96712d7) | `` ft2-clone: 1.75 -> 1.76 ``                                              |
| [`080716f2`](https://github.com/NixOS/nixpkgs/commit/080716f284ed28ac8be36bb4cf676bea035f3b87) | `` python311Packages.phx-class-registry: 4.0.6 -> 4.1.0 ``                 |
| [`e8836154`](https://github.com/NixOS/nixpkgs/commit/e88361546946893ef57dd31b9a322d65fd57722b) | `` python312Packages.aemet-opendata: 0.4.7 -> 0.5.1 ``                     |
| [`81a62f07`](https://github.com/NixOS/nixpkgs/commit/81a62f07205aad145e2058245b9c7634059aa96e) | `` python311Packages.openstacksdk: 2.1.0 -> 3.0.0 ``                       |
| [`b502e9a5`](https://github.com/NixOS/nixpkgs/commit/b502e9a54f2ea3d69a491cdd03456b90c27f9e82) | `` python312Packages.brother: 3.0.0 -> 4.0.0 ``                            |
| [`2bc7231a`](https://github.com/NixOS/nixpkgs/commit/2bc7231a6dd52bb478cabf2975527ea133efc033) | `` ocamlPackages.cohttp: 5.3.0 -> 5.3.1 ``                                 |
| [`e59c530c`](https://github.com/NixOS/nixpkgs/commit/e59c530c30136017376f1c59678f96ef406fc0e0) | `` lnd: 0.17.3-beta -> 0.17.4-beta ``                                      |
| [`efc0a80b`](https://github.com/NixOS/nixpkgs/commit/efc0a80b20a495b8f1d2c79bb5802085118b072f) | `` ocamlPackages.macaddr: 5.4.0 -> 5.5.0 ``                                |
| [`597a204e`](https://github.com/NixOS/nixpkgs/commit/597a204ef75acede9a744bd1c259e0c8f421175f) | `` kchat: init at 2.4.0 ``                                                 |
| [`740f6fb7`](https://github.com/NixOS/nixpkgs/commit/740f6fb7d80e1b10ec930e2e6d88dca4a4689fa1) | `` emacs: retire myself from maintainers ``                                |
| [`e50e3a95`](https://github.com/NixOS/nixpkgs/commit/e50e3a959a58a61aeea12fa8f5da94ee343a9003) | `` python311Packages.autoit-ripper: remove stale postPatch section ``      |
| [`46912e29`](https://github.com/NixOS/nixpkgs/commit/46912e299955b05d223cda08c43b8e665147ec9f) | `` python312Packages.opower: 0.3.0 -> 0.3.1 ``                             |
| [`4208934f`](https://github.com/NixOS/nixpkgs/commit/4208934fef45207aa0ee2e4b6410ceb28b655a1e) | `` python312Packages.botocore-stubs: 1.34.48 -> 1.34.49 ``                 |
| [`1ce0f9b3`](https://github.com/NixOS/nixpkgs/commit/1ce0f9b3fef96640a1ae68717d87f267cd219b68) | `` python311Packages.boto3-stubs: 1.34.48 -> 1.34.49 ``                    |
| [`23fcd515`](https://github.com/NixOS/nixpkgs/commit/23fcd515392ded1b8cc1dffa142f2fe4ebd09472) | `` ayatana-indicator-session: Re-enable test-service test ``               |
| [`2b0673c2`](https://github.com/NixOS/nixpkgs/commit/2b0673c217a04a40b9195deb84b103f6dc54343a) | `` opencolorio: fix tests on staging-next ``                               |
| [`7d52ac6d`](https://github.com/NixOS/nixpkgs/commit/7d52ac6d831e17e503123a2e466984d33927cb95) | `` python311Packages.dask: provide dataframe extra for tests ``            |
| [`d01044ec`](https://github.com/NixOS/nixpkgs/commit/d01044ecfa9c89a925bebb76cf60f2e3b9cea667) | `` zabbix40: drop, no more supported upstream ``                           |
| [`a65967a1`](https://github.com/NixOS/nixpkgs/commit/a65967a12c9e09d23ff50b25785f861ee6af0539) | `` nixos/nix: documentation: fix outdated reference to /etc/nix.conf ``    |
| [`8e8148f6`](https://github.com/NixOS/nixpkgs/commit/8e8148f624362e60a5adf1b9efcdfcf246047bbc) | `` git-absorb: 0.6.11 -> 0.6.12 ``                                         |
| [`bf289c83`](https://github.com/NixOS/nixpkgs/commit/bf289c83795349bbe455d76ee3c0a5efa3b5c039) | `` hugo: 1.123.2 -> 1.123.3 ``                                             |
| [`ef22d82d`](https://github.com/NixOS/nixpkgs/commit/ef22d82d56fc2b5ff8b1b078ca1f78c0404cdcd3) | `` linuxPackages.r8168: 8.048.03 -> 8.052.01 ``                            |
| [`50f953be`](https://github.com/NixOS/nixpkgs/commit/50f953be9b5b4cb01a665f8ea3cade97dc7906f3) | `` cri-o: 1.29.1 -> 1.29.2 ``                                              |
| [`aef5e138`](https://github.com/NixOS/nixpkgs/commit/aef5e138b1372074083581852c7b30bd850cb340) | `` vdrPlugins.softhddevice: 2.0.9 -> 2.1.1 ``                              |
| [`1da7dfa5`](https://github.com/NixOS/nixpkgs/commit/1da7dfa57d4a380230edba7686a0ffe8a4a31eea) | `` nixosTests.power-profiles-daemon: test profilectl CLI ``                |
| [`93679d4d`](https://github.com/NixOS/nixpkgs/commit/93679d4d0ab7e22acd71d54e43abce590e7ea40e) | `` power-profiles-daemon: 0.13 -> 0.20 ``                                  |
| [`49a820ea`](https://github.com/NixOS/nixpkgs/commit/49a820eae13fb16bece6cadf6f0096f61d99f0ec) | `` python311Packages.smartypants: avoid rebuild ``                         |
| [`2d24bceb`](https://github.com/NixOS/nixpkgs/commit/2d24bceb57b8bc2883c4468f2c4bb7d665ea4318) | `` python312Packages.dep-logic: 0.0.4 -> 0.2.0 ``                          |
| [`ee5bef2e`](https://github.com/NixOS/nixpkgs/commit/ee5bef2e6976f3d67011be40bb647879e1dfe5e1) | `` obs-studio-plugins.obs-shaderfilter: 2.0.0 -> 2.2.2 ``                  |
| [`8f3b751c`](https://github.com/NixOS/nixpkgs/commit/8f3b751ca8a8f5978d76fbe35b6f6b229f463275) | `` wineWowPackages.minimal: fix build (missing `--without-x`) ``           |
| [`6d762aa8`](https://github.com/NixOS/nixpkgs/commit/6d762aa899f7d5c4e2248336d58804f3fb02bac9) | `` postgresql14Packages.lantern: 0.0.12 -> 0.2.0 ``                        |
| [`9ba19dd9`](https://github.com/NixOS/nixpkgs/commit/9ba19dd9fec14480c3caca2e67b913ab0554b249) | `` maintainers: update cafkafk matrix homeserver ``                        |
| [`9692775b`](https://github.com/NixOS/nixpkgs/commit/9692775b5479f0ae0d590e066253a00b1ebb36e0) | `` kodiPackages.svtplay: 5.1.12 -> 5.1.21 ``                               |
| [`a1b3b482`](https://github.com/NixOS/nixpkgs/commit/a1b3b4827801fdc801afcf2fefae1c7a89e0ce31) | `` kodiPackages.iagl: 3.0.6 -> 3.0.9 ``                                    |
| [`f86a2c60`](https://github.com/NixOS/nixpkgs/commit/f86a2c60033e75fab4ddad7052558d8cbf0e6df5) | `` kodiPackages.jellyfin: 0.7.10 -> 0.7.12 ``                              |
| [`23245398`](https://github.com/NixOS/nixpkgs/commit/23245398884ad3619e860d4d2aa43f358ed8ec69) | `` home-assistant-custom-lovelace-modules.mushroom: 3.4.0 -> 3.4.2 ``      |
| [`f96ed272`](https://github.com/NixOS/nixpkgs/commit/f96ed2726446e895a6fe8d986440d9564e83ce7c) | `` fishPlugins.forgit: 24.01.0 -> 24.02.0 ``                               |
| [`a3d47ebf`](https://github.com/NixOS/nixpkgs/commit/a3d47ebf7234b8bbbe6216bbf5104aa57c94fd46) | `` fishPlugins.done: 1.19.1 -> 1.19.2 ``                                   |
| [`a9db7786`](https://github.com/NixOS/nixpkgs/commit/a9db778648cf22419ea7b768016c74a4d8b0b69f) | `` llvmPackages_git.libcxxabi: unbreak on x86_64-darwin ``                 |
| [`e9770e52`](https://github.com/NixOS/nixpkgs/commit/e9770e52ec060b4a860d18fc6f3cfd72a7918093) | `` python312Packages.trimesh: 4.1.4 -> 4.1.5 ``                            |
| [`1bb56dc5`](https://github.com/NixOS/nixpkgs/commit/1bb56dc55e5516a284803f1ded21d97b108c66f0) | `` linux: enable CONFIG_MAC80211_MESH ``                                   |
| [`876379f8`](https://github.com/NixOS/nixpkgs/commit/876379f8831012a0fec768898f0d3ef68df16bf5) | `` python312Packages.smartypants: fix tests and regex patterns ``          |
| [`bc38c127`](https://github.com/NixOS/nixpkgs/commit/bc38c1274e359e6c4bec15c58cc85cecf2d81940) | `` python312Packages.sanic: disable failing test ``                        |
| [`544c197e`](https://github.com/NixOS/nixpkgs/commit/544c197eb80505155ceea67aac87af9f217f7310) | `` python312Packages.sip4: disable ``                                      |
| [`59ad9d60`](https://github.com/NixOS/nixpkgs/commit/59ad9d607dcb5b1bc2fcd5b13385033cb49bee51) | `` python311Packages.sip: 6.8.1 -> 6.8.3 ``                                |
| [`b055c264`](https://github.com/NixOS/nixpkgs/commit/b055c2641043c5028db00543713813d7079e882b) | `` python311Packages.openai: ignore DeprecationWarning during tests ``     |
| [`61e612ad`](https://github.com/NixOS/nixpkgs/commit/61e612ad380df17481606dc1b7eeaa8038f914ca) | `` python311Packages.asyncua: pin to pytest-asyncio 0.21 ``                |
| [`c13dadf6`](https://github.com/NixOS/nixpkgs/commit/c13dadf60c321a4768da5f01f0327250679f9940) | `` python311Packages.beartype: 0.16.4 -> 0.17.2 ``                         |
| [`de39d4da`](https://github.com/NixOS/nixpkgs/commit/de39d4da7e36637e124e844659c15887f20455c1) | `` python311Packages.zha-quirks: 0.0.111 -> 0.0.112 ``                     |
| [`820b56f1`](https://github.com/NixOS/nixpkgs/commit/820b56f17d5d9ce8e5ba0660525ac844e82fe167) | `` python312Packages.mypy: skip failing test ``                            |
| [`97dcead2`](https://github.com/NixOS/nixpkgs/commit/97dcead2631cc3a0f1232cef69b1a715d2e7a180) | `` python311Packages.param: ignore DeprecationWarning on tests ``          |
| [`3381beaf`](https://github.com/NixOS/nixpkgs/commit/3381beaf2afc92407590f0fce7108ea618754b22) | `` python311Packages.pipdeptree: 2.14.0 -> 2.15.0 ``                       |
| [`8adc7b78`](https://github.com/NixOS/nixpkgs/commit/8adc7b7875923d27c255e8fbef66b423caf8a0a7) | `` python312Packages.black: ignore DeprecationWarning during tests ``      |
| [`d5c1111c`](https://github.com/NixOS/nixpkgs/commit/d5c1111cf2d5354d5bf09c72ec508b3f2fec8031) | `` python312Packages.partd: fix build, refactor ``                         |
| [`ca63a1b8`](https://github.com/NixOS/nixpkgs/commit/ca63a1b87be6fd837af3ec20c56c2fcf3659a437) | `` python311Packages.pytest-benchmark: fix tests ``                        |
| [`ad5464de`](https://github.com/NixOS/nixpkgs/commit/ad5464deab151e4b9bc407a442116f0e2d7ff1ca) | `` vscode-extensions.moshfeu.compare-folders: init at 0.24.2 ``            |
| [`fb09dc98`](https://github.com/NixOS/nixpkgs/commit/fb09dc98ae3ac83e243ff8c2c8db82aefa7431d8) | `` python3Packages.osc-sdk-python: init at 0.27.0 (#290714) ``             |
| [`33875273`](https://github.com/NixOS/nixpkgs/commit/338752737588db77aec63cf4b737c28ed46dc338) | `` surrealdb-migrations: 1.0.1 -> 1.1.0 ``                                 |
| [`c6d343ca`](https://github.com/NixOS/nixpkgs/commit/c6d343cabd2a61d6a64b2f31ebf9306976c9e72e) | `` python312Packages.py-ecc: disable failing tests ``                      |
| [`9dfa68c2`](https://github.com/NixOS/nixpkgs/commit/9dfa68c2c3a954b540140bb4e40b0b7f0117e11a) | `` python311Packages.cloudflare: 2.19.0 -> 2.19.2 ``                       |
| [`afad2235`](https://github.com/NixOS/nixpkgs/commit/afad2235d2e1e1874439a47ef0e61ea70ac11504) | `` svndumpsanitizer: init at 2.0.7 (#282398) ``                            |
| [`7d0ac962`](https://github.com/NixOS/nixpkgs/commit/7d0ac96293b167e0f039bb93f1075d99679134de) | `` python312Packages.eth-typing: 3.2.0 -> 4.0.0 ``                         |
| [`f784710a`](https://github.com/NixOS/nixpkgs/commit/f784710a1a0c7363f79aa0fd048245af8c8a081f) | `` python312Packages.eth-utils: 2.1.1 -> 4.0.0 ``                          |
| [`cb8c1e41`](https://github.com/NixOS/nixpkgs/commit/cb8c1e4120b5552391805135044c0a3faf3f8682) | `` python311Packages.py-ecc: 6.0.0 -> 7.0.0 ``                             |
| [`edb51635`](https://github.com/NixOS/nixpkgs/commit/edb51635cc7facd3da2794284f087fae6cde6732) | `` python312Packages.spake2: fix build ``                                  |
| [`090edbf0`](https://github.com/NixOS/nixpkgs/commit/090edbf0b4f65deed315426b06c4cdb89ff8e094) | `` libretro.genesis-plus-gx: unstable-2024-02-16 -> unstable-2024-02-23 `` |
| [`baa5774f`](https://github.com/NixOS/nixpkgs/commit/baa5774f2e12a50cf3aaa4bea8f0a80a03561948) | `` gitui: 0.25.0 -> 0.25.1 ``                                              |
| [`036cf181`](https://github.com/NixOS/nixpkgs/commit/036cf1811a78cbec34f19797ab39ec15abb9f21b) | `` namespace-cli: 0.0.341 -> 0.0.345 ``                                    |
| [`34cacf41`](https://github.com/NixOS/nixpkgs/commit/34cacf41961e471c2f6ae57dd55cad7e714478a4) | `` libretro.gambatte: unstable-2024-02-09 -> unstable-2024-02-23 ``        |
| [`1becba97`](https://github.com/NixOS/nixpkgs/commit/1becba97637d66a1ede42bb9b14868d13eaafbbe) | `` python311Packages.tencentcloud-sdk-python: init at 3.0.1094 ``          |
| [`8d05bb96`](https://github.com/NixOS/nixpkgs/commit/8d05bb96ec621f77eb09cde3e5a0365bca2dfb68) | `` postgresql_jdbc: 42.6.0 -> 42.6.1 ``                                    |
| [`6c99eab8`](https://github.com/NixOS/nixpkgs/commit/6c99eab8981f77767f754209e4156c314cfae9e0) | `` files-cli: 2.12.37 -> 2.12.38 ``                                        |
| [`4e686dcf`](https://github.com/NixOS/nixpkgs/commit/4e686dcfbd778c5953467387ee4fe42f4b32e75e) | `` libretro.flycast: unstable-2024-02-09 -> unstable-2024-02-23 ``         |
| [`c29ea9fd`](https://github.com/NixOS/nixpkgs/commit/c29ea9fd7cc75c93d5b940c670f95a08269adee3) | `` zpaqfranz: 59.1 -> 59.2 ``                                              |
| [`46c8d648`](https://github.com/NixOS/nixpkgs/commit/46c8d6487a8146f0dd4889bffddc40bdfbe99930) | `` mastodon: 4.2.7 -> 4.2.8 ``                                             |
| [`1a6333bb`](https://github.com/NixOS/nixpkgs/commit/1a6333bbdeda6fe4c47ad4cd0c4b5b6d1a3ca45a) | `` python311Packages.pysaml2: 7.4.1 -> 7.5.0 ``                            |
| [`51bac09a`](https://github.com/NixOS/nixpkgs/commit/51bac09a7c2688cfd4d31f4703af6149555a1fe3) | `` wownero: fix `gcc-13` build ``                                          |
| [`6034b81a`](https://github.com/NixOS/nixpkgs/commit/6034b81ab79b5ad619a3227c47638d5db3b492e7) | `` oranda: 0.6.1 -> 0.6.2 ``                                               |
| [`782673e3`](https://github.com/NixOS/nixpkgs/commit/782673e303fc5187c9380f990bf9b6181c29e478) | `` kubelogin: 0.1.0 -> 0.1.1 ``                                            |
| [`2a1a6a98`](https://github.com/NixOS/nixpkgs/commit/2a1a6a98d906f3bbafaccb44b8267a28661fcf81) | `` python311Packages.pytelegrambotapi: 4.15.2 -> 4.16.0 ``                 |
| [`60731f27`](https://github.com/NixOS/nixpkgs/commit/60731f2750a2251cbfe9a1259eb3275a03020a3b) | `` edk2: 202311 -> 202402 ``                                               |
| [`f8385fee`](https://github.com/NixOS/nixpkgs/commit/f8385fee9b73384116d5aca2d2736a1a5ae94a10) | `` xmr-stak: mark broken ``                                                |
| [`4d4d5556`](https://github.com/NixOS/nixpkgs/commit/4d4d5556959c5188e81a801f892323545044899d) | `` api-linter: add meta.mainProgram ``                                     |
| [`440deb90`](https://github.com/NixOS/nixpkgs/commit/440deb904eaa0d4c5745f321c2f6cedda3b8750d) | `` api-linter: migrate to by-name ``                                       |
| [`41edc3e0`](https://github.com/NixOS/nixpkgs/commit/41edc3e0c3de6956b32268bfe403b6154629fa66) | `` cargo-semver-checks: 0.29.0 -> 0.29.1 ``                                |
| [`e4af5549`](https://github.com/NixOS/nixpkgs/commit/e4af5549813b6964b1c850f6a17a80ade337e6c1) | `` diswall: 0.5.0 -> 0.5.1 ``                                              |
| [`4a05fed0`](https://github.com/NixOS/nixpkgs/commit/4a05fed0b4206a772ad0bdd53894b7926eb0abba) | `` cargo-deny: 0.14.11 -> 0.14.12 ``                                       |
| [`01cbced4`](https://github.com/NixOS/nixpkgs/commit/01cbced4ef81053ad7dfada33f35527511aad724) | `` python311Packages.autobahn: use pytest-asyncio_0_21 ``                  |
| [`921f8cf9`](https://github.com/NixOS/nixpkgs/commit/921f8cf974d558efcd3a1a38c85a49c664016dec) | `` python311Packages.pytest-asyncio_0_21: init at 0.21.1 ``                |
| [`882c3fbc`](https://github.com/NixOS/nixpkgs/commit/882c3fbcaefc1c88eabb831e73dd6f3add894d34) | `` ungoogled-chromium: 121.0.6167.184-1 -> 122.0.6261.69-1 ``              |
| [`9cb5b641`](https://github.com/NixOS/nixpkgs/commit/9cb5b641fef6eeec3bc09b69677d909faede682f) | `` chromium: 122.0.6261.57 -> 122.0.6261.69 ``                             |
| [`670632a0`](https://github.com/NixOS/nixpkgs/commit/670632a0c2e68433dc731af5feb83bc7d622d569) | `` chromedriver: 122.0.6261.57 -> 122.0.6261.69 ``                         |
| [`877179c8`](https://github.com/NixOS/nixpkgs/commit/877179c89d4195b3751c53e159e8efc14d626fd9) | `` nixos/steam: add localNetworkTransfers.openFirewall option ``           |
| [`c2241c55`](https://github.com/NixOS/nixpkgs/commit/c2241c55cccda0956ba99e2ab443d29b326657fc) | `` xmrig-mo: 6.20.0-mo1 -> 6.21.0-mo2 ``                                   |