### PR TITLE
chore(flake/lanzaboote): `e761c7ee` -> `eeb45682`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -844,11 +844,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1709051793,
-        "narHash": "sha256-4FXFBq5mN1IwN18Fd2OEF1iCZV5PC40gP2L64oyq3xQ=",
+        "lastModified": 1709332019,
+        "narHash": "sha256-kJAoPvpVRO3WR1dCZQKJpUMYoyA/6u9iUDX9gGEkjGI=",
         "owner": "nix-community",
         "repo": "lanzaboote",
-        "rev": "e761c7ee47b64debc687d8bff7599d702c893dcc",
+        "rev": "eeb45682dd4b2a921a3cab286f13101c9750d6bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                    | Message                                                               |
| --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`d470342a`](https://github.com/nix-community/lanzaboote/commit/d470342af6fb149ee5a7685f2ec3a984ddc68112) | `` tests: remove custom OVMF overrides ``                             |
| [`7df500bd`](https://github.com/nix-community/lanzaboote/commit/7df500bd1cc911932f9c3a7cd2eb6c071764f0c4) | `` readme: add mention of "Window UEFI Mode" needed on some boards `` |
| [`e2e8059d`](https://github.com/nix-community/lanzaboote/commit/e2e8059df26a70a43796c60da25d3f4c6b2eb4a5) | `` stub(*): merge dynamically initrds ``                              |
| [`88bcd99c`](https://github.com/nix-community/lanzaboote/commit/88bcd99ca8dc13e67670e601f94a6c9f623b426a) | `` stub(*): support dynamic initrds ``                                |