### PR TITLE
chore(flake/nixpkgs): `bc6d119b` -> `b8698cd8`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1327,11 +1327,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1709228265,
-        "narHash": "sha256-smzkHvYpuOQ0h0b7prfyRtOHIDnmxuTiuenQ9hV2PZM=",
+        "lastModified": 1709357594,
+        "narHash": "sha256-C6BNtZewmFbBuPgqAUa/o3pZ4nYZJkQfFB1nhQbBFEc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bc6d119bd0615780470db760bc2cb24ee4583102",
+        "rev": "b8698cd8d62c42cf3e2b3a95224c57173b73e494",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`b8698cd8`](https://github.com/NixOS/nixpkgs/commit/b8698cd8d62c42cf3e2b3a95224c57173b73e494) | `` macOS support for NixOS tests (#282401) ``                                              |
| [`25bf3103`](https://github.com/NixOS/nixpkgs/commit/25bf31036f2d95aa707a9c368a5b899dff02cec0) | `` vamp-plugin-sdk: fix owner in fetchFromGitHub ``                                        |
| [`520456e9`](https://github.com/NixOS/nixpkgs/commit/520456e9053da088ca8a4dc8eec28601e9415203) | `` qt6Packages.fcitx5-qt: fix repo in fetchFromGitHub ``                                   |
| [`e44cce2a`](https://github.com/NixOS/nixpkgs/commit/e44cce2a3cb4a0ed00c13e266c1c6a2b57b2364a) | `` google-cloud-cpp: drop redundant `disable-warnings-if-gcc13` ``                         |
| [`6eef1793`](https://github.com/NixOS/nixpkgs/commit/6eef1793ca4a066f6ad20a46bcd9b44b538940d6) | `` distrobuilder.tests: update `incus.container` reference ``                              |
| [`dddab82f`](https://github.com/NixOS/nixpkgs/commit/dddab82fc6a5b81ca3f312b23dd12c9a39fc6a33) | `` labwc: 0.7.0 -> 0.7.1 ``                                                                |
| [`fb0a0722`](https://github.com/NixOS/nixpkgs/commit/fb0a07229f81417b90cbb05d6522dbc4c654fb76) | `` tests.nixpkgs-check-by-name: More inline format! arguments ``                           |
| [`5981aff2`](https://github.com/NixOS/nixpkgs/commit/5981aff2125baba1430e5a96338a71e2e1fad18d) | `` tests.nixpkgs-check-by-name: Use RelativePath for relative paths ``                     |
| [`a9bebf8e`](https://github.com/NixOS/nixpkgs/commit/a9bebf8eb55f3fdd7d5fdb661ed0140fd12f111d) | `` opengist: init at 1.6.1 ``                                                              |
| [`4e8281c9`](https://github.com/NixOS/nixpkgs/commit/4e8281c904c6bcf2b442394423bb4091b98e0bc8) | `` btop: drop redundant `disable-warnings-if-gcc13` ``                                     |
| [`c97effab`](https://github.com/NixOS/nixpkgs/commit/c97effabc120ae5d9aefb5d6cdac3883c5963762) | `` reproc: drop redundant `disable-warnings-if-gcc13` ``                                   |
| [`4ffb9ba7`](https://github.com/NixOS/nixpkgs/commit/4ffb9ba70757d3ba610129ed4d5ba449883bdc4c) | `` garage: mark broken on Darwin ``                                                        |
| [`98325e4b`](https://github.com/NixOS/nixpkgs/commit/98325e4ba7700850df97825f3bf37bf46d1a9a41) | `` tippecanoe: add mainProgram ``                                                          |
| [`fb6fa7b3`](https://github.com/NixOS/nixpkgs/commit/fb6fa7b3d9e7ef87056654030668ff4d74f24f9f) | `` nixfmt-rfc-style: 2024-01-31 -> 2024-03-01 ``                                           |
| [`3f388279`](https://github.com/NixOS/nixpkgs/commit/3f388279f7ed3a8b0b8cfc45d3f4305ecb2eb1c5) | `` nnpdf: 4.0.8 -> 4.0.9 ``                                                                |
| [`13c74202`](https://github.com/NixOS/nixpkgs/commit/13c7420268a2d0d329d6c0eef67d478d576a576b) | `` vale: 3.2.0 -> 3.2.1 ``                                                                 |
| [`5920196c`](https://github.com/NixOS/nixpkgs/commit/5920196c69843bed60cdc5362ec58102f590b5f5) | `` tippecanoe: 2.46.0 -> 2.47.0 ``                                                         |
| [`b041481e`](https://github.com/NixOS/nixpkgs/commit/b041481ef31d70e2728fa4c97a80ec6ae131ca19) | `` garage: 0.9.1 -> 0.9.2 ``                                                               |
| [`37942460`](https://github.com/NixOS/nixpkgs/commit/3794246066409d7baac72e3fdfb0e4f66ef4a013) | `` nixos/nixpkgs: fix determination for cross-compiled nixos system ``                     |
| [`19bfc60e`](https://github.com/NixOS/nixpkgs/commit/19bfc60e9f564194ad00508c578c7e1a329056f5) | `` garage_0_8: 0.8.5 -> 0.8.6 ``                                                           |
| [`cd6e28ab`](https://github.com/NixOS/nixpkgs/commit/cd6e28ab9d310bdedd16e73292c3139e6ec5c53f) | `` python311Packages.textnets: 0.9.3 -> 0.9.4 ``                                           |
| [`fd1136a7`](https://github.com/NixOS/nixpkgs/commit/fd1136a79646e4a49416cb2fe83679a15c4dcdf5) | `` live555: 2024.02.23 -> 2024.02.28 ``                                                    |
| [`89304e3b`](https://github.com/NixOS/nixpkgs/commit/89304e3b2bea15be5fff830b8191f9be4570272c) | `` cargo-bloat: add `meta.mainProgram` ``                                                  |
| [`f9cf9ecd`](https://github.com/NixOS/nixpkgs/commit/f9cf9ecda4cf926144207ca26db6bebcc04f445d) | `` python311Packages.python-novaclient: 18.4.0 -> 18.5.0 ``                                |
| [`253d5068`](https://github.com/NixOS/nixpkgs/commit/253d5068d8ca446c2b99929dda2f17370b1839ac) | `` cargo-bloat: migrate to by-name ``                                                      |
| [`6e2d4054`](https://github.com/NixOS/nixpkgs/commit/6e2d4054aefe6d0065786c944db88951c4064e21) | `` nixos/fcitx5: add plasma6 support option ``                                             |
| [`81ed07d2`](https://github.com/NixOS/nixpkgs/commit/81ed07d28a62242872c2ff32eaa4a766758d5c38) | `` fcitx5-with-addons: build for both qt versions ``                                       |
| [`6fb9849e`](https://github.com/NixOS/nixpkgs/commit/6fb9849e686cdf986e8cf734b3f466ee5d16e6cf) | `` fcitx5-configtool: build for both qt versions ``                                        |
| [`6f8d73e5`](https://github.com/NixOS/nixpkgs/commit/6f8d73e50210306ba9acd02324d62bfd18e223c9) | `` nng: 1.7.2 -> 1.7.3 ``                                                                  |
| [`45e4e8f9`](https://github.com/NixOS/nixpkgs/commit/45e4e8f97356dcf7429657f553ac7514b218f01a) | `` fcitx5-chinese-addons: build for both qt versions ``                                    |
| [`51f1291e`](https://github.com/NixOS/nixpkgs/commit/51f1291ea5091d226228255beb2adf6a9ea04fb6) | `` fcitx5-unikey: build for both qt versions ``                                            |
| [`0b5b74bb`](https://github.com/NixOS/nixpkgs/commit/0b5b74bbeb4b881b2d4e9c4fb87fcca72fe99301) | `` fcitx5-skk: build for both qt versions ``                                               |
| [`9336fcc5`](https://github.com/NixOS/nixpkgs/commit/9336fcc5ae4fa579b6f3fb7f0e68277d875ec435) | `` fcitx5: drop superfluous use of libsForQt5.callPackage ``                               |
| [`8e8f6a57`](https://github.com/NixOS/nixpkgs/commit/8e8f6a57f4b79ef6152cd9b84ce80f3071fb301d) | `` cargo-chef: 0.1.64 -> 0.1.65 ``                                                         |
| [`34ad69f5`](https://github.com/NixOS/nixpkgs/commit/34ad69f5a469c034b6e8f22399692b576fffd50a) | `` mold: 2.4.0 -> 2.4.1 ``                                                                 |
| [`8147f49e`](https://github.com/NixOS/nixpkgs/commit/8147f49e28c9dd5219944095396212a59b8d530c) | `` direnv: 2.33.0 -> 2.34.0 (#292564) ``                                                   |
| [`bd3290c7`](https://github.com/NixOS/nixpkgs/commit/bd3290c7dabebc8645d478c847d6fa94e865d389) | `` oculante: 0.8.11 -> 0.8.13 ``                                                           |
| [`75a1ff3f`](https://github.com/NixOS/nixpkgs/commit/75a1ff3f94d7d214f039eb3ec1a400a46836ea19) | `` mergerfs: 2.40.1 -> 2.40.2 ``                                                           |
| [`49e70199`](https://github.com/NixOS/nixpkgs/commit/49e70199883b5878c5da26f72a60989bf6687d9f) | `` fcitx5-unikey: 5.1.2 -> 5.1.3 ``                                                        |
| [`b90a2326`](https://github.com/NixOS/nixpkgs/commit/b90a2326edbc6016ee88c06751c4e6670315ce03) | `` fcitx5-table-other: 5.1.0 -> 5.1.1 ``                                                   |
| [`b85b81d2`](https://github.com/NixOS/nixpkgs/commit/b85b81d21567ea839bdd48f96756b40e74790cf9) | `` fcitx5-table-extra: 5.1.3 -> 5.1.4 ``                                                   |
| [`7603c679`](https://github.com/NixOS/nixpkgs/commit/7603c6794e6c296419be24601d1df53e3ff900ba) | `` fcitx5-skk: 5.1.1 -> 5.1.2 ``                                                           |
| [`0be796b5`](https://github.com/NixOS/nixpkgs/commit/0be796b5bf0e9727b297688231cda14ea87d733c) | `` fcitx5-rime: 5.1.4 -> 5.1.5 ``                                                          |
| [`ace8f134`](https://github.com/NixOS/nixpkgs/commit/ace8f134eaa387f5c11c50ed51af354c3443a5f6) | `` fcitx5-hangul: 5.1.1 -> 5.1.2 ``                                                        |
| [`02370479`](https://github.com/NixOS/nixpkgs/commit/0237047987756ff594cfddd1b48d4a26e594ac88) | `` fcitx5-gtk: 5.1.1 -> 5.1.2 ``                                                           |
| [`5a7d6c36`](https://github.com/NixOS/nixpkgs/commit/5a7d6c36987a8c6e4d12b5d02bdee80d8a25f47f) | `` fcitx5-configtool: 5.1.3 -> 5.1.4 ``                                                    |
| [`78497390`](https://github.com/NixOS/nixpkgs/commit/78497390bb5931dbc0de8f563c2914c869085be1) | `` fcitx5-chinese-addons: 5.1.3 -> 5.1.4 ``                                                |
| [`2527e875`](https://github.com/NixOS/nixpkgs/commit/2527e875cc87f6eab9c10701026f8d65f69d36f4) | `` fcitx5: 5.1.7 -> 5.1.8 ``                                                               |
| [`f9ff5e8d`](https://github.com/NixOS/nixpkgs/commit/f9ff5e8db1d4c0ff64c3dc786b81bddc80245d14) | `` xcb-imdkit: 1.0.6 -> 1.0.7 ``                                                           |
| [`5870d6ea`](https://github.com/NixOS/nixpkgs/commit/5870d6ea116ed130013c742f47c3bcb981dc5f70) | `` libime: 1.1.5 -> 1.1.6 ``                                                               |
| [`1048982e`](https://github.com/NixOS/nixpkgs/commit/1048982ea126aadd3aee8730813c4e6873360b19) | `` eksctl: 0.172.0 -> 0.173.0 ``                                                           |
| [`2170ed00`](https://github.com/NixOS/nixpkgs/commit/2170ed0090d36aa16bfe870f280afac60307c1cb) | `` kool: 3.1.0 -> 3.2.0 ``                                                                 |
| [`c617c307`](https://github.com/NixOS/nixpkgs/commit/c617c307daee372feca181e44dde5370dcb2a205) | `` fishPlugins.forgit: 24.02.0 -> 24.03.0 ``                                               |
| [`2b7b9cd9`](https://github.com/NixOS/nixpkgs/commit/2b7b9cd91652ddbd96a86258f0d3457c53321706) | `` spotifywm: ensure all files are propagated ``                                           |
| [`fbef1439`](https://github.com/NixOS/nixpkgs/commit/fbef14399697dd5459485671336f169dc658870c) | `` ttdl: 4.2.0 -> 4.2.1 ``                                                                 |
| [`131f84fb`](https://github.com/NixOS/nixpkgs/commit/131f84fbafa3e7802b2fa662cc675b5e82941674) | `` waycheck: 1.1.0 -> 1.1.1 ``                                                             |
| [`29a1b11f`](https://github.com/NixOS/nixpkgs/commit/29a1b11f916e5994f7ad23039ae21945df99247c) | `` zfs_*: Avoid failing pkgs/by-name migration check ``                                    |
| [`64f29a96`](https://github.com/NixOS/nixpkgs/commit/64f29a96ad1d91d0d28aa63bb67b488ebfa225f1) | `` asnmap: refactor ``                                                                     |
| [`c60dafe6`](https://github.com/NixOS/nixpkgs/commit/c60dafe6b735c3da2cbc6c438330d5d5ab0a9d0f) | `` linux-rt_6_6: 6.6.15-rt22 -> 6.6.18-rt23 ``                                             |
| [`39f3ac14`](https://github.com/NixOS/nixpkgs/commit/39f3ac14a4ac25ddb6a3778bea9b9b903ea0e097) | `` linux-rt_6_1: 6.1.77-rt24 -> 6.1.79-rt25 ``                                             |
| [`72f4920f`](https://github.com/NixOS/nixpkgs/commit/72f4920f2f4e250c6fcc4d946467995f47f45d46) | `` linux_4_19: 4.19.307 -> 4.19.308 ``                                                     |
| [`01a3cfdf`](https://github.com/NixOS/nixpkgs/commit/01a3cfdf71e3565e78478fc9451850d8230affa3) | `` linux_5_4: 5.4.269 -> 5.4.270 ``                                                        |
| [`26856a40`](https://github.com/NixOS/nixpkgs/commit/26856a40a8c120246d64ac5b93471c142a355efe) | `` linux_5_10: 5.10.210 -> 5.10.211 ``                                                     |
| [`3a05b894`](https://github.com/NixOS/nixpkgs/commit/3a05b894f646905ac4932db2befd02daa29bab2e) | `` linux_5_15: 5.15.149 -> 5.15.150 ``                                                     |
| [`dc81b2ea`](https://github.com/NixOS/nixpkgs/commit/dc81b2ea9ec340b6147fad82b35c7a3b742cb75c) | `` linux_6_1: 6.1.79 -> 6.1.80 ``                                                          |
| [`e5adec46`](https://github.com/NixOS/nixpkgs/commit/e5adec46da5803ba373beb931923b591099df7c2) | `` linux_6_6: 6.6.18 -> 6.6.19 ``                                                          |
| [`a190a93d`](https://github.com/NixOS/nixpkgs/commit/a190a93d59548fcf8ffa66bb6f6a9a9ea572cd46) | `` linux_6_7: 6.7.6 -> 6.7.7 ``                                                            |
| [`299251e8`](https://github.com/NixOS/nixpkgs/commit/299251e8d4bf4469f99842049f7a952dc2425d48) | `` kdePackages.akonadi: restore mysql backend ``                                           |
| [`b9a5d3fa`](https://github.com/NixOS/nixpkgs/commit/b9a5d3fab6118c7a1e6598741706eb1e5cc7b9f5) | `` intel-cmt-cat: 23.11 -> 23.11.1 ``                                                      |
| [`d6804e01`](https://github.com/NixOS/nixpkgs/commit/d6804e012cea9abd6604166631d2d8cd0819a8f0) | `` kdePackages.oxygen: fix build ``                                                        |
| [`e4387fde`](https://github.com/NixOS/nixpkgs/commit/e4387fdefaa9babc088128c07927f0097b0f835b) | `` diffoscope: 257 -> 259 ``                                                               |
| [`b75a29cb`](https://github.com/NixOS/nixpkgs/commit/b75a29cb6ca9b5d2e4823622be84d10a6b2e299f) | `` nixos/lib/make-disk-image.nix: fix systemd-boot-builder clobbering /homeless-shelter `` |
| [`72e569f1`](https://github.com/NixOS/nixpkgs/commit/72e569f1f2c1bc89bf37e36796d60db3eceb1096) | `` python311Packages.python-heatclient: 3.4.0 -> 3.5.0 ``                                  |
| [`77f61be4`](https://github.com/NixOS/nixpkgs/commit/77f61be48ce7e188a986aad0aa9e9ca67c964b39) | `` python311Packages.faster-whisper: 0.10.0 -> 1.0.1 ``                                    |
| [`4217f7f6`](https://github.com/NixOS/nixpkgs/commit/4217f7f66caebcd4fa3283f3d7a0b1604bb446e1) | `` asnmap: 1.0.6 -> 1.1.0 ``                                                               |
| [`034299c4`](https://github.com/NixOS/nixpkgs/commit/034299c4a4a23cac2e5715f81863231ad615f5bb) | `` logseq: 0.10.6 -> 0.10.7 ``                                                             |
| [`0e0e32e1`](https://github.com/NixOS/nixpkgs/commit/0e0e32e14df39515d27d3968b4092a2613a4b900) | `` python311Packages.python-swiftclient: 4.4.0 -> 4.5.0 ``                                 |
| [`ce373e1d`](https://github.com/NixOS/nixpkgs/commit/ce373e1dadf2682fc944f974993c55ba3b0c49a9) | `` python312Packages.uncertainties: fix test by moving from nose to pynose ``              |
| [`3635ded1`](https://github.com/NixOS/nixpkgs/commit/3635ded162ea60708d5adb811e4cdd34fdb397d5) | `` python312Packages.aiounittest: fix tests by moving to pynose ``                         |
| [`dfe7aace`](https://github.com/NixOS/nixpkgs/commit/dfe7aace8b820b9150fe1d7ac9fa57151f186a34) | `` python311Packages.python-ironicclient: 5.4.0 -> 5.5.0 ``                                |
| [`e33e623d`](https://github.com/NixOS/nixpkgs/commit/e33e623d727d11abb1e2fad5e811db4fed01f4c9) | `` calibre: 7.5.1 -> 7.6.0 ``                                                              |
| [`bc78ba46`](https://github.com/NixOS/nixpkgs/commit/bc78ba4618e0356cbf29bc20a4cd1bd52f860947) | `` python311Packages.botocore-stubs: 1.34.52 -> 1.34.53 ``                                 |
| [`02f0c7af`](https://github.com/NixOS/nixpkgs/commit/02f0c7af80e39ae5e55a72be66fd47bca81059e3) | `` python311Packages.boto3-stubs: 1.34.52 -> 1.34.53 ``                                    |
| [`42cc9e42`](https://github.com/NixOS/nixpkgs/commit/42cc9e42cb33d1ed822299a5472d1fdc1608cac3) | `` python311Packages.aiomysensors: 0.3.12 -> 0.3.13 ``                                     |
| [`6d1747e8`](https://github.com/NixOS/nixpkgs/commit/6d1747e8e67b7124bf2b2bc021f53608d254972f) | `` python311Packages.aioautomower: 2024.2.9 -> 2024.2.10 ``                                |
| [`a25dba4c`](https://github.com/NixOS/nixpkgs/commit/a25dba4cbda455c79ac7412c9f78215609bef182) | `` python311Packages.aioairzone-cloud: 0.3.8 -> 0.4.5 ``                                   |
| [`9e03d5d0`](https://github.com/NixOS/nixpkgs/commit/9e03d5d0310511dcbe7ea2a08947470a5c3362b9) | `` python311Packages.tencentcloud-sdk-python: 3.0.1094 -> 3.0.1098 ``                      |
| [`9547597b`](https://github.com/NixOS/nixpkgs/commit/9547597b5437cb24675877f057c1c5c01890cfcf) | `` python311Packages.weconnect: 0.60.1 -> 0.60.2 ``                                        |