### PR TITLE
chore(flake/emacs-overlay): `5e278b16` -> `1e6301ed`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -290,11 +290,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1709226281,
-        "narHash": "sha256-lqIEcsfb1p3bVyTLE1mrRbrQnHTYUxDUBW+wpkNvC7o=",
+        "lastModified": 1709399032,
+        "narHash": "sha256-4LUxOtqa4PDyHbgqDPM9M23S5Q1gg47rAflE+qhclm8=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5e278b16d982831f1b81669d26649454c1a37981",
+        "rev": "1e6301ed0b30f7601ab4cf85cabc086385ce3618",
         "type": "github"
       },
       "original": {
@@ -1217,11 +1217,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1709128929,
-        "narHash": "sha256-GWrv9a+AgGhG4/eI/CyVVIIygia7cEy68Huv3P8oyaw=",
+        "lastModified": 1709309926,
+        "narHash": "sha256-VZFBtXGVD9LWTecGi6eXrE0hJ/mVB3zGUlHImUs2Qak=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c8e74c2f83fe12b4e5a8bd1abbc090575b0f7611",
+        "rev": "79baff8812a0d68e24a836df0a364c678089e2c7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`1e6301ed`](https://github.com/nix-community/emacs-overlay/commit/1e6301ed0b30f7601ab4cf85cabc086385ce3618) | `` Updated emacs ``        |
| [`bde7c369`](https://github.com/nix-community/emacs-overlay/commit/bde7c369f548e93febee51d1bc38ecbac644c308) | `` Updated melpa ``        |
| [`d8b62d7b`](https://github.com/nix-community/emacs-overlay/commit/d8b62d7bf5edf5d14ba03a904c9c9c4f3b719e81) | `` Updated elpa ``         |
| [`bab54c41`](https://github.com/nix-community/emacs-overlay/commit/bab54c414822538a2275bd32d546f87192ae1576) | `` Updated flake inputs `` |
| [`89541209`](https://github.com/nix-community/emacs-overlay/commit/89541209151acb287bfb71659e738038521b0bcb) | `` Updated emacs ``        |
| [`16fc59cc`](https://github.com/nix-community/emacs-overlay/commit/16fc59cc0a5882b60dbd7d5665363d743b3d95c1) | `` Updated emacs ``        |
| [`ba8ee81a`](https://github.com/nix-community/emacs-overlay/commit/ba8ee81a90e1019be55f950dffb4b75099691a3e) | `` Updated elpa ``         |
| [`d909a8b4`](https://github.com/nix-community/emacs-overlay/commit/d909a8b4f5b332a8086ce2fbe7f30b91957c229b) | `` Updated nongnu ``       |
| [`2b95246f`](https://github.com/nix-community/emacs-overlay/commit/2b95246fa59e3dd0627e308df545bbd4cc3ce22f) | `` Updated emacs ``        |
| [`c2af4557`](https://github.com/nix-community/emacs-overlay/commit/c2af45572b1a63acd56b23f135c5866ff19a7962) | `` Updated melpa ``        |
| [`94bd2c06`](https://github.com/nix-community/emacs-overlay/commit/94bd2c06076fa392ccfcb88f63adf19b2482d5d9) | `` Updated elpa ``         |
| [`514217c9`](https://github.com/nix-community/emacs-overlay/commit/514217c91d0c914a2545a482e6c8bb051edcaa49) | `` Updated flake inputs `` |
| [`d7155aaa`](https://github.com/nix-community/emacs-overlay/commit/d7155aaadc98b2c13874f78cc5e00f2dfefd7a6e) | `` Updated melpa ``        |
| [`f46c7855`](https://github.com/nix-community/emacs-overlay/commit/f46c7855660fd07e03c4ce68f025b65f22ff95e2) | `` Updated emacs ``        |
| [`51d054fd`](https://github.com/nix-community/emacs-overlay/commit/51d054fd379c4bf1bc9df49c98db0a356ffc20f5) | `` Updated melpa ``        |
| [`03b374a3`](https://github.com/nix-community/emacs-overlay/commit/03b374a38f808b3f42d7a8b59bcc8ba7c20e5ce9) | `` Updated elpa ``         |
| [`001333f7`](https://github.com/nix-community/emacs-overlay/commit/001333f7e2fd7fbe5052bcabcf95adbe1275a29b) | `` Updated nongnu ``       |
| [`7cfc879c`](https://github.com/nix-community/emacs-overlay/commit/7cfc879c71a7903886fd4135a66495dd9cd365f0) | `` Updated flake inputs `` |