### PR TITLE
chore(flake/treefmt-nix): `e7a277c5` -> `9c57261c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1627,11 +1627,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709546977,
-        "narHash": "sha256-R0bi8zAWt1s1q7lSvwiFI8+kEL29rm4WtYTqPgjlEBs=",
+        "lastModified": 1709911575,
+        "narHash": "sha256-yC2iOKe0BSZAeXLNPXPrsGn5BwUTYYZESKb+OblLnXY=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e7a277c5d12bf570efa2427d9cfdb760b9a0512f",
+        "rev": "9c57261c71871d2208a6dd4394774cca226c6dbc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                               | Message                                                            |
| ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
| [`9c57261c`](https://github.com/numtide/treefmt-nix/commit/9c57261c71871d2208a6dd4394774cca226c6dbc) | `` fix(programs): leptosfmt does not touch files anymore (#166) `` |
| [`783cb44b`](https://github.com/numtide/treefmt-nix/commit/783cb44b0a0a1b02eba7fee58f3b606fbbf1519a) | `` feat(programs): add dos2unix (#165) ``                          |