### PR TITLE
chore(flake/nur): `192aa9b1` -> `74be1009`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1343,11 +1343,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1708818247,
-        "narHash": "sha256-op6sluExBoA6Y3FdeHtDINEWCXzns4jg2H+xfkjikuI=",
+        "lastModified": 1709211057,
+        "narHash": "sha256-Bd+pOFvVxfiF5LbLq4RsuhCAP++gPhv2g9vm+7+TYqY=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "192aa9b134f867b6811ecd0444e994ef941648db",
+        "rev": "74be1009198dc18d3c974d85f7660e6e6c1c8184",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                            |
| -------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`74be1009`](https://github.com/nix-community/NUR/commit/74be1009198dc18d3c974d85f7660e6e6c1c8184) | `` automatic update ``             |
| [`0168a848`](https://github.com/nix-community/NUR/commit/0168a84850c8770adb26fd4bf8a3b4bf9103932a) | `` automatic update ``             |
| [`fbe8df1c`](https://github.com/nix-community/NUR/commit/fbe8df1c13fd8e63e35c2c4654104661eb1fbbed) | `` automatic update ``             |
| [`2b3b8752`](https://github.com/nix-community/NUR/commit/2b3b8752d1bd83b66b38163685f686ba8f3d1924) | `` automatic update ``             |
| [`7975ad51`](https://github.com/nix-community/NUR/commit/7975ad514763c1f05ff4f61dda641adaf1efbab0) | `` automatic update ``             |
| [`6823c94a`](https://github.com/nix-community/NUR/commit/6823c94afb3a35e71414c6fcab276b1b5a3662a7) | `` automatic update ``             |
| [`40f4664d`](https://github.com/nix-community/NUR/commit/40f4664dfa27f5b5c938a01660d63a1bdecde35f) | `` automatic update ``             |
| [`fde0f4f3`](https://github.com/nix-community/NUR/commit/fde0f4f35ebf2ed4d0308d84087f875f913e97a6) | `` automatic update ``             |
| [`72ee76e3`](https://github.com/nix-community/NUR/commit/72ee76e356013f2ff5516aaa9d7276466bad6aed) | `` automatic update ``             |
| [`10c14d98`](https://github.com/nix-community/NUR/commit/10c14d9853b0286711d63fe0ecdeefebd53c5d94) | `` automatic update ``             |
| [`390e8cf9`](https://github.com/nix-community/NUR/commit/390e8cf9e5280fec60624737618bb0f6dbf99bb6) | `` automatic update ``             |
| [`c908e030`](https://github.com/nix-community/NUR/commit/c908e0303b21d92daf63c3a4241126fd9d93d01d) | `` automatic update ``             |
| [`ca5f207f`](https://github.com/nix-community/NUR/commit/ca5f207f80b8782de0552e7182f76414c5cd7c23) | `` automatic update ``             |
| [`fa6c40d5`](https://github.com/nix-community/NUR/commit/fa6c40d5b94adc81bb61c5561d188c5866f8bce8) | `` automatic update ``             |
| [`8495ff48`](https://github.com/nix-community/NUR/commit/8495ff48e2699a6b679878774396092f37e0e331) | `` automatic update ``             |
| [`d8a664be`](https://github.com/nix-community/NUR/commit/d8a664bee9fbd87836e983e301d0513dd9f279c1) | `` automatic update ``             |
| [`4bd6f5cb`](https://github.com/nix-community/NUR/commit/4bd6f5cb15e23013cd8cdc6aa10dcf8ce3dc8609) | `` automatic update ``             |
| [`2779c60a`](https://github.com/nix-community/NUR/commit/2779c60a9cb1188359ae97ec0c1c8042d04eb20f) | `` automatic update ``             |
| [`23341250`](https://github.com/nix-community/NUR/commit/23341250077c28dd4c0cdc83a4cf59dd3a27d9ac) | `` automatic update ``             |
| [`29baed9c`](https://github.com/nix-community/NUR/commit/29baed9ccb889e9bb0eaf51dab3a5fcdd247d3e7) | `` automatic update ``             |
| [`fc9e8ef9`](https://github.com/nix-community/NUR/commit/fc9e8ef9cea57baa3669766b78e3236207df39ba) | `` automatic update ``             |
| [`a6e5afae`](https://github.com/nix-community/NUR/commit/a6e5afae495cf1dd3dcd1d89c672885fc5eb2688) | `` automatic update ``             |
| [`1bf10717`](https://github.com/nix-community/NUR/commit/1bf10717adfd557fe76165fcc7be830398f859e3) | `` automatic update ``             |
| [`02e10290`](https://github.com/nix-community/NUR/commit/02e102900bc348f79757dd80154c59cc25d6a790) | `` automatic update ``             |
| [`c82f190b`](https://github.com/nix-community/NUR/commit/c82f190b6cc61639fce2c4d4b303d7d8ab9f04bc) | `` automatic update ``             |
| [`342e550a`](https://github.com/nix-community/NUR/commit/342e550a2ca6c50564d30cab76c27fb9342fca9f) | `` automatic update ``             |
| [`35e7560d`](https://github.com/nix-community/NUR/commit/35e7560db72c0c948af2738c1f54e7e3b06f9e56) | `` automatic update ``             |
| [`516f71ad`](https://github.com/nix-community/NUR/commit/516f71ad79219fb882027f4ce9bfe1f700db0863) | `` automatic update ``             |
| [`7afc7905`](https://github.com/nix-community/NUR/commit/7afc790502560fc0e4897a1fe996865185bcff69) | `` automatic update ``             |
| [`62aa1985`](https://github.com/nix-community/NUR/commit/62aa1985c7e5fe6f2246eabd345619c288dd30f7) | `` automatic update ``             |
| [`fc48817f`](https://github.com/nix-community/NUR/commit/fc48817f24a90cc4bfece1f70252051b028368ff) | `` automatic update ``             |
| [`369aad59`](https://github.com/nix-community/NUR/commit/369aad59c996fe9de023d0f7d9e462c85da65339) | `` automatic update ``             |
| [`01d877e5`](https://github.com/nix-community/NUR/commit/01d877e55d2113ab72bb5fbb66dc9c53c80c1024) | `` automatic update ``             |
| [`a143c335`](https://github.com/nix-community/NUR/commit/a143c335d8516e7fb7536e98b38944b9d337167f) | `` automatic update ``             |
| [`cda46f8b`](https://github.com/nix-community/NUR/commit/cda46f8ba81f533ebff2a90db89364c6237fbc52) | `` automatic update ``             |
| [`2aa19247`](https://github.com/nix-community/NUR/commit/2aa19247aeafc2a24c6900bdb7d717624f3d123d) | `` automatic update ``             |
| [`7ad26a18`](https://github.com/nix-community/NUR/commit/7ad26a18580a690e3e0c71d023520bbc1e06f0b0) | `` automatic update ``             |
| [`ba8d6464`](https://github.com/nix-community/NUR/commit/ba8d6464499d8a05b91c715ba850e1b3ca2b3a2c) | `` automatic update ``             |
| [`1eba323f`](https://github.com/nix-community/NUR/commit/1eba323f8f599701fc07fcb62ab60d681330a084) | `` automatic update ``             |
| [`7c521252`](https://github.com/nix-community/NUR/commit/7c5212524ec49bf659dd8e5b7de572f03f27fc9f) | `` automatic update ``             |
| [`5bcb1e79`](https://github.com/nix-community/NUR/commit/5bcb1e798d578b41ad62b86416b574ca97454d79) | `` automatic update ``             |
| [`5434c62e`](https://github.com/nix-community/NUR/commit/5434c62e9f06f38a1b60affe7012dc4498bb6c94) | `` automatic update ``             |
| [`1ecfd53f`](https://github.com/nix-community/NUR/commit/1ecfd53fed16ad1ac971cf4cbfa89f44a7683fbd) | `` automatic update ``             |
| [`4e6f7a80`](https://github.com/nix-community/NUR/commit/4e6f7a809b8efb65c591043923213d82521d3fc5) | `` automatic update ``             |
| [`8f4c569c`](https://github.com/nix-community/NUR/commit/8f4c569c132e4b20eac909ec30c650e436ac5574) | `` automatic update ``             |
| [`50c9ffc8`](https://github.com/nix-community/NUR/commit/50c9ffc84902256dc6d095a0dddb0d9cb69b4938) | `` automatic update ``             |
| [`016ff0e6`](https://github.com/nix-community/NUR/commit/016ff0e6f2448d76aef5337ad25bb5f7b0f5ed45) | `` automatic update ``             |
| [`8860cc9b`](https://github.com/nix-community/NUR/commit/8860cc9b5dfc855f648c5b8d47f23a0d456d4869) | `` automatic update ``             |
| [`050fba32`](https://github.com/nix-community/NUR/commit/050fba3242dfec4f41ce7942b75100b84cb48247) | `` automatic update ``             |
| [`4f7da707`](https://github.com/nix-community/NUR/commit/4f7da7070f59ac7be0dba7190e36e19cd46ad960) | `` automatic update ``             |
| [`db349576`](https://github.com/nix-community/NUR/commit/db349576a93c04796f3ccc86bd2f2102e3b3dfc0) | `` automatic update ``             |
| [`6e33d820`](https://github.com/nix-community/NUR/commit/6e33d820cf579ffc04066aeefcb06648ce5e3286) | `` automatic update ``             |
| [`202caf5f`](https://github.com/nix-community/NUR/commit/202caf5f54797187056eb542841264fdcc69278f) | `` automatic update ``             |
| [`8370645b`](https://github.com/nix-community/NUR/commit/8370645b84697e2bfe7fbb917f7346e553beb2b6) | `` automatic update ``             |
| [`c21175ec`](https://github.com/nix-community/NUR/commit/c21175ecb82aa84a5714547b30106f70ac11efaf) | `` automatic update ``             |
| [`8aed89d9`](https://github.com/nix-community/NUR/commit/8aed89d9ee195307e8b62f7b1ac169b0b5f13899) | `` automatic update ``             |
| [`b2a437c8`](https://github.com/nix-community/NUR/commit/b2a437c84e7af787459ced8d94737f20456f42a6) | `` automatic update ``             |
| [`4d6b3ba0`](https://github.com/nix-community/NUR/commit/4d6b3ba0fee3c75f8842e4e1c8945aaa24ca1823) | `` automatic update ``             |
| [`07246215`](https://github.com/nix-community/NUR/commit/0724621598e2a1849b934f4f38f64519bb1cf0ec) | `` automatic update ``             |
| [`1a8c4eda`](https://github.com/nix-community/NUR/commit/1a8c4eda55d24a097271d89ba9eb8681e650c029) | `` automatic update ``             |
| [`ad8cd957`](https://github.com/nix-community/NUR/commit/ad8cd957b3a11da615e092e517c22be0179966b1) | `` automatic update ``             |
| [`ba27e577`](https://github.com/nix-community/NUR/commit/ba27e5779f132762e94fb77b598aee0cda693466) | `` add Educorreia932 repository `` |
| [`facd37dc`](https://github.com/nix-community/NUR/commit/facd37dc8ed65a8bda15f8bff223c6bbc8265628) | `` automatic update ``             |
| [`79c79825`](https://github.com/nix-community/NUR/commit/79c7982504e4a36b3e0c9091e60a6241a309dd16) | `` add nousefreak repository ``    |
| [`c086b70f`](https://github.com/nix-community/NUR/commit/c086b70fd169a837cfb17615810b3785540ca298) | `` automatic update ``             |
| [`07b39287`](https://github.com/nix-community/NUR/commit/07b39287302f01fa0f389830e8241dc1f2e7da78) | `` add guanran928 repository ``    |
| [`6ec9b716`](https://github.com/nix-community/NUR/commit/6ec9b716040e4a3701ac1e0807e450ede7606177) | `` automatic update ``             |
| [`bac24373`](https://github.com/nix-community/NUR/commit/bac24373cde80987b895dc80da7b22262a715c0d) | `` automatic update ``             |
| [`053ea69d`](https://github.com/nix-community/NUR/commit/053ea69d454c1f9a72f0b0250dc98f42e5a02ea1) | `` automatic update ``             |
| [`870c1879`](https://github.com/nix-community/NUR/commit/870c1879a3b277c16b7ed483edbce8e9fc6f1b80) | `` automatic update ``             |
| [`0ff6d565`](https://github.com/nix-community/NUR/commit/0ff6d565aa7b176c964777e0675df38f2b66a2e9) | `` automatic update ``             |
| [`36121729`](https://github.com/nix-community/NUR/commit/3612172937c01525cc14646aea107cc764ed5cb2) | `` automatic update ``             |
| [`cdb259ad`](https://github.com/nix-community/NUR/commit/cdb259ad397fa9e087bbe75c180b11972504b508) | `` automatic update ``             |
| [`67f12457`](https://github.com/nix-community/NUR/commit/67f124575c14b4aa0d565d5f248d82350625209c) | `` automatic update ``             |
| [`4b831266`](https://github.com/nix-community/NUR/commit/4b8312664c01d20da6b27627b3690a99ee2b6d86) | `` automatic update ``             |
| [`2e171de7`](https://github.com/nix-community/NUR/commit/2e171de74cc6b1eba87485afd001dc37a5fbb3b7) | `` automatic update ``             |
| [`9ad94435`](https://github.com/nix-community/NUR/commit/9ad944357c8e4af38264c99bd8d988a48cdf7597) | `` automatic update ``             |
| [`e0c1ab7b`](https://github.com/nix-community/NUR/commit/e0c1ab7bea5b4cc584de7fc0073000a1fc5079dd) | `` automatic update ``             |
| [`7e02cdc2`](https://github.com/nix-community/NUR/commit/7e02cdc204d068e429e8d864933379e4665da52f) | `` automatic update ``             |
| [`7d6c7813`](https://github.com/nix-community/NUR/commit/7d6c781342f58e0d8fdb281f2abc238b1aa38e5c) | `` automatic update ``             |
| [`b54e6ceb`](https://github.com/nix-community/NUR/commit/b54e6ceb1036361636218767115d204c06799aca) | `` automatic update ``             |
| [`dc3adf0b`](https://github.com/nix-community/NUR/commit/dc3adf0b8f3d2df76fe0b500901b2f24ebc0039e) | `` automatic update ``             |
| [`213b98be`](https://github.com/nix-community/NUR/commit/213b98be1ba8adb0ac3b89efd1bf7ec571301a32) | `` automatic update ``             |
| [`5396ce87`](https://github.com/nix-community/NUR/commit/5396ce87ee01074a6491d6207587c6eac52cd56e) | `` automatic update ``             |
| [`1fe352ab`](https://github.com/nix-community/NUR/commit/1fe352ab8a7560c8bbd793852c52979894a7705e) | `` automatic update ``             |
| [`78c9459d`](https://github.com/nix-community/NUR/commit/78c9459d2ca2194a6f9a7d676390c6912a7e0704) | `` automatic update ``             |
| [`2b881bb2`](https://github.com/nix-community/NUR/commit/2b881bb2d0853c61f207f9486099d923dae10a75) | `` automatic update ``             |
| [`7c776517`](https://github.com/nix-community/NUR/commit/7c77651728ecfa2188e8c7eec34a1646567362d2) | `` automatic update ``             |
| [`ab92c5c6`](https://github.com/nix-community/NUR/commit/ab92c5c64ef62f5e80144fe681dc1e97d54cac60) | `` automatic update ``             |
| [`834687f6`](https://github.com/nix-community/NUR/commit/834687f661d7083626a2481ba1c7f8eeae98244c) | `` automatic update ``             |
| [`02f95dc0`](https://github.com/nix-community/NUR/commit/02f95dc07523e444691aca63243ce1660c1937fa) | `` automatic update ``             |
| [`1a8f1350`](https://github.com/nix-community/NUR/commit/1a8f13501baaa98a17387c742bf0a13e53ae974c) | `` automatic update ``             |
| [`408fe763`](https://github.com/nix-community/NUR/commit/408fe76319f64a9395291e71879b85f34428d46c) | `` automatic update ``             |
| [`d0aeb622`](https://github.com/nix-community/NUR/commit/d0aeb622bd4baa0d645abb68930eec2b88654a01) | `` automatic update ``             |
| [`e38c20f5`](https://github.com/nix-community/NUR/commit/e38c20f50c537690d8e40c22eab80c65ad6f634a) | `` automatic update ``             |
| [`46eb23f6`](https://github.com/nix-community/NUR/commit/46eb23f6c3724da2c4fc62968663b3063987be3d) | `` automatic update ``             |
| [`be8e5dc5`](https://github.com/nix-community/NUR/commit/be8e5dc50940ca6a2e94a7edaf151ef056816df9) | `` automatic update ``             |
| [`d825643f`](https://github.com/nix-community/NUR/commit/d825643f7c47eedc0e27abe716df7d3fe7a9182b) | `` automatic update ``             |
| [`a1b32783`](https://github.com/nix-community/NUR/commit/a1b327833d80c8210e03a8ca20a53ee7fc5e676a) | `` automatic update ``             |
| [`51b5dfc6`](https://github.com/nix-community/NUR/commit/51b5dfc67df3a2815c354d8faeadc872f2d7ee9d) | `` automatic update ``             |
| [`6298f9ef`](https://github.com/nix-community/NUR/commit/6298f9ef11374cd702f19e989eaed2f088066e4f) | `` automatic update ``             |
| [`373f4c4b`](https://github.com/nix-community/NUR/commit/373f4c4b272bbfdfa1bfd74dc9b3fdaa36801033) | `` automatic update ``             |
| [`e87cad65`](https://github.com/nix-community/NUR/commit/e87cad65ed138017180bb0d0b9164d2cdca80585) | `` automatic update ``             |
| [`d7d9902a`](https://github.com/nix-community/NUR/commit/d7d9902aeda4c7c46ecd8978fb5aec59dcd12d34) | `` automatic update ``             |
| [`442c6e5b`](https://github.com/nix-community/NUR/commit/442c6e5b2038f4abd4e89fa6bb46c9122e75be7b) | `` automatic update ``             |
| [`9549d87f`](https://github.com/nix-community/NUR/commit/9549d87f2cddc0579c67443e4ee6a95ea1da6380) | `` automatic update ``             |
| [`4a78ac86`](https://github.com/nix-community/NUR/commit/4a78ac8656d2461d8873554950b53f698c2a6cb6) | `` automatic update ``             |
| [`d4cff0d9`](https://github.com/nix-community/NUR/commit/d4cff0d91d9e8bc38c0d2446a0617eea68ea0d17) | `` automatic update ``             |