### PR TITLE
chore(flake/spicetify-nix): `dc12e982` -> `268610a4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1520,11 +1520,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708747934,
-        "narHash": "sha256-yfdQZYjxvkjwVF3Fl4CmJv2l/f4uk49x1EcI9iRCyBk=",
+        "lastModified": 1709179807,
+        "narHash": "sha256-zfKcBQ6zxMwC9GOkcRqAbEAsrKbydo6FEzlk7r9XLS0=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "dc12e982d81512e658d9ca4e30cdf5b846a8c160",
+        "rev": "268610a47b78b83d6c0307b6781b0e61331e6200",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`268610a4`](https://github.com/Gerg-L/spicetify-nix/commit/268610a47b78b83d6c0307b6781b0e61331e6200) | `` CI update 2024-02-29 (#86) `` |
| [`67638711`](https://github.com/Gerg-L/spicetify-nix/commit/676387119739497bed69297a35cbdc0261951488) | `` -2 LoC ``                     |
| [`89d01a38`](https://github.com/Gerg-L/spicetify-nix/commit/89d01a38bc36d8f091d053f6efca0409d92da6eb) | `` CI update 2024-02-28 (#85) `` |
| [`9e9d400e`](https://github.com/Gerg-L/spicetify-nix/commit/9e9d400e92b479495f55916a11a69f11a22862af) | `` CI update 2024-02-27 (#84) `` |
| [`c67ffcbe`](https://github.com/Gerg-L/spicetify-nix/commit/c67ffcbe1314de6ef1437f261f623c9666f8b01a) | `` CI update 2024-02-26 (#83) `` |
| [`a492d9df`](https://github.com/Gerg-L/spicetify-nix/commit/a492d9dfa9277fc06b0011f8566b805ddc03a992) | `` CI update 2024-02-25 (#82) `` |