### PR TITLE
chore(flake/treefmt-nix): `36fd6923` -> `e497a9dd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1645,11 +1645,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708681819,
-        "narHash": "sha256-+YIvy0dDZw8KIFVPS9i+mTHf2RqSJ0+dBB9AXBvDTks=",
+        "lastModified": 1708897213,
+        "narHash": "sha256-QECZB+Hgz/2F/8lWvHNk05N6NU/rD9bWzuNn6Cv8oUk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "36fd6923c122a983bc3915692e6cb3ff341ef083",
+        "rev": "e497a9ddecff769c2a7cbab51e1ed7a8501e7a3a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                |
| ---------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`e497a9dd`](https://github.com/numtide/treefmt-nix/commit/e497a9ddecff769c2a7cbab51e1ed7a8501e7a3a) | `` feat(programs): add templ (#161) `` |