### PR TITLE
chore(flake/emacs-overlay): `fb22d2ec` -> `4dd04421`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -290,11 +290,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1709657478,
-        "narHash": "sha256-EsC1qEMGfJo+oosdgMdmgKLKXZXIzTEc2PEQ26EofpQ=",
+        "lastModified": 1710003807,
+        "narHash": "sha256-NVQosZpEz9dDo2f9I84P9NCsVjx2NQy3T9Lpp3TbJJs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fb22d2ecf6d4741221eba1950d5fb6b1702b9a26",
+        "rev": "4dd04421a91873b26f5b4acc8b2c947cb91c7900",
         "type": "github"
       },
       "original": {
@@ -1199,11 +1199,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1709569716,
-        "narHash": "sha256-iOR44RU4jQ+YPGrn+uQeYAp7Xo7Z/+gT+wXJoGxxLTY=",
+        "lastModified": 1709884566,
+        "narHash": "sha256-NSYJg2sfdO/XS3L8XN/59Zhzn0dqWm7XtVnKI2mHq3w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "617579a787259b9a6419492eaac670a5f7663917",
+        "rev": "2be119add7b37dc535da2dd4cba68e2cf8d1517e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`4dd04421`](https://github.com/nix-community/emacs-overlay/commit/4dd04421a91873b26f5b4acc8b2c947cb91c7900) | `` Updated emacs ``        |
| [`0247f642`](https://github.com/nix-community/emacs-overlay/commit/0247f6426f346c7ffd575ed938ee835cea1b329e) | `` Updated melpa ``        |
| [`74be16c1`](https://github.com/nix-community/emacs-overlay/commit/74be16c1d2aaecc4e3cd19d323e89f528b492a57) | `` Updated elpa ``         |
| [`aed9a9e5`](https://github.com/nix-community/emacs-overlay/commit/aed9a9e58391a498c2ed2b5bbd0b59ec3d862f6d) | `` Updated emacs ``        |
| [`1e2aa1e2`](https://github.com/nix-community/emacs-overlay/commit/1e2aa1e26bc1a49b1ff4326e7b5193bcfb732129) | `` Updated melpa ``        |
| [`db47b248`](https://github.com/nix-community/emacs-overlay/commit/db47b2483942771a725cf10e7cd3b1ec562750b7) | `` Updated flake inputs `` |
| [`e32ea52f`](https://github.com/nix-community/emacs-overlay/commit/e32ea52fb7488de5a89f93dafe3050c30dab21fd) | `` Updated emacs ``        |
| [`831c263f`](https://github.com/nix-community/emacs-overlay/commit/831c263fb23fb7f1319c594130a59fdea819ecc7) | `` Updated melpa ``        |
| [`79a88091`](https://github.com/nix-community/emacs-overlay/commit/79a880910d54496696b71804aba9a8baeb7257e1) | `` Updated elpa ``         |
| [`5cc9aea5`](https://github.com/nix-community/emacs-overlay/commit/5cc9aea5965112e115907410eb7d0e578f269680) | `` Updated elpa ``         |
| [`6cd7ddb6`](https://github.com/nix-community/emacs-overlay/commit/6cd7ddb6c8a8ac4b2bfb35ca3261d3e689740c8e) | `` Updated emacs ``        |
| [`306bf8bb`](https://github.com/nix-community/emacs-overlay/commit/306bf8bbce411033bbef90fd29018b468cb988a3) | `` Updated melpa ``        |
| [`da023f67`](https://github.com/nix-community/emacs-overlay/commit/da023f67f164e5571faeac7feec565f211a1b27b) | `` Updated elpa ``         |
| [`50ac0adb`](https://github.com/nix-community/emacs-overlay/commit/50ac0adb684bcde50574db50f814960545620730) | `` Updated emacs ``        |
| [`368f873d`](https://github.com/nix-community/emacs-overlay/commit/368f873d4066da95159c2095a847f6c36d74af83) | `` Updated melpa ``        |
| [`35b810dc`](https://github.com/nix-community/emacs-overlay/commit/35b810dcbe9543e026f6a7095b955f7c9643b9b3) | `` Updated emacs ``        |
| [`4cab03f2`](https://github.com/nix-community/emacs-overlay/commit/4cab03f2abf26865a6696e593b2cefe942c37216) | `` Updated melpa ``        |
| [`1a4c7993`](https://github.com/nix-community/emacs-overlay/commit/1a4c799379c9e34c1143e10e2379fc9bfaeed5b7) | `` Updated flake inputs `` |
| [`e720d1e4`](https://github.com/nix-community/emacs-overlay/commit/e720d1e442dbdd2ea55cddfe3e918ba2868f2c56) | `` Updated emacs ``        |
| [`a1e4ce73`](https://github.com/nix-community/emacs-overlay/commit/a1e4ce731728a2caeb622945efc360641dde2eff) | `` Updated melpa ``        |
| [`534e9e5c`](https://github.com/nix-community/emacs-overlay/commit/534e9e5cfacc2231cef91cd8bb566fc913f870e5) | `` Updated elpa ``         |
| [`2f8aaed4`](https://github.com/nix-community/emacs-overlay/commit/2f8aaed4b9cf8b9337af27f887022285d6455cc8) | `` Updated nongnu ``       |
| [`8bac1264`](https://github.com/nix-community/emacs-overlay/commit/8bac12643777ddcade600de7752615867f7f518f) | `` Updated melpa ``        |
| [`d6fc9ce4`](https://github.com/nix-community/emacs-overlay/commit/d6fc9ce426b1574182f0db5b395386920750a61b) | `` Updated emacs ``        |
| [`3f549c3f`](https://github.com/nix-community/emacs-overlay/commit/3f549c3f5f9c4f764779fa161fbe5a245e6fb5c2) | `` Updated elpa ``         |
| [`984860d0`](https://github.com/nix-community/emacs-overlay/commit/984860d0f4f5c3a6d1d92d0ac3cd1c081408e138) | `` Updated emacs ``        |
| [`abc67e1b`](https://github.com/nix-community/emacs-overlay/commit/abc67e1b6e96a8da4fed8c5bc6ab962cf05a3dec) | `` Updated melpa ``        |
| [`9ae82c10`](https://github.com/nix-community/emacs-overlay/commit/9ae82c10a7065080516fb7665a143ff6f8a57136) | `` Updated emacs ``        |
| [`efdcd87f`](https://github.com/nix-community/emacs-overlay/commit/efdcd87f425e4c37a7053b0466100bb0cba74889) | `` Updated melpa ``        |
| [`c61a9a41`](https://github.com/nix-community/emacs-overlay/commit/c61a9a413d4423c2c08ed0fa740e9d124db316a3) | `` Updated elpa ``         |