### PR TITLE
chore(flake/nix-index-database): `93554c04` -> `2ad5ebce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1067,11 +1067,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709435391,
-        "narHash": "sha256-s4itTkIVxn5lYeTzwkbAgl99atnjdZv1idI1118vdzA=",
+        "lastModified": 1709906691,
+        "narHash": "sha256-206XMy1NGW42bnHukJl5W2F90yHNoJc7+H3i+/8i2Pg=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "93554c04c2f1c02f4a383538e8848d511c3129e9",
+        "rev": "2ad5ebce1e1be47a8cf330d85265ac09ffa15178",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                  |
| ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`56335944`](https://github.com/nix-community/nix-index-database/commit/56335944627b7360c31da13c73aa521d996637d8) | `` Document nix-locate usage. Fix #79 `` |
| [`c46d85da`](https://github.com/nix-community/nix-index-database/commit/c46d85da736e6b2563cf1f284f7e054bd87b9b38) | `` readme: Mic92 -> nix-community ``     |