### PR TITLE
chore(flake/nur): `74be1009` -> `5609d1c2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1343,11 +1343,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709211057,
-        "narHash": "sha256-Bd+pOFvVxfiF5LbLq4RsuhCAP++gPhv2g9vm+7+TYqY=",
+        "lastModified": 1709228792,
+        "narHash": "sha256-LnXEv6h7HUUsnYI1TsJ2/3GWqQFGyFbPSE9aUZTXWk0=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "74be1009198dc18d3c974d85f7660e6e6c1c8184",
+        "rev": "5609d1c281c1e3b6ca5fe2a8470b03f9f4f100d0",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`5609d1c2`](https://github.com/nix-community/NUR/commit/5609d1c281c1e3b6ca5fe2a8470b03f9f4f100d0) | `` automatic update `` |
| [`c52cf947`](https://github.com/nix-community/NUR/commit/c52cf9478c981de340151638d76c3c2371eb9ebe) | `` automatic update `` |
| [`2b541769`](https://github.com/nix-community/NUR/commit/2b541769a2b3628ee8105a3418b62dfdb0f57f80) | `` automatic update `` |
| [`fca09fec`](https://github.com/nix-community/NUR/commit/fca09fec01533adaaaaa3ddc3eb6f351913af615) | `` automatic update `` |