### PR TITLE
chore(flake/home-manager): `23ff9821` -> `b0b0c3d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -680,11 +680,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709578243,
-        "narHash": "sha256-hF96D+c2PBmAFhymMw3z8hou++lqKtZ7IzpFbYeL1/Y=",
+        "lastModified": 1709988192,
+        "narHash": "sha256-qxwIkl85P0I1/EyTT+NJwzbXdOv86vgZxcv4UKicjK8=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "23ff9821bcaec12981e32049e8687f25f11e5ef3",
+        "rev": "b0b0c3d94345050a7f86d1ebc6c56eea4389d030",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                   |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
| [`b0b0c3d9`](https://github.com/nix-community/home-manager/commit/b0b0c3d94345050a7f86d1ebc6c56eea4389d030) | `` targets/generic-linux: use xdg path for defexpr ``     |
| [`16311f1d`](https://github.com/nix-community/home-manager/commit/16311f1d3c518656f680b7d09e29e37826f9802e) | `` borgmatic: add option for pattern matching ``          |
| [`17431970`](https://github.com/nix-community/home-manager/commit/17431970b4ebc75a92657101ccffcfc9e1f9d8f0) | `` files: fix activation under Nix 2.3 ``                 |
| [`b3a9fb9d`](https://github.com/nix-community/home-manager/commit/b3a9fb9d05e5117413eb87867cebd0ecc2f59b7e) | `` treewide: stop `run` from discarding error messages `` |
| [`bfc438e9`](https://github.com/nix-community/home-manager/commit/bfc438e9b707502dce0474738eff562a38046dc1) | `` ranger: add module ``                                  |
| [`b550d074`](https://github.com/nix-community/home-manager/commit/b550d074fbcd31ac90012596c4d3f5b775dcaddd) | `` zk: add module ``                                      |
| [`8b07ca54`](https://github.com/nix-community/home-manager/commit/8b07ca541939211d3cc437ddfd74ebdef3d72471) | `` rio: fix docbookisms ``                                |
| [`9a3a5b44`](https://github.com/nix-community/home-manager/commit/9a3a5b4402e49ac62badff01b095f222724500a0) | `` rio: use XDG config for both linux and darwin ``       |
| [`417015af`](https://github.com/nix-community/home-manager/commit/417015af0dc2525557ab36528643c2d519ca4334) | `` himalaya: adjust code for v1.0.0-beta.3 ``             |
| [`0c65bfa3`](https://github.com/nix-community/home-manager/commit/0c65bfa3cf7e8621a6cd3da500f591e2e92a6259) | `` git-sync: allow passing extraPackages to service ``    |
| [`1283bf6e`](https://github.com/nix-community/home-manager/commit/1283bf6ebbdee4d980b7551bed4c6596805e812c) | `` xdg-user-dirs: check for existing symlink ``           |
| [`cf111d1a`](https://github.com/nix-community/home-manager/commit/cf111d1a849ddfc38e9155be029519b0e2329615) | `` zsh: improve `shell{,Global}Aliases` ``                |
| [`ad9254cd`](https://github.com/nix-community/home-manager/commit/ad9254cd9af9165000ecd6ef9c23c2b8ceda01c7) | `` vdirsyncer: fix verify option type (#5096) ``          |
| [`f240015a`](https://github.com/nix-community/home-manager/commit/f240015a3a2e03370cb86a820909af14ec1ed35a) | `` gallery-dl: add package option ``                      |
| [`8d9fde0f`](https://github.com/nix-community/home-manager/commit/8d9fde0fba21425729905f795fe72c2840a20442) | `` i3/sway: remove sebtm maintainer ``                    |
| [`692726d2`](https://github.com/nix-community/home-manager/commit/692726d2ad5727cf14c563d0f1d2c015c021d7a5) | `` Translate using Weblate (German) ``                    |
| [`d19bf3ae`](https://github.com/nix-community/home-manager/commit/d19bf3ae21686854760cfc5e81f269ea51072563) | `` Add translation using Weblate (Vietnamese) ``          |
| [`f30d23fa`](https://github.com/nix-community/home-manager/commit/f30d23faccdeb8237168525be65f55e44811e4c1) | `` Translate using Weblate (French) ``                    |
| [`572b0706`](https://github.com/nix-community/home-manager/commit/572b070627c62eee20b9f0254128890a69894fc2) | `` Add translation using Weblate (Vietnamese) ``          |
| [`c7e50657`](https://github.com/nix-community/home-manager/commit/c7e50657fb167023a79d6dd3d15be577ea97baab) | `` Translate using Weblate (Chinese (Simplified)) ``      |
| [`571ac919`](https://github.com/nix-community/home-manager/commit/571ac9199c80e42c8e49b9095d5a93a58a17e770) | `` Translate using Weblate (German) ``                    |
| [`ae84f4fd`](https://github.com/nix-community/home-manager/commit/ae84f4fd2c56c0766c5b12c3efda102b749aed56) | `` Translate using Weblate (Italian) ``                   |
| [`40c57ce0`](https://github.com/nix-community/home-manager/commit/40c57ce052cc8ef1bf0c836b87263a43b69e1fb6) | `` programs.khal: Simplify calendar setup (#5073) ``      |
| [`613384a5`](https://github.com/nix-community/home-manager/commit/613384a51119ea34af58eb5e611e7f31dd3970d6) | `` tests: include a service in integration tests ``       |
| [`950673ce`](https://github.com/nix-community/home-manager/commit/950673cec79298d9a1072499e0181849545376e2) | `` pueue: always write configuration file ``              |
| [`47717650`](https://github.com/nix-community/home-manager/commit/477176502a6e099192da61984cd5be896d0b5659) | `` flake.lock: Update ``                                  |
| [`1d717f58`](https://github.com/nix-community/home-manager/commit/1d717f581b7b001b2a1293277a1d3386fca5b87e) | `` gpg-agent: Fix nushell integration ``                  |
| [`3c7bacf1`](https://github.com/nix-community/home-manager/commit/3c7bacf1d42e533299c5e3baf74556a0e0ac3d0e) | `` ci: remove cachix action ``                            |
| [`9daee941`](https://github.com/nix-community/home-manager/commit/9daee941ab013b057df34ebb7f1c41cafabfea95) | `` gpg: fix immutable keyfile test ``                     |
| [`c386fde5`](https://github.com/nix-community/home-manager/commit/c386fde594c016865ecc98235a0454bea782ecc7) | `` bemenu: stub package in tests ``                       |
| [`bdea159f`](https://github.com/nix-community/home-manager/commit/bdea159ffab9865f808b8d92fd2bef33521867b2) | `` fcitx5: fix reference to fcitx5-with-addons ``         |