### PR TITLE
chore(flake/niri): `8a6cfe69` -> `3506329a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -949,16 +949,16 @@
     "niri-stable": {
       "flake": false,
       "locked": {
-        "lastModified": 1708141626,
-        "narHash": "sha256-vO6ak5rT6ntBC20vYC36zcEcHv7Cki9y8A+c7ThfsUg=",
+        "lastModified": 1709981118,
+        "narHash": "sha256-VTtXEfxc3OCdtdYiEdtftOQ7gDJNb679Yw8v1Lu3lhY=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "62892d636112230dc16778b91331fbe97576b005",
+        "rev": "acd33653b3d908b1c97e2247048af50613e4a77d",
         "type": "github"
       },
       "original": {
         "owner": "YaLTeR",
-        "ref": "v0.1.2",
+        "ref": "v0.1.3",
         "repo": "niri",
         "type": "github"
       }
@@ -966,11 +966,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1709651181,
-        "narHash": "sha256-toGTLn85MSCk0pwFQ99UGh8bv9Hf5zi5DfRWcyMMSiU=",
+        "lastModified": 1709995031,
+        "narHash": "sha256-UF9jHoZtRzSZNX8fTj+NEs3fz09p98hS8mxY9SQw5IE=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "9cbbffc23ce7610762325eb76b84fe835c4cd65f",
+        "rev": "1971a41fdd68f0a33bd5db22f776821682c23206",
         "type": "github"
       },
       "original": {
@@ -988,11 +988,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1709668268,
-        "narHash": "sha256-AODSgEoUF3fF4nPKxHwmwavnIKvz2krinEhGhIGAheg=",
+        "lastModified": 1710030115,
+        "narHash": "sha256-n2PjtWePvzHNBCRkf8+8GrRpN+ek7HmXOYmBq4JrpVQ=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "8a6cfe697d00f63c4eecabaf0a792baeea829b50",
+        "rev": "3506329ac9c452b223f02ad0f22a6af393b79921",
         "type": "github"
       },
       "original": {
@@ -1277,11 +1277,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1709479366,
-        "narHash": "sha256-n6F0n8UV6lnTZbYPl1A9q1BS0p4hduAv1mGAP17CVd0=",
+        "lastModified": 1709703039,
+        "narHash": "sha256-6hqgQ8OK6gsMu1VtcGKBxKQInRLHtzulDo9Z5jxHEFY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b8697e57f10292a6165a20f03d2f42920dfaf973",
+        "rev": "9df3e30ce24fd28c7b3e2de0d986769db5d6225d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                             |
| --------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
| [`3506329a`](https://github.com/sodiboo/niri-flake/commit/3506329ac9c452b223f02ad0f22a6af393b79921) | `` update version string to look a lot nicer ``     |
| [`d45256c9`](https://github.com/sodiboo/niri-flake/commit/d45256c9ebb9faa4cf31067bc2ee1e92915e6399) | `` flake.lock: Update ``                            |
| [`6bfdf529`](https://github.com/sodiboo/niri-flake/commit/6bfdf529a50d347f23900cf028c5c76c64df7f74) | `` niri v0.1.3; cache builds with nixpkgs stable `` |
| [`dafa93c3`](https://github.com/sodiboo/niri-flake/commit/dafa93c3e595e2718c6848ddefbffd4f28ca12f6) | `` flake.lock: Update ``                            |
| [`63a3f6ca`](https://github.com/sodiboo/niri-flake/commit/63a3f6cae29a3ac3c3b383924d5c86f2d1c05703) | `` flake.lock: Update ``                            |
| [`663317bd`](https://github.com/sodiboo/niri-flake/commit/663317bd9ac76c336dd74c996fcc20c737307feb) | `` flake.lock: Update ``                            |
| [`a6b2bd47`](https://github.com/sodiboo/niri-flake/commit/a6b2bd473b20612aefe6c3cfac1cd607208011d4) | `` flake.lock: Update ``                            |
| [`fcbc2e53`](https://github.com/sodiboo/niri-flake/commit/fcbc2e536b2a53f7c340db6d1553fbf6e41e1412) | `` flake.lock: Update ``                            |
| [`13a80494`](https://github.com/sodiboo/niri-flake/commit/13a8049438c78252e74eec2879d95a97f5012077) | `` flake.lock: Update ``                            |
| [`47967e85`](https://github.com/sodiboo/niri-flake/commit/47967e85fbb256184346946ff408f09eef2e3766) | `` flake.lock: Update ``                            |