### PR TITLE
chore(flake/hyprland): `b39dcfa4` -> `1698d336`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -703,11 +703,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1709211818,
-        "narHash": "sha256-KQhRS30corMberlHhcs9i3TlSoEnz9Or009yJgmNk/k=",
+        "lastModified": 1709227424,
+        "narHash": "sha256-/RC/4TDKW6FABeSPMIeHbPf81k6ZOI8SoNBFOTDyy9c=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "b39dcfa497f84486569bf862092dfcfadbfd8747",
+        "rev": "1698d336f2511ee7c93d0a520c7ba3491c831e8d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                   |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
| [`1698d336`](https://github.com/hyprwm/Hyprland/commit/1698d336f2511ee7c93d0a520c7ba3491c831e8d) | `` core: fix crashes on access of deleted wlr_ surface `` |
| [`fbba8757`](https://github.com/hyprwm/Hyprland/commit/fbba8757cb1fbc79cc4b7744826a5a4cfca9264a) | `` window: remove unused list ``                          |
| [`6916d0a6`](https://github.com/hyprwm/Hyprland/commit/6916d0a6a316d602ff766abe5abffacf929b6801) | `` surface: unify owners ``                               |
| [`bcec082a`](https://github.com/hyprwm/Hyprland/commit/bcec082a1c20da4b69d56b0f0f98e00ecb3b5c96) | `` build: fix libc++/clang build (#4886) ``               |
| [`2e111c8c`](https://github.com/hyprwm/Hyprland/commit/2e111c8cf97d391c25fc6263660271fab605ece1) | `` xdg: rewrite entire popup implementation ``            |