### PR TITLE
chore(flake/hyprland): `f534ac3f` -> `b39dcfa4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -703,11 +703,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1708817736,
-        "narHash": "sha256-GZEoru+4uNIGEZ8j1TPaxZwM+ApIngHU/iX3sIGgUO4=",
+        "lastModified": 1709211818,
+        "narHash": "sha256-KQhRS30corMberlHhcs9i3TlSoEnz9Or009yJgmNk/k=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "f534ac3fc462d8af923d2a1ab8ef58f62639a1ea",
+        "rev": "b39dcfa497f84486569bf862092dfcfadbfd8747",
         "type": "github"
       },
       "original": {
@@ -753,11 +753,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708681732,
-        "narHash": "sha256-ULZZLZ9C33G13IaXLuAc4oTzHUvnATI8Fj2u6gzMfT0=",
+        "lastModified": 1708787654,
+        "narHash": "sha256-7ACgM3ZuAhPqurXHUvR2nWMRcnmzGGPjLK6q4DSTelI=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "f4466367ef0a92a6425d482050dc2b8840c0e644",
+        "rev": "0fce791ba2334aca183f2ed42399518947550d0d",
         "type": "github"
       },
       "original": {
@@ -1249,11 +1249,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1708475490,
-        "narHash": "sha256-g1v0TsWBQPX97ziznfJdWhgMyMGtoBFs102xSYO4syU=",
+        "lastModified": 1708807242,
+        "narHash": "sha256-sRTRkhMD4delO/hPxxi+XwLqPn8BuUq6nnj4JqLwOu0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0e74ca98a74bc7270d28838369593635a5db3260",
+        "rev": "73de017ef2d18a04ac4bfd0c02650007ccb31c2a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                        |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
| [`b39dcfa4`](https://github.com/hyprwm/Hyprland/commit/b39dcfa497f84486569bf862092dfcfadbfd8747) | `` refactor: move a few things to desktop/ ``                                                  |
| [`4bff762d`](https://github.com/hyprwm/Hyprland/commit/4bff762d9733ba7334cd37b995cf51552cc80be0) | `` xwaylandmgr: don't read xwayland surface from unmapped xwayland ``                          |
| [`b1c0f1cc`](https://github.com/hyprwm/Hyprland/commit/b1c0f1cc018d13ac1e5ebccaade5528ec757bd74) | `` subsurface: Rewrite the subsurface tree (#4877) ``                                          |
| [`1e7eb3a5`](https://github.com/hyprwm/Hyprland/commit/1e7eb3a5a5419f97b61a3403880b161c85dd7b17) | `` xdg: check for floating conditions before sending tiled size hint ``                        |
| [`097f561e`](https://github.com/hyprwm/Hyprland/commit/097f561e41e5660333492c1f188199e837742efe) | `` surfacetree: Revert "subsurfaceTree: assign surfaces to a CWLSurface" ``                    |
| [`a31433c2`](https://github.com/hyprwm/Hyprland/commit/a31433c21511df93e59b1e5b167723a0d2ee2c52) | `` renderer: damage whole ring on failed commit ``                                             |
| [`51b1b17f`](https://github.com/hyprwm/Hyprland/commit/51b1b17fcbb6c13667710a6bebac1003a5231bd2) | `` subsurfaceTree: assign surfaces to a CWLSurface ``                                          |
| [`29cdd7de`](https://github.com/hyprwm/Hyprland/commit/29cdd7de1f8d99462915540569fbe54f10f609f4) | `` layers: minor fixes for new animations ``                                                   |
| [`4bc669f9`](https://github.com/hyprwm/Hyprland/commit/4bc669f9331bb66ab30bd705d09f1239bc3e83ed) | `` layers: add fully featured animations ``                                                    |
| [`f4f3aa2e`](https://github.com/hyprwm/Hyprland/commit/f4f3aa2e505ca1b22688fb4a32f31c4bfb851dd0) | `` layout: add size prediction for initial xdg commits ``                                      |
| [`c198d744`](https://github.com/hyprwm/Hyprland/commit/c198d744b77f272c2fc187eb6d431580a99ab6c3) | `` keybinds: unconstrain mouse on focusmonitor and cyclenext (#4863) ``                        |
| [`1c460e98`](https://github.com/hyprwm/Hyprland/commit/1c460e98f870676b15871fe4e5bfeb1a32a3d6d8) | `` props: bump ver to 0.36.0 ``                                                                |
| [`489ac40a`](https://github.com/hyprwm/Hyprland/commit/489ac40abd7b3ae037e1681ee92bbef9d981a29c) | `` config: Add option to resolve keybinds by sym instead of code (#4851) ``                    |
| [`e3373669`](https://github.com/hyprwm/Hyprland/commit/e3373669e5544c3f18cf1edcd8fcfff9c6222f5c) | `` wayland: implement keyboard_shortcuts_inhibit_v1 ``                                         |
| [`f26d7aa5`](https://github.com/hyprwm/Hyprland/commit/f26d7aa58d78e764871ff026fb78f4322f0a6879) | `` config: add defaultName for workspace rules ``                                              |
| [`e2c28654`](https://github.com/hyprwm/Hyprland/commit/e2c286548d2a83376df3001bab0b48e529bd0075) | `` avar: return curve value of 1 when not animated ``                                          |
| [`60f81b8a`](https://github.com/hyprwm/Hyprland/commit/60f81b8a23d3d18fc0e57ca56eadbce6facb27ee) | `` input: Map touch devices and tablets bound to an output (#3544) ``                          |
| [`98034fea`](https://github.com/hyprwm/Hyprland/commit/98034fea3c1d5c1836bcc3b523cf1089dd5ac502) | `` screencopy: send full frame damage ``                                                       |
| [`21f7f32d`](https://github.com/hyprwm/Hyprland/commit/21f7f32dc98521025cea76e530204ea64f2630f0) | `` screencopy: avoid dangling client ptrs on client destroy ``                                 |
| [`ffd72172`](https://github.com/hyprwm/Hyprland/commit/ffd721724392a565d2a45ea0f82d80530129f25a) | `` IME: don't set modifiers on grab destroy ``                                                 |
| [`bc3f5b94`](https://github.com/hyprwm/Hyprland/commit/bc3f5b94eb55b5538540942dd1dc676a7d757d6d) | `` core: nullcheck for old monitor in moveWorkspaceToMonitor ``                                |
| [`f7a34534`](https://github.com/hyprwm/Hyprland/commit/f7a34534873bf499fc1a04a5fa25ada03c4ee415) | `` socket2: move to the wayland event loop ``                                                  |
| [`1742605e`](https://github.com/hyprwm/Hyprland/commit/1742605eb89b17d04d807dfb1a21ac0deb3a945c) | `` keybinds: fix movewindoworgroup onto empy workspace on next monitor (#4486) ``              |
| [`81fe2ae7`](https://github.com/hyprwm/Hyprland/commit/81fe2ae7f1da7578ac5208158c5bbc4d079effa3) | `` surface: ensure global pointers valid before using in destructor (#4844) ``                 |
| [`dfcfb92e`](https://github.com/hyprwm/Hyprland/commit/dfcfb92ec611345848f3840d34d66b8501e6367c) | `` renderer: take into account fading out windows in solitary recheck ``                       |
| [`98154020`](https://github.com/hyprwm/Hyprland/commit/981540207490f402d1382eb3df149ece6db8b809) | `` keybinds: focus floating on top of fs ``                                                    |
| [`a14f6b57`](https://github.com/hyprwm/Hyprland/commit/a14f6b570f7dc99d81db1a8cccbae986c3f98f64) | `` keybinds: fix focuswindow for fullscreen (#4840) ``                                         |
| [`7f35bff7`](https://github.com/hyprwm/Hyprland/commit/7f35bff7203909adaa279c56ce2d84c957377568) | `` [gha] Nix: update inputs ``                                                                 |
| [`54a83299`](https://github.com/hyprwm/Hyprland/commit/54a8329936d31537411c7a1a4d1815820b98316a) | `` layout: Fixed ghost window when opened while fullscreen on a different workspace (#4822) `` |
| [`f9cfec8a`](https://github.com/hyprwm/Hyprland/commit/f9cfec8abb9033e14f558fc2dc24dfa1c2a51e5a) | `` compositor: allow source monitor to be provided to `getMonitorInDirection` (#4837) ``       |