### PR TITLE
chore(flake/nur): `c10daa69` -> `91cc2004`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1325,11 +1325,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1709670325,
-        "narHash": "sha256-8kaRyki/vK0dQeH6tRxy/xW9Ocq2jF5rwEsH5iLFbzM=",
+        "lastModified": 1710019138,
+        "narHash": "sha256-6v+/OWVboOYiv6Eb75HEDMVXp3kyExgJPOkn3NnpGJE=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "c10daa69f6a06c5743ab07c111ee546ce6698098",
+        "rev": "91cc200411377bd61e63526d925a82be50dc9d7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                |
| -------------------------------------------------------------------------------------------------- | ---------------------- |
| [`91cc2004`](https://github.com/nix-community/NUR/commit/91cc200411377bd61e63526d925a82be50dc9d7f) | `` automatic update `` |
| [`0fcbd140`](https://github.com/nix-community/NUR/commit/0fcbd140884d31178bfeae69998e7472b53de304) | `` automatic update `` |
| [`cf1e9b0e`](https://github.com/nix-community/NUR/commit/cf1e9b0e085368cc489c765f285f1d07c2ec8d36) | `` automatic update `` |
| [`414e2ef3`](https://github.com/nix-community/NUR/commit/414e2ef360397c9e024d09dda6de78455d2e00b2) | `` automatic update `` |
| [`ef329c54`](https://github.com/nix-community/NUR/commit/ef329c544e503cb626c0927c9bd67df7b163bd65) | `` automatic update `` |
| [`b9fdd3da`](https://github.com/nix-community/NUR/commit/b9fdd3dace5a629c585a2e137563c2a04fe59e40) | `` automatic update `` |
| [`a2c8dbc6`](https://github.com/nix-community/NUR/commit/a2c8dbc69af439969f96519317880bd1f5b352c8) | `` automatic update `` |
| [`65c8f63b`](https://github.com/nix-community/NUR/commit/65c8f63bfac1d8113b0fefeee2ea306fabc76987) | `` automatic update `` |
| [`ffe51132`](https://github.com/nix-community/NUR/commit/ffe511324b8e9853e6fda172d033b6de2897c941) | `` automatic update `` |
| [`b8dc242a`](https://github.com/nix-community/NUR/commit/b8dc242a9cf5b85b798ac1ba235e7ced8323b760) | `` automatic update `` |
| [`a725b78c`](https://github.com/nix-community/NUR/commit/a725b78cdcdefe02dc4de9ba32f270d16d32628f) | `` automatic update `` |
| [`01e63128`](https://github.com/nix-community/NUR/commit/01e631284d5ad81e58fc332086f435f0a57bb00d) | `` automatic update `` |
| [`7d1f369d`](https://github.com/nix-community/NUR/commit/7d1f369d01ee0eb3e05fd1b9fb25e73992df625b) | `` automatic update `` |
| [`2f11b175`](https://github.com/nix-community/NUR/commit/2f11b175650fb864efa620aa1db5f47eb9408d52) | `` automatic update `` |
| [`760b9ced`](https://github.com/nix-community/NUR/commit/760b9ced75917fd0b7d80765511b70c1fbb0ae6e) | `` automatic update `` |
| [`3f83e9c6`](https://github.com/nix-community/NUR/commit/3f83e9c6d97104c5b87563784d1b25edf1c2b952) | `` automatic update `` |
| [`79e75953`](https://github.com/nix-community/NUR/commit/79e7595387c63174a948c951a580eecad498384c) | `` automatic update `` |
| [`17c9e04c`](https://github.com/nix-community/NUR/commit/17c9e04c8053f5722a5c8a1239108294fa6764e1) | `` automatic update `` |
| [`76f8da45`](https://github.com/nix-community/NUR/commit/76f8da4574c89286569aa292316ea3843227a8eb) | `` automatic update `` |
| [`699643a5`](https://github.com/nix-community/NUR/commit/699643a50ddd0a758c3d73af3cd52afb270a2f0e) | `` automatic update `` |
| [`3a6e31e6`](https://github.com/nix-community/NUR/commit/3a6e31e637e8bb05567741cf98b914c41400b1d0) | `` automatic update `` |
| [`71ff7f65`](https://github.com/nix-community/NUR/commit/71ff7f65c103361e170371351d742dc42bf4ff2f) | `` automatic update `` |
| [`e6999b0b`](https://github.com/nix-community/NUR/commit/e6999b0bacd992f609dcb1657461c682addaf9d0) | `` automatic update `` |
| [`0e308c95`](https://github.com/nix-community/NUR/commit/0e308c9589e11470660afed7c69f530ae6253c15) | `` automatic update `` |
| [`aa86c655`](https://github.com/nix-community/NUR/commit/aa86c6552aa736aa9f1ec2121d2d745d0f113521) | `` automatic update `` |
| [`f0549341`](https://github.com/nix-community/NUR/commit/f0549341806ffe0d50059a2c4cdfd73380cc1800) | `` automatic update `` |
| [`2a86b0c0`](https://github.com/nix-community/NUR/commit/2a86b0c093a448ad66cef5a51eff81433a43edb8) | `` automatic update `` |
| [`abf0979b`](https://github.com/nix-community/NUR/commit/abf0979b47bd2c9746e552f43cb99a9f714fcd8b) | `` automatic update `` |
| [`1cc9f2fb`](https://github.com/nix-community/NUR/commit/1cc9f2fb404ca1d261338ba0ebde17cfe6155def) | `` automatic update `` |
| [`16940537`](https://github.com/nix-community/NUR/commit/16940537af952d8d2cf870eda0d2f355addcaba6) | `` automatic update `` |
| [`b1c8505d`](https://github.com/nix-community/NUR/commit/b1c8505d06299a4b6ef3ad332a5d59d10a2e9077) | `` automatic update `` |
| [`49341904`](https://github.com/nix-community/NUR/commit/4934190443e3ef3cd172c789c1315635df133486) | `` automatic update `` |
| [`8e291fa4`](https://github.com/nix-community/NUR/commit/8e291fa4e2b9e8a6a0b740239e1c10e20858299b) | `` automatic update `` |
| [`8803df6e`](https://github.com/nix-community/NUR/commit/8803df6e3a9b825ad7979184f25471719e7040bb) | `` automatic update `` |
| [`81222c58`](https://github.com/nix-community/NUR/commit/81222c588980f9c4615195ec2723576504b48316) | `` automatic update `` |
| [`dc353b85`](https://github.com/nix-community/NUR/commit/dc353b8596452bc4ecd7cdb6ed1d64314cf87981) | `` automatic update `` |
| [`5c70fdaf`](https://github.com/nix-community/NUR/commit/5c70fdaf1205fa010f458b6a2f3835f14e32e3b4) | `` automatic update `` |
| [`9ef12405`](https://github.com/nix-community/NUR/commit/9ef124059b9f2fb675ae3a6ae68e62a3ef8f7b6a) | `` automatic update `` |
| [`974b64aa`](https://github.com/nix-community/NUR/commit/974b64aacff650ec2e9b6d71e6c86a48ff9216e5) | `` automatic update `` |
| [`7f0e6093`](https://github.com/nix-community/NUR/commit/7f0e6093eb1b84e71889ba2c3763ed55ce1bb817) | `` automatic update `` |
| [`4806f72e`](https://github.com/nix-community/NUR/commit/4806f72ee2cc5da76160fc4f003bbb777011876a) | `` automatic update `` |
| [`58fa39c2`](https://github.com/nix-community/NUR/commit/58fa39c20a5f813f127d8fc0d06e36dba31ec6af) | `` automatic update `` |
| [`7f2452fb`](https://github.com/nix-community/NUR/commit/7f2452fb0a3a523159456396ecc21be850d9e31f) | `` automatic update `` |
| [`1a38c5ff`](https://github.com/nix-community/NUR/commit/1a38c5ff874ee2f4bf017baa391f96d9643980c6) | `` automatic update `` |
| [`d0659ed2`](https://github.com/nix-community/NUR/commit/d0659ed2332119b1f89ae82f7adf3b9e0d0efd09) | `` automatic update `` |
| [`05b54830`](https://github.com/nix-community/NUR/commit/05b548306e488860c6ff962680b086a481451c4d) | `` automatic update `` |
| [`930a647c`](https://github.com/nix-community/NUR/commit/930a647ccc4d582815b1f81fcee9b406b5d929fe) | `` automatic update `` |
| [`6e7382a8`](https://github.com/nix-community/NUR/commit/6e7382a8bb7d7f3920d4ff37ecad5f53bdfe11a5) | `` automatic update `` |
| [`e0a81dd9`](https://github.com/nix-community/NUR/commit/e0a81dd9f1bac574b4c760ee087995c03c00e351) | `` automatic update `` |
| [`bfaf2fee`](https://github.com/nix-community/NUR/commit/bfaf2fee0da0b371afd5fa2f6fb4057844a9d70b) | `` automatic update `` |
| [`6ea67584`](https://github.com/nix-community/NUR/commit/6ea6758424a5feb2997261317e2cfae6c010b646) | `` automatic update `` |
| [`527f1d25`](https://github.com/nix-community/NUR/commit/527f1d2569fbbe1c6db8e44bdfb399242a307d98) | `` automatic update `` |
| [`bda1b55d`](https://github.com/nix-community/NUR/commit/bda1b55d8bd4e9f0e906a88ff38b8ae88afced73) | `` automatic update `` |
| [`33bc9053`](https://github.com/nix-community/NUR/commit/33bc905322ad38466b503a3e756c60d9e8356350) | `` automatic update `` |
| [`895e0855`](https://github.com/nix-community/NUR/commit/895e0855655804508fbeb90ed38bc82b6139c9bc) | `` automatic update `` |
| [`26eee509`](https://github.com/nix-community/NUR/commit/26eee509e64c2e8412dab1a16c3b4b33157e27f2) | `` automatic update `` |
| [`23b9ff0c`](https://github.com/nix-community/NUR/commit/23b9ff0c834c893cae94f5ba60efeebe8c5fecc9) | `` automatic update `` |
| [`9602b22e`](https://github.com/nix-community/NUR/commit/9602b22e2be274462244655685f98bc3a0954cc4) | `` automatic update `` |
| [`677476e9`](https://github.com/nix-community/NUR/commit/677476e90a9b33bf552d0b5669ee5234daa6f313) | `` automatic update `` |
| [`c8e59e17`](https://github.com/nix-community/NUR/commit/c8e59e176be96678a3921d644b4e174710233c17) | `` automatic update `` |
| [`13f3128f`](https://github.com/nix-community/NUR/commit/13f3128f689122557f2452ce3a98a66a5c7e3b77) | `` automatic update `` |
| [`ee33835d`](https://github.com/nix-community/NUR/commit/ee33835dff35a325a7140b748ac73a08fed3b13f) | `` automatic update `` |
| [`3428e6cf`](https://github.com/nix-community/NUR/commit/3428e6cf4521df6254ff5b8bcf31df84fc1dd0d2) | `` automatic update `` |
| [`24eb65ac`](https://github.com/nix-community/NUR/commit/24eb65ac74dbc70f963567ae4e88b598ce76129c) | `` automatic update `` |
| [`14f8dbec`](https://github.com/nix-community/NUR/commit/14f8dbec7f6d16c520c632f377c6ab0da706312b) | `` automatic update `` |
| [`922e9ab7`](https://github.com/nix-community/NUR/commit/922e9ab7245e8d8083cb2e8e61021e27d5f6b2f6) | `` automatic update `` |
| [`cacd071c`](https://github.com/nix-community/NUR/commit/cacd071c8805056e2072163ac115089b7983fb43) | `` automatic update `` |
| [`a7d5f1e0`](https://github.com/nix-community/NUR/commit/a7d5f1e07e7883c3e064ec87470e7e9c3840f762) | `` automatic update `` |
| [`95082a57`](https://github.com/nix-community/NUR/commit/95082a571b70231e56db5070dcdf675356da7b52) | `` automatic update `` |
| [`5e12fd0b`](https://github.com/nix-community/NUR/commit/5e12fd0b31670e7f51da6be185f2a7c44bedfb76) | `` automatic update `` |
| [`9566b92d`](https://github.com/nix-community/NUR/commit/9566b92d9be6a7e13b9381c728ef0642449a8fca) | `` automatic update `` |
| [`23f0c5dd`](https://github.com/nix-community/NUR/commit/23f0c5dd985819bd159215cf2e602b7daa2268cc) | `` automatic update `` |
| [`7316bcec`](https://github.com/nix-community/NUR/commit/7316bcece06f7b9d7fd4b4c4b2e2b4f78432942d) | `` automatic update `` |
| [`81142813`](https://github.com/nix-community/NUR/commit/81142813d61a934d2f5c9080295d18a9f3417e4d) | `` automatic update `` |
| [`e75e8885`](https://github.com/nix-community/NUR/commit/e75e8885efb15f254aebf64ec33e338ffe551ee0) | `` automatic update `` |
| [`f8f9912a`](https://github.com/nix-community/NUR/commit/f8f9912a9f678c521e4a2e061d52311844b27724) | `` automatic update `` |
| [`e4ea33b9`](https://github.com/nix-community/NUR/commit/e4ea33b9aa652e2871fbc604d1d611e6f5940a66) | `` automatic update `` |
| [`466d739c`](https://github.com/nix-community/NUR/commit/466d739cfde240577a1e201889e489f55bbda6c7) | `` automatic update `` |
| [`43d0d0b8`](https://github.com/nix-community/NUR/commit/43d0d0b8a4b5a56b53851858a5e8dce27b14381f) | `` automatic update `` |
| [`b9f3efde`](https://github.com/nix-community/NUR/commit/b9f3efdee1b6242f67dc46b782b2a27247ae0a35) | `` automatic update `` |
| [`eff97899`](https://github.com/nix-community/NUR/commit/eff97899a55520915041fc278e5f4094a89d8a49) | `` automatic update `` |
| [`12859d6d`](https://github.com/nix-community/NUR/commit/12859d6d480786d515a6b5b4ea749b194330c896) | `` automatic update `` |
| [`513ce65a`](https://github.com/nix-community/NUR/commit/513ce65ad8cb152f03f88081e80892eaadc83ea2) | `` automatic update `` |
| [`f3257281`](https://github.com/nix-community/NUR/commit/f325728186437fe1dbe732d40fe22b0d4cc13fc4) | `` automatic update `` |
| [`97d7ae67`](https://github.com/nix-community/NUR/commit/97d7ae675bb9261e8ea9036433467d7f6fc8cf57) | `` automatic update `` |
| [`8154431d`](https://github.com/nix-community/NUR/commit/8154431d2d636cd43b23a2559dee80bda631ca74) | `` automatic update `` |
| [`c210daf7`](https://github.com/nix-community/NUR/commit/c210daf7d5e72fe0807ed5c7fde52a0e8b8dc026) | `` automatic update `` |
| [`53103057`](https://github.com/nix-community/NUR/commit/5310305765d5347d5d078838f541a3f74f74fa1e) | `` automatic update `` |
| [`8d6e8a7a`](https://github.com/nix-community/NUR/commit/8d6e8a7a64fa1bef1c662a84d9643f58598eb2a7) | `` automatic update `` |
| [`fe40949e`](https://github.com/nix-community/NUR/commit/fe40949ea87f14665b7139ae414e395e58fa0b43) | `` automatic update `` |
| [`d6580e52`](https://github.com/nix-community/NUR/commit/d6580e52fa6582bd490f2b5014b505129891419f) | `` automatic update `` |
| [`9b766455`](https://github.com/nix-community/NUR/commit/9b766455d1b07a2042a14c39902728c2529174c2) | `` automatic update `` |
| [`d92ff072`](https://github.com/nix-community/NUR/commit/d92ff072d96bcbdf4eae2481f6d5bf7f55d6d312) | `` automatic update `` |
| [`73761ba8`](https://github.com/nix-community/NUR/commit/73761ba861f07b13d9717c13fbd500eec0a5ab0a) | `` automatic update `` |
| [`db764ae1`](https://github.com/nix-community/NUR/commit/db764ae1d6a0a43676d67bcb7d122338f466c377) | `` automatic update `` |
| [`94cc427b`](https://github.com/nix-community/NUR/commit/94cc427bb87caa8d954e3e80c72e39e078c93dca) | `` automatic update `` |
| [`8a98fb18`](https://github.com/nix-community/NUR/commit/8a98fb18f7884c796fccac5a4a0cc5ffb7cb47e4) | `` automatic update `` |