### PR TITLE
chore(flake/emacs-overlay): `299398be` -> `88cb60b6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -290,11 +290,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1708794236,
-        "narHash": "sha256-DTmyCeySQjFOuSNRUFpA2Jxkqo7bMXvSn2tXSVk3RpQ=",
+        "lastModified": 1709197479,
+        "narHash": "sha256-2+Mu5f6sru7wfAXTo21EfYlTGEo4j8ddl4LrsBiv/6A=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "299398be3c27d885cf17ff8310944b307a1449e9",
+        "rev": "88cb60b6c44861e422302371c0761a89377cf2c7",
         "type": "github"
       },
       "original": {
@@ -523,11 +523,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
+        "lastModified": 1709126324,
+        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
         "type": "github"
       },
       "original": {
@@ -1217,11 +1217,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1708702655,
-        "narHash": "sha256-qxT5jSLhelfLhQ07+AUxSTm1VnVH+hQxDkQSZ/m/Smo=",
+        "lastModified": 1709128929,
+        "narHash": "sha256-GWrv9a+AgGhG4/eI/CyVVIIygia7cEy68Huv3P8oyaw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c5101e457206dd437330d283d6626944e28794b3",
+        "rev": "c8e74c2f83fe12b4e5a8bd1abbc090575b0f7611",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`88cb60b6`](https://github.com/nix-community/emacs-overlay/commit/88cb60b6c44861e422302371c0761a89377cf2c7) | `` Updated emacs ``        |
| [`b0ff39b2`](https://github.com/nix-community/emacs-overlay/commit/b0ff39b2ecfd233a8117dd95dd1b1bfd926714ae) | `` Updated melpa ``        |
| [`f0b399a4`](https://github.com/nix-community/emacs-overlay/commit/f0b399a48ad970fbaabb0a171b103b066285054c) | `` Updated flake inputs `` |
| [`a9db0bff`](https://github.com/nix-community/emacs-overlay/commit/a9db0bffddf142648d9fc5be615dbc246d589296) | `` Updated emacs ``        |
| [`7854b1de`](https://github.com/nix-community/emacs-overlay/commit/7854b1dee71f6bab443ed2b96c962f63cc409cdb) | `` Updated melpa ``        |
| [`c1da8cd5`](https://github.com/nix-community/emacs-overlay/commit/c1da8cd5719b0ef18fec8deea705cc77504f9217) | `` Updated elpa ``         |
| [`d80b2213`](https://github.com/nix-community/emacs-overlay/commit/d80b22132b8ea17707f87220b3518d9de200b599) | `` Updated flake inputs `` |
| [`8c56baa0`](https://github.com/nix-community/emacs-overlay/commit/8c56baa0e5ba4bbf9947605a31672e2f4735b1a9) | `` Updated emacs ``        |
| [`0e8baab3`](https://github.com/nix-community/emacs-overlay/commit/0e8baab3c80e696600dfcc6a673c399a8c339e68) | `` Updated melpa ``        |
| [`678a4feb`](https://github.com/nix-community/emacs-overlay/commit/678a4febfec7ae6900d54a2bab7db41a55aeacd6) | `` Updated elpa ``         |
| [`4719c864`](https://github.com/nix-community/emacs-overlay/commit/4719c864b381b19dcacf7f720be3ee8a96a62da5) | `` Updated flake inputs `` |
| [`119523b8`](https://github.com/nix-community/emacs-overlay/commit/119523b8931aaad7648e1e42fe653f66a9b5ee21) | `` Updated emacs ``        |
| [`2dc1cb18`](https://github.com/nix-community/emacs-overlay/commit/2dc1cb1830ec2d802a74aa0338fe39fd082b4348) | `` Updated melpa ``        |
| [`84fdcde6`](https://github.com/nix-community/emacs-overlay/commit/84fdcde68b7b07761b69d5a416b66ed61dcfb23c) | `` Updated melpa ``        |
| [`d220ffb9`](https://github.com/nix-community/emacs-overlay/commit/d220ffb9f6ae2708cfd6179f7dd9d6502f220a39) | `` Updated elpa ``         |
| [`fb25df62`](https://github.com/nix-community/emacs-overlay/commit/fb25df62dc98426dd4d97f871332ab579db70a02) | `` Updated flake inputs `` |
| [`cc3baade`](https://github.com/nix-community/emacs-overlay/commit/cc3baadef2a6e417cff991253f741b7726836649) | `` Updated emacs ``        |
| [`aa54c73c`](https://github.com/nix-community/emacs-overlay/commit/aa54c73cba1e6fed697f72c6d823df229116be41) | `` Updated melpa ``        |
| [`3e9c83ab`](https://github.com/nix-community/emacs-overlay/commit/3e9c83abe98d2846f96a01afa313010a0f82e775) | `` Updated elpa ``         |
| [`a00d13fb`](https://github.com/nix-community/emacs-overlay/commit/a00d13fb01ea97b39d558bda561955ccf4d0aaee) | `` Updated nongnu ``       |
| [`c94a9019`](https://github.com/nix-community/emacs-overlay/commit/c94a9019370b0d719621e1478d5bb317223ec15b) | `` Updated emacs ``        |
| [`c70c2e2a`](https://github.com/nix-community/emacs-overlay/commit/c70c2e2ac3b0b8f4f194cbd34115c65a033adefd) | `` Updated melpa ``        |
| [`2dee8f65`](https://github.com/nix-community/emacs-overlay/commit/2dee8f65405e0445d7178531e79a45b6fecfab92) | `` Updated emacs ``        |
| [`759e91c6`](https://github.com/nix-community/emacs-overlay/commit/759e91c65bad01974b7514a2905365bc04a115b4) | `` Updated melpa ``        |
| [`fdc34eab`](https://github.com/nix-community/emacs-overlay/commit/fdc34eabbe59ffe5e935fcb53a40996fc4e46958) | `` Updated elpa ``         |
| [`25081a86`](https://github.com/nix-community/emacs-overlay/commit/25081a866d8e2efeaa5407ee658051c140a63dd1) | `` Updated nongnu ``       |
| [`f6a1a96f`](https://github.com/nix-community/emacs-overlay/commit/f6a1a96f834d3d7936a768472d09006cc18d62d2) | `` Updated melpa ``        |
| [`fd86f754`](https://github.com/nix-community/emacs-overlay/commit/fd86f7540e1b446f3646906b7ee3cfdb4d8702d1) | `` Updated emacs ``        |
| [`17580f47`](https://github.com/nix-community/emacs-overlay/commit/17580f47433324e6e0a7a136103a3da9fd1c4749) | `` Updated elpa ``         |
| [`dc68b375`](https://github.com/nix-community/emacs-overlay/commit/dc68b375c2733198f642804a3cfacab5ede99761) | `` Updated emacs ``        |
| [`091bfb2b`](https://github.com/nix-community/emacs-overlay/commit/091bfb2bf49d1c4aa31ff070ba17ed0cebca7f94) | `` Updated melpa ``        |
| [`a31b5c4d`](https://github.com/nix-community/emacs-overlay/commit/a31b5c4d51ff2e400453aceea4b81a4a066eca79) | `` Updated emacs ``        |
| [`255453a9`](https://github.com/nix-community/emacs-overlay/commit/255453a988380977c0df4eb2149434ee26151aaf) | `` Updated melpa ``        |
| [`a33b5055`](https://github.com/nix-community/emacs-overlay/commit/a33b5055039d7e575203ea63f9e194b141bf1231) | `` Updated elpa ``         |
| [`5f4a570f`](https://github.com/nix-community/emacs-overlay/commit/5f4a570f269fc26a704eccb796f5c59e4aaa96d3) | `` Updated flake inputs `` |
| [`482ea123`](https://github.com/nix-community/emacs-overlay/commit/482ea12373e83482e9a37113908cb947980cf8aa) | `` Updated emacs ``        |
| [`8bd96b59`](https://github.com/nix-community/emacs-overlay/commit/8bd96b59c634cb8fd2cf7528a81be84d0779b0df) | `` Updated melpa ``        |
| [`fd78fc83`](https://github.com/nix-community/emacs-overlay/commit/fd78fc83959ee842d637871a046027ec4c69f194) | `` Updated elpa ``         |
| [`16b8c77f`](https://github.com/nix-community/emacs-overlay/commit/16b8c77f0c2f8ba9acdb1284b784aa0490e4d86e) | `` Updated flake inputs `` |
| [`42b8b4a5`](https://github.com/nix-community/emacs-overlay/commit/42b8b4a59edbd70550ebc96e95c9258dbdefd753) | `` Updated emacs ``        |
| [`0a1a15af`](https://github.com/nix-community/emacs-overlay/commit/0a1a15afc03b1a48662ac62879b1918ec11289e2) | `` Updated melpa ``        |
| [`f42e044d`](https://github.com/nix-community/emacs-overlay/commit/f42e044d8eae9e0da1a00afa79d411765c757648) | `` Updated emacs ``        |
| [`47070af1`](https://github.com/nix-community/emacs-overlay/commit/47070af18d262bd7a84f55c8e2b5108eae7d1de9) | `` Updated melpa ``        |
| [`c9356ad5`](https://github.com/nix-community/emacs-overlay/commit/c9356ad50ab78e0ac6eec0505cbdd3685427cee4) | `` Updated elpa ``         |