### PR TITLE
chore(flake/hyprland): `7ce781e8` -> `acf0b536`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -703,11 +703,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1709344015,
-        "narHash": "sha256-R8ribue2QDmjk3DnLVPIi4MYLkJN/wvBKTXGJAERE8Y=",
+        "lastModified": 1709425896,
+        "narHash": "sha256-r/Tsr+BfgaiJIWTwWrrxHzTmNGEIi8HzYDGO3kFJmx8=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "7ce781e87cf7cf789a54d37af7d78f1c11d66dbc",
+        "rev": "2a08f2ba84ead47bd13aae5797d0d71b2e11b612",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                          |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------- |
| [`acf0b536`](https://github.com/hyprwm/Hyprland/commit/acf0b536a643bd5c87cd6097f5c94b4041797c15) | `` xwayland: disable initial focus for xwayland dialogs (#4936) ``               |
| [`1762e9c6`](https://github.com/hyprwm/Hyprland/commit/1762e9c6ec0140a35e79b0f4c88cce003b05ced5) | `` renderer: respect forceNoBlur when rendering small surface windows (#4932) `` |
| [`964f1a43`](https://github.com/hyprwm/Hyprland/commit/964f1a438df5114fd9d771f24015e95b8061e503) | `` keybinds: Add the 'catchall' keyword that matches all keys (#4930) ``         |
| [`508262b7`](https://github.com/hyprwm/Hyprland/commit/508262b7db6e8e88573a4069c88b4fb88ccff1d5) | `` events: update render data after workspace window rule (#4931) ``             |
| [`d72ea5f2`](https://github.com/hyprwm/Hyprland/commit/d72ea5f2a7fdb0d0a7bf914412327195b05199b0) | `` input: Rewritten pointer constraints (#4889) ``                               |
| [`328ab431`](https://github.com/hyprwm/Hyprland/commit/328ab431655f207a5ee59737291f8e8d85fab992) | `` hyprpm: don't copy .so if file doesn't exist ``                               |
| [`d2289d83`](https://github.com/hyprwm/Hyprland/commit/d2289d8327d46e6b55c06b3c639fc138c3e02d1a) | `` xdg: minor improvements to initial size reporting ``                          |
| [`be89d6fa`](https://github.com/hyprwm/Hyprland/commit/be89d6faa988f6bd33a66f02746872c649a16180) | `` notifs: Implement notification dimissing (#4790) ``                           |
| [`8811f4b6`](https://github.com/hyprwm/Hyprland/commit/8811f4b69ade469285635c539f20194d717c8e17) | `` drag: check min size for reisze drags ``                                      |
| [`52db2166`](https://github.com/hyprwm/Hyprland/commit/52db21660801ef4300a8b3c5dbb5c7e244ed2d19) | `` events: don't switch to active workspace on workspace rule ``                 |
| [`1e311c94`](https://github.com/hyprwm/Hyprland/commit/1e311c947e4601612492d2b1aa34adb186e4fbe7) | `` Nix: add missing dependencies for make asan (#4919) ``                        |