### PR TITLE
chore(flake/home-manager): `4ee704cb` -> `2f336776`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -680,11 +680,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708806879,
-        "narHash": "sha256-MSbxtF3RThI8ANs/G4o1zIqF5/XlShHvwjl9Ws0QAbI=",
+        "lastModified": 1709204054,
+        "narHash": "sha256-U1idK0JHs1XOfSI1APYuXi4AEADf+B+ZU4Wifc0pBHk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "4ee704cb13a5a7645436f400b9acc89a67b9c08a",
+        "rev": "2f3367769a93b226c467551315e9e270c3f78b15",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                             |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`2f336776`](https://github.com/nix-community/home-manager/commit/2f3367769a93b226c467551315e9e270c3f78b15) | `` Translate using Weblate (Portuguese (Brazil)) `` |
| [`ecfffe36`](https://github.com/nix-community/home-manager/commit/ecfffe363102f2c95bed6576465504c6a57bf8fe) | `` river: fix systemd activation (#5055) ``         |
| [`1d085ea4`](https://github.com/nix-community/home-manager/commit/1d085ea4444d26aa52297758b333b449b2aa6fca) | `` yazi: update shell integrations (#5048) ``       |