### PR TITLE
chore(flake/spicetify-nix): `15aa1288` -> `f97c89ae`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1502,11 +1502,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709611865,
-        "narHash": "sha256-oTfe4qY+dV5vYYTLKKt7+o1YCRZRMCxE3jIfO+TB7Y4=",
+        "lastModified": 1709957366,
+        "narHash": "sha256-6oS3oHhUQbevVItRU8b4WQIZFAEu0hyoE0WOFdDCvGQ=",
         "owner": "Gerg-L",
         "repo": "spicetify-nix",
-        "rev": "15aa1288278bb4903b66b7738b2893672e3ea857",
+        "rev": "f97c89aebd7076cce03c56466269cabb3d7c75f5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                          |
| ----------------------------------------------------------------------------------------------------- | -------------------------------- |
| [`f97c89ae`](https://github.com/Gerg-L/spicetify-nix/commit/f97c89aebd7076cce03c56466269cabb3d7c75f5) | `` CI update 2024-03-09 (#95) `` |
| [`8a3bcc8f`](https://github.com/Gerg-L/spicetify-nix/commit/8a3bcc8f4be5366aed588c8181874f40e7822291) | `` CI update 2024-03-08 (#94) `` |
| [`542ef89b`](https://github.com/Gerg-L/spicetify-nix/commit/542ef89b09568ed8c324281e9afeafa05619a5e9) | `` CI update 2024-03-07 (#93) `` |