### PR TITLE
chore(flake/treefmt-nix): `e497a9dd` -> `093f82e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1645,11 +1645,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708897213,
-        "narHash": "sha256-QECZB+Hgz/2F/8lWvHNk05N6NU/rD9bWzuNn6Cv8oUk=",
+        "lastModified": 1709373438,
+        "narHash": "sha256-F/Vieen5x2nf05KJ5AitoE/GSB0FU2jMffSM8bHSuBs=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e497a9ddecff769c2a7cbab51e1ed7a8501e7a3a",
+        "rev": "093f82e5707bb6f14ee38a742748f9fb4ab1488e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                              |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------ |
| [`093f82e5`](https://github.com/numtide/treefmt-nix/commit/093f82e5707bb6f14ee38a742748f9fb4ab1488e) | `` feat(programs): add opa (#162) `` |