### PR TITLE
chore(flake/nur): `a04e8bf5` -> `7dece497`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1343,11 +1343,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709240301,
-        "narHash": "sha256-O/IAJcIUB7ZQTXsnmuqOnHbM5oIypIh15T944zXwA54=",
+        "lastModified": 1709423131,
+        "narHash": "sha256-IC6JS+Rk6MKg7jl6C9gHHl2StLvwnzDkN3cjU5SQ+ig=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "a04e8bf56f7cc3fc05a117733ede8d7a38e50eac",
+        "rev": "7dece49714e9c3dd6b7395ac789099b82ab40104",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`7dece497`](https://github.com/nix-community/NUR/commit/7dece49714e9c3dd6b7395ac789099b82ab40104) | `` automatic update `` |
| [`f4befb15`](https://github.com/nix-community/NUR/commit/f4befb1532ff62f5c542928d1a03a9e2b2465f5d) | `` automatic update `` |
| [`d4a9ca59`](https://github.com/nix-community/NUR/commit/d4a9ca59599c0e4f5acfb079a55fe0578ecfc4de) | `` automatic update `` |
| [`38334efa`](https://github.com/nix-community/NUR/commit/38334efa320e3981afe86f37d816059b4dbe6978) | `` automatic update `` |
| [`8913066d`](https://github.com/nix-community/NUR/commit/8913066dbc3d389d2a26354c30753ceb1acb6e32) | `` automatic update `` |
| [`3a467458`](https://github.com/nix-community/NUR/commit/3a4674583d8b69fdc3875c5615046d540ea56a27) | `` automatic update `` |
| [`96180796`](https://github.com/nix-community/NUR/commit/96180796965f828546779a019a38ee6fe769a119) | `` automatic update `` |
| [`79a69d91`](https://github.com/nix-community/NUR/commit/79a69d9135886a0a5954c573402b0724b2562d22) | `` automatic update `` |
| [`3635ceab`](https://github.com/nix-community/NUR/commit/3635ceabe30c7434fd847edc466e41b45c3149e4) | `` automatic update `` |
| [`44508429`](https://github.com/nix-community/NUR/commit/445084298133120908fbc286fd6e50bf1aab390a) | `` automatic update `` |
| [`ffd46da1`](https://github.com/nix-community/NUR/commit/ffd46da1c67009bd0272e4faa331ae38c545f3fa) | `` automatic update `` |
| [`c2d6a728`](https://github.com/nix-community/NUR/commit/c2d6a7282138ae32abf50aae5fd2efddb066a6da) | `` automatic update `` |
| [`3c45f6cd`](https://github.com/nix-community/NUR/commit/3c45f6cd9a2520013c5aa946c00307132b236262) | `` automatic update `` |
| [`3de7657e`](https://github.com/nix-community/NUR/commit/3de7657e6ea4ed20f9b4076f1dd33a5e91a43ab7) | `` automatic update `` |
| [`a539b9e3`](https://github.com/nix-community/NUR/commit/a539b9e38cd2604dae50937d80f181cca533a462) | `` automatic update `` |
| [`f26313a6`](https://github.com/nix-community/NUR/commit/f26313a67e4c6f4bd0e31ffef9f60bfca1948cf2) | `` automatic update `` |
| [`311db66b`](https://github.com/nix-community/NUR/commit/311db66ba3e01bcadeb9cc278d1efe9b807357c6) | `` automatic update `` |
| [`d60602f3`](https://github.com/nix-community/NUR/commit/d60602f3743c42707c2cc3c2c68791fc8274ec36) | `` automatic update `` |
| [`bec74ea5`](https://github.com/nix-community/NUR/commit/bec74ea540396d8f279f3630d0b53932ce235333) | `` automatic update `` |
| [`5b634d81`](https://github.com/nix-community/NUR/commit/5b634d8100c7e7d3ac195e393ea5c14fb6e90db3) | `` automatic update `` |
| [`b5b87b28`](https://github.com/nix-community/NUR/commit/b5b87b2880e3091ad286fddd4464caab2e4558f8) | `` automatic update `` |
| [`d7b81a30`](https://github.com/nix-community/NUR/commit/d7b81a30d06405b2b6ba17698dffe6215e219409) | `` automatic update `` |
| [`407972e6`](https://github.com/nix-community/NUR/commit/407972e64109cbe67992a754c09fdff96df8c19c) | `` automatic update `` |
| [`b79b14e8`](https://github.com/nix-community/NUR/commit/b79b14e80708477d8cf7c269bd6a5e62121da0cd) | `` automatic update `` |
| [`dcf16e00`](https://github.com/nix-community/NUR/commit/dcf16e00e8bdfd336dd7e8a9c8e133133d0af959) | `` automatic update `` |
| [`6575c91c`](https://github.com/nix-community/NUR/commit/6575c91c724aa12426c49a70bca63a94462f4efd) | `` automatic update `` |
| [`6b9b5949`](https://github.com/nix-community/NUR/commit/6b9b59495ff2a7092af2d4c399e0cf9142d50100) | `` automatic update `` |
| [`7d003db9`](https://github.com/nix-community/NUR/commit/7d003db96005f367008a368f5e3ea1b9d073d64f) | `` automatic update `` |
| [`2bc9cfcb`](https://github.com/nix-community/NUR/commit/2bc9cfcb92c01b8483e1768c39823b36d6077059) | `` automatic update `` |
| [`7cc43767`](https://github.com/nix-community/NUR/commit/7cc43767dba920519939e2a7f0162e8703fb3673) | `` automatic update `` |
| [`73216284`](https://github.com/nix-community/NUR/commit/73216284e7eebc9b5c34b9ce05f220e7e2168e20) | `` automatic update `` |
| [`c4456ad5`](https://github.com/nix-community/NUR/commit/c4456ad5a0982c8d37429125b106bf287f0296e4) | `` automatic update `` |
| [`aef6b1d5`](https://github.com/nix-community/NUR/commit/aef6b1d5c2c4adb830eddf478c0f418cb5d4032c) | `` automatic update `` |
| [`62244671`](https://github.com/nix-community/NUR/commit/622446714ffabe84c4e007ad8d14be1a44d051a3) | `` automatic update `` |
| [`9338d6c7`](https://github.com/nix-community/NUR/commit/9338d6c7c4115a8c7fe17fc887919204a9635545) | `` automatic update `` |
| [`f272567e`](https://github.com/nix-community/NUR/commit/f272567edc7cb4c72cc11d045e4db2660a9dd126) | `` automatic update `` |
| [`c14e838f`](https://github.com/nix-community/NUR/commit/c14e838f7baab6f5ddce63082f79d129446bd20a) | `` automatic update `` |
| [`6ad856f5`](https://github.com/nix-community/NUR/commit/6ad856f58f1da6cbd6e003f1b5245fd4232d821a) | `` automatic update `` |
| [`c1a0966d`](https://github.com/nix-community/NUR/commit/c1a0966dac356909a9dfd8c161e08f3ac10e003b) | `` automatic update `` |
| [`407fbafd`](https://github.com/nix-community/NUR/commit/407fbafde51bdab6e1b43ac0ea1c51d6f448ca41) | `` automatic update `` |
| [`8e82d078`](https://github.com/nix-community/NUR/commit/8e82d0789dab6faf0abe94def7b8bc9cab2996bc) | `` automatic update `` |
| [`bf3465e3`](https://github.com/nix-community/NUR/commit/bf3465e366e868b9d91f78e54d55566ebd2aa03e) | `` automatic update `` |
| [`975323e2`](https://github.com/nix-community/NUR/commit/975323e2a56dde3ed8879469091a830ca8b2f3cd) | `` automatic update `` |
| [`e2083b88`](https://github.com/nix-community/NUR/commit/e2083b8865f5427a5f178766e5241ecc49e87507) | `` automatic update `` |
| [`f8d65afc`](https://github.com/nix-community/NUR/commit/f8d65afc4806c6541bf5f516a8319c31c7386ede) | `` automatic update `` |
| [`f4be25a0`](https://github.com/nix-community/NUR/commit/f4be25a071c35bb099d40bc6be7652c1a17fdf2b) | `` automatic update `` |
| [`45e26847`](https://github.com/nix-community/NUR/commit/45e268473e501a69fca55cd4c3b362521b2a0312) | `` automatic update `` |
| [`8220695f`](https://github.com/nix-community/NUR/commit/8220695f13e8cc6840369766638de8a547deba46) | `` automatic update `` |
| [`55aa32e9`](https://github.com/nix-community/NUR/commit/55aa32e99d1a780ff593f667aab845c76ba9ac07) | `` automatic update `` |
| [`66ec9b1c`](https://github.com/nix-community/NUR/commit/66ec9b1cbbb72b79d7d6d5b5d219713f7b4af888) | `` automatic update `` |
| [`7fa3452d`](https://github.com/nix-community/NUR/commit/7fa3452ddbcf35f1a1e9c8153a6734db81e1ae85) | `` automatic update `` |
| [`334b28aa`](https://github.com/nix-community/NUR/commit/334b28aa542a238f3ad41d10fec8d5ebeab15506) | `` automatic update `` |
| [`14de3286`](https://github.com/nix-community/NUR/commit/14de3286e2081dbffaa7ebb595363227b6af2a74) | `` automatic update `` |
| [`b9478b89`](https://github.com/nix-community/NUR/commit/b9478b89c4fb5e2d0d6b1717b5278d3d748daad2) | `` automatic update `` |