### PR TITLE
chore(flake/chaotic): `39b0ccd1` -> `1c8a5091`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -100,11 +100,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1709211633,
-        "narHash": "sha256-0O6sAGJqVlbL2oatQPOqoefM7IFBfzXkr61JcOmmsdI=",
+        "lastModified": 1709404342,
+        "narHash": "sha256-mDVOKW0rWQ/ntTmp9JY47/Fq48A6RaDkY4x5Mizj+sg=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "39b0ccd13d13867e27cb6e27511c621b8e414ac8",
+        "rev": "1c8a5091186cf93fb3d9bb0cfa3945bd28a7c868",
         "type": "github"
       },
       "original": {
@@ -1138,12 +1138,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1709150264,
-        "narHash": "sha256-HofykKuisObPUfj0E9CJVfaMhawXkYx3G8UIFR/XQ38=",
-        "rev": "9099616b93301d5cf84274b184a3a5ec69e94e08",
-        "revCount": 589696,
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
+        "revCount": 590113,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.589696%2Brev-9099616b93301d5cf84274b184a3a5ec69e94e08/018df3e5-846d-74da-b6a7-4656c4e990d6/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.590113%2Brev-1536926ef5621b09bba54035ae2bb6d806d72ac8/018df9f0-47ef-778e-b2d9-de8f1e70489d/source.tar.gz"
       },
       "original": {
         "type": "tarball",


### PR DESCRIPTION
| Commit                                                                                          | Message                         |
| ----------------------------------------------------------------------------------------------- | ------------------------------- |
| [`1c8a5091`](https://github.com/chaotic-cx/nyx/commit/1c8a5091186cf93fb3d9bb0cfa3945bd28a7c868) | `` fix eval ``                  |
| [`26df8afe`](https://github.com/chaotic-cx/nyx/commit/26df8afe1492b086ace6ccc84c29a755085ed23e) | `` nixpkgs: bump to 20240301 `` |