### PR TITLE
chore(flake/spicetify-nix): `268610a4` -> `ca349109`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1520,11 +1520,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709179807,
-        "narHash": "sha256-zfKcBQ6zxMwC9GOkcRqAbEAsrKbydo6FEzlk7r9XLS0=",
+        "lastModified": 1709352587,
+        "narHash": "sha256-mOJR3Ip5g6bwqGzQVX6Cix6x+rU2nSXTSkIhHSDXBk4=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "268610a47b78b83d6c0307b6781b0e61331e6200",
+        "rev": "ca349109bcfe34e6a58e786456dcb299e656935b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`ca349109`](https://github.com/Gerg-L/spicetify-nix/commit/ca349109bcfe34e6a58e786456dcb299e656935b) | `` CI update 2024-03-02 (#88) `` |
| [`dab28555`](https://github.com/Gerg-L/spicetify-nix/commit/dab285559294e7e7bd173756351df30fa01eda10) | `` CI update 2024-03-01 (#87) `` |