### PR TITLE
chore(flake/hyprland): `05dd204c` -> `335506d5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -538,7 +538,7 @@
     },
     "flake-utils_3": {
       "inputs": {
-        "systems": "systems_4"
+        "systems": "systems_5"
       },
       "locked": {
         "lastModified": 1709126324,
@@ -556,7 +556,7 @@
     },
     "flake-utils_4": {
       "inputs": {
-        "systems": "systems_5"
+        "systems": "systems_6"
       },
       "locked": {
         "lastModified": 1694529238,
@@ -574,7 +574,7 @@
     },
     "flake-utils_5": {
       "inputs": {
-        "systems": "systems_6"
+        "systems": "systems_7"
       },
       "locked": {
         "lastModified": 1701680307,
@@ -592,7 +592,7 @@
     },
     "flake-utils_6": {
       "inputs": {
-        "systems": "systems_7"
+        "systems": "systems_8"
       },
       "locked": {
         "lastModified": 1701680307,
@@ -693,21 +693,48 @@
         "type": "github"
       }
     },
+    "hyprcursor": {
+      "inputs": {
+        "hyprlang": "hyprlang",
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709942067,
+        "narHash": "sha256-DGU4zQDwIx6pXM6oHdA+89UU/QjqE05HiXOvigECJjI=",
+        "owner": "hyprwm",
+        "repo": "hyprcursor",
+        "rev": "a2233d4a2a58233457712acfd88d10a2a8a85711",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprcursor",
+        "type": "github"
+      }
+    },
     "hyprland": {
       "inputs": {
+        "hyprcursor": "hyprcursor",
         "hyprland-protocols": "hyprland-protocols",
-        "hyprlang": "hyprlang",
+        "hyprlang": "hyprlang_2",
         "nixpkgs": "nixpkgs_2",
-        "systems": "systems_3",
+        "systems": "systems_4",
         "wlroots": "wlroots",
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1709671568,
-        "narHash": "sha256-SLuttkmvMLZZmGruMrIzp6V0jl9urjvFpvKhgSSZcy8=",
+        "lastModified": 1710026388,
+        "narHash": "sha256-Z/ReJhaauOe+uThHB1LJ/3tJOnNxdYybS72Z8gkRWT8=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "05dd204c5feddd18084a4ae5e4747579b0728a23",
+        "rev": "335506d5557b91a0baf974750c353443841e691b",
         "type": "github"
       },
       "original": {
@@ -745,6 +772,29 @@
       "inputs": {
         "nixpkgs": [
           "hyprland",
+          "hyprcursor",
+          "nixpkgs"
+        ],
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1709914708,
+        "narHash": "sha256-bR4o3mynoTa1Wi4ZTjbnsZ6iqVcPGriXp56bZh5UFTk=",
+        "owner": "hyprwm",
+        "repo": "hyprlang",
+        "rev": "a685493fdbeec01ca8ccdf1f3655c044a8ce2fe2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprlang",
+        "type": "github"
+      }
+    },
+    "hyprlang_2": {
+      "inputs": {
+        "nixpkgs": [
+          "hyprland",
           "nixpkgs"
         ],
         "systems": [
@@ -753,11 +803,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708787654,
-        "narHash": "sha256-7ACgM3ZuAhPqurXHUvR2nWMRcnmzGGPjLK6q4DSTelI=",
+        "lastModified": 1709914708,
+        "narHash": "sha256-bR4o3mynoTa1Wi4ZTjbnsZ6iqVcPGriXp56bZh5UFTk=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "0fce791ba2334aca183f2ed42399518947550d0d",
+        "rev": "a685493fdbeec01ca8ccdf1f3655c044a8ce2fe2",
         "type": "github"
       },
       "original": {
@@ -1231,11 +1281,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1708807242,
-        "narHash": "sha256-sRTRkhMD4delO/hPxxi+XwLqPn8BuUq6nnj4JqLwOu0=",
+        "lastModified": 1709703039,
+        "narHash": "sha256-6hqgQ8OK6gsMu1VtcGKBxKQInRLHtzulDo9Z5jxHEFY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "73de017ef2d18a04ac4bfd0c02650007ccb31c2a",
+        "rev": "9df3e30ce24fd28c7b3e2de0d986769db5d6225d",
         "type": "github"
       },
       "original": {
@@ -1562,16 +1612,16 @@
     },
     "systems_4": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
         "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "default",
+        "repo": "default-linux",
         "type": "github"
       }
     },
@@ -1620,6 +1670,21 @@
         "type": "github"
       }
     },
+    "systems_8": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
@@ -1644,18 +1709,18 @@
       "flake": false,
       "locked": {
         "host": "gitlab.freedesktop.org",
-        "lastModified": 1708558866,
-        "narHash": "sha256-Mz6hCtommq7RQfcPnxLINigO4RYSNt23HeJHC6mVmWI=",
+        "lastModified": 1709983277,
+        "narHash": "sha256-wXWIJLd4F2JZeMaihWVDW/yYXCLEC8OpeNJZg9a9ly8=",
         "owner": "wlroots",
         "repo": "wlroots",
-        "rev": "0cb091f1a2d345f37d2ee445f4ffd04f7f4ec9e5",
+        "rev": "50eae512d9cecbf0b3b1898bb1f0b40fa05fe19b",
         "type": "gitlab"
       },
       "original": {
         "host": "gitlab.freedesktop.org",
         "owner": "wlroots",
         "repo": "wlroots",
-        "rev": "0cb091f1a2d345f37d2ee445f4ffd04f7f4ec9e5",
+        "rev": "50eae512d9cecbf0b3b1898bb1f0b40fa05fe19b",
         "type": "gitlab"
       }
     },
@@ -1679,11 +1744,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708696469,
-        "narHash": "sha256-shh5wmpeYy3MmsBfkm4f76yPsBDGk6OLYRVG+ARy2F0=",
+        "lastModified": 1709299639,
+        "narHash": "sha256-jYqJM5khksLIbqSxCLUUcqEgI+O2LdlSlcMEBs39CAU=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "1b713911c2f12b96c2574474686e4027ac4bf826",
+        "rev": "2d2fb547178ec025da643db57d40a971507b82fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                           |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
| [`335506d5`](https://github.com/hyprwm/Hyprland/commit/335506d5557b91a0baf974750c353443841e691b) | `` constraints: only warp cursor on deactivate if constraint is locked. (#5056) ``                |
| [`b0f98a3d`](https://github.com/hyprwm/Hyprland/commit/b0f98a3d3e9e5f5f7f89fa4e855dbeb860e7a0c4) | `` compositor: reject focus to noFocus OR xwayland windows ``                                     |
| [`2ed032a7`](https://github.com/hyprwm/Hyprland/commit/2ed032a7fd140ee85483a891fa63c16668019577) | `` xwayland: fix no_xwayland compiles ``                                                          |
| [`739c5bc9`](https://github.com/hyprwm/Hyprland/commit/739c5bc98c6037101e5744827dd66e696a4e9ecd) | `` cursormgr: fix invalid access to hyprcursor in xwayland init ``                                |
| [`26cd1bf9`](https://github.com/hyprwm/Hyprland/commit/26cd1bf949d0460b754fe3b1ae7f06bd4b2535ee) | `` input: fix minor default cursor reset conditions ``                                            |
| [`18a35b14`](https://github.com/hyprwm/Hyprland/commit/18a35b140681767e055bb78d268efafab8664f90) | `` cursormgr: fix memory leak with cursor buffers ``                                              |
| [`7e41e514`](https://github.com/hyprwm/Hyprland/commit/7e41e5146d124aa1161a73c249d41ad60f1bb162) | `` cursormgr: add fallbacks for unknown cursors ``                                                |
| [`c3882bb8`](https://github.com/hyprwm/Hyprland/commit/c3882bb83240b602277f2d22f21d71690531f62e) | `` internal: Support libhyprcursor (#5009) ``                                                     |
| [`e7a5db48`](https://github.com/hyprwm/Hyprland/commit/e7a5db4852d654596e554b9cdeaa2694b346ee03) | `` xwayland: Set xwayland's name prop (#4924) ``                                                  |
| [`a01949dd`](https://github.com/hyprwm/Hyprland/commit/a01949dd286ba67f8026aeec38b44b61e20be412) | `` deco: fix warnings ``                                                                          |
| [`fa886d8b`](https://github.com/hyprwm/Hyprland/commit/fa886d8b11b5d38f9fa12debcdd1f992b258406a) | `` [gha] Nix: update wlroots ``                                                                   |
| [`3f58e77e`](https://github.com/hyprwm/Hyprland/commit/3f58e77e75efad11edf5a0f6fd41f57a796323aa) | `` deps: update wlroots ``                                                                        |
| [`300d77ed`](https://github.com/hyprwm/Hyprland/commit/300d77edd9833db42c999a91271ae23a5be69ef2) | `` keybinds: track submap at press for keypresses ``                                              |
| [`c9ea600b`](https://github.com/hyprwm/Hyprland/commit/c9ea600baa186acd3825dde306a6b3f89de09131) | `` layer-shell: allow for popup creation before map ``                                            |
| [`3e930a56`](https://github.com/hyprwm/Hyprland/commit/3e930a568a76a810dde6bcabcf737a81850e7153) | `` format: fix format ``                                                                          |
| [`024d4ddc`](https://github.com/hyprwm/Hyprland/commit/024d4ddc74c9bd7945c4075c972575f20bc5b9bd) | `` input: scale local coords in constraints ``                                                    |
| [`717d5b3c`](https://github.com/hyprwm/Hyprland/commit/717d5b3cc2b9e2f94d3ec1ba794e21bc2bb787e3) | `` hyprctl: hide unmapped windows without -a ``                                                   |
| [`0a4ade01`](https://github.com/hyprwm/Hyprland/commit/0a4ade01d35abb4506da77cc64ab93e0c5c34dbd) | `` format: make ci happy ``                                                                       |
| [`5920c6a6`](https://github.com/hyprwm/Hyprland/commit/5920c6a6b8d059413377f0cb25f3dfb1dc8c4201) | `` socket2: Add 5 IPC event with support for workspace ID (#5022) ``                              |
| [`4c34e4aa`](https://github.com/hyprwm/Hyprland/commit/4c34e4aac25309b1203b5527387c8425f8e84ca8) | `` windowrules: minor improvements to min/max size ``                                             |
| [`d1c80c31`](https://github.com/hyprwm/Hyprland/commit/d1c80c31c8d4bdaff37c04d0e713cb8ba71f7588) | `` README: change dwl link to new codeberg link (#5026) ``                                        |
| [`1290507a`](https://github.com/hyprwm/Hyprland/commit/1290507ac418bd48490522da9bf612d271e87010) | `` windowrules: check if floating when resizing from maxsize (#5019) ``                           |
| [`e52d3fa8`](https://github.com/hyprwm/Hyprland/commit/e52d3fa8522ff83813a9006d4bf46b3057f4a4cc) | `` windowrules: Make min/maxsize rules dynamic (#4775) ``                                         |
| [`ceecdd0f`](https://github.com/hyprwm/Hyprland/commit/ceecdd0fd511122b7ff4f477a606880fe6599100) | `` hyprctl: Fix incorrect invalid fontsize kwarg response (#5013) ``                              |
| [`6c4e2489`](https://github.com/hyprwm/Hyprland/commit/6c4e2489a0a153ac2a92744ecb2985280c97fc89) | `` layout: Fix toggling fullscreen special workspace on different monitor (#5000) ``              |
| [`bf71026b`](https://github.com/hyprwm/Hyprland/commit/bf71026b8d31edc86a97222ef0fbec4972635cac) | `` master: change active monitor when moving windows around (#5001) ``                            |
| [`77161fdb`](https://github.com/hyprwm/Hyprland/commit/77161fdbef72033ea1989e4c4d386a5732bd6bf0) | `` flake.lock: update ``                                                                          |
| [`ce072638`](https://github.com/hyprwm/Hyprland/commit/ce072638e9d86aac15c5ff4c6dd777b2894af422) | `` Nix: use propagatedBuildInputs instead of wrapping ``                                          |
| [`95769a3c`](https://github.com/hyprwm/Hyprland/commit/95769a3c54448e8e65b1bb0c3d4e7ff3bb9edaba) | `` compositor: update state after moving to workspace ``                                          |
| [`067df843`](https://github.com/hyprwm/Hyprland/commit/067df84388be41b7b2352918060c2e9d88717740) | `` notify: Add custom fontsize support for notifications (#4981) ``                               |
| [`8e2a62e5`](https://github.com/hyprwm/Hyprland/commit/8e2a62e53bf51e8b4ae719d0e46797b0a26eeb22) | `` events: apply monitor state on sessionActive ``                                                |
| [`669ea8a3`](https://github.com/hyprwm/Hyprland/commit/669ea8a373f6d365c16ab40a82953f2e52faa765) | `` ci: pack hyprpm to the release tar ``                                                          |
| [`082bf002`](https://github.com/hyprwm/Hyprland/commit/082bf002546cfa7aaa7c5b79b03a1b6dd95454af) | `` hyprpm: Add support for specifying exact git revisions for plugin repo (#4983) ``              |
| [`d6f1b151`](https://github.com/hyprwm/Hyprland/commit/d6f1b151b2fe85ffbb131cbdd05acefc6a357e81) | `` animations: fix m_Goal not being set after #4911 (#4992) ``                                    |
| [`fb87e332`](https://github.com/hyprwm/Hyprland/commit/fb87e332c59ce386a095b3e81bb1abbcc9cc3e5c) | `` input: fix window move stutter by introducing additional checks for low-hz monitors (#4553) `` |
| [`b1e2ca04`](https://github.com/hyprwm/Hyprland/commit/b1e2ca04a016b1ea24344d3cfb2eb3370863eb5e) | `` CrashReporter: Fix compilation with musl libc (#4805) ``                                       |