### PR TITLE
chore(flake/nix-index-database): `17352eb2` -> `f070c7ee`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1085,11 +1085,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708225687,
-        "narHash": "sha256-NJBDfvknI26beOFmjO2coeJMTTUCCtw2Iu+rvJ1Zb9k=",
+        "lastModified": 1708830466,
+        "narHash": "sha256-nGKe3Y1/jkLR2eh1aRSVBtKadMBNv8kOnB52UXqRy6A=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "17352eb241a8d158c4ac523b19d8d2a6c8efe127",
+        "rev": "f070c7eeec3bde8c8c8baa9c02b6d3d5e114d73b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`f070c7ee`](https://github.com/nix-community/nix-index-database/commit/f070c7eeec3bde8c8c8baa9c02b6d3d5e114d73b) | `` update packages.nix to release 2024-02-25-030647 `` |
| [`fddc437b`](https://github.com/nix-community/nix-index-database/commit/fddc437be33818182affef83fa2077261373c6e9) | `` flake.lock: Update ``                               |