### PR TITLE
chore(flake/nh): `aa4df097` -> `6947e6f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708335499,
-        "narHash": "sha256-ZOAhp3hiJsWdNDSs/SF2EPylluAx5PiZv9aAUwZrKOI=",
+        "lastModified": 1709278248,
+        "narHash": "sha256-ceZXyzxTLSOrQlcTPQmvQnDV696NNMBwFmVPb9jpX2E=",
         "owner": "viperML",
         "repo": "nh",
-        "rev": "aa4df097654cdeb15aa74aabd72863a6fb30c7e6",
+        "rev": "6947e6f6f234d303131ecc1e54ef6703c82257e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                      | Message             |
| ------------------------------------------------------------------------------------------- | ------------------- |
| [`6947e6f6`](https://github.com/viperML/nh/commit/6947e6f6f234d303131ecc1e54ef6703c82257e3) | `` fix deps.rs ``   |
| [`daca52fa`](https://github.com/viperML/nh/commit/daca52fa2c0ab36399cdb1c7d08e8f20b3c21abf) | `` fix MRSV ``      |
| [`f2927179`](https://github.com/viperML/nh/commit/f29271798e6068845edf2b97c0b4f371b8b38ab2) | `` Bump all deps `` |
| [`0d9bbe47`](https://github.com/viperML/nh/commit/0d9bbe4735c2dec28c47826874162f9693771a50) | `` fix update ``    |
| [`ca4e26d7`](https://github.com/viperML/nh/commit/ca4e26d781460c96199e3bfd057dc726d7157e47) | `` fix update ``    |
| [`3eab5ee3`](https://github.com/viperML/nh/commit/3eab5ee325fc848294f624055ca4aba380ad8287) | `` fix update ``    |