### PR TITLE
chore(flake/nh): `6947e6f6` -> `3f148b0c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -896,11 +896,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709278248,
-        "narHash": "sha256-ceZXyzxTLSOrQlcTPQmvQnDV696NNMBwFmVPb9jpX2E=",
+        "lastModified": 1709714234,
+        "narHash": "sha256-fnuVQqdK48c66EC4mL8t7uLhwsY6JDyn7H5tjRpx9Sg=",
         "owner": "viperML",
         "repo": "nh",
-        "rev": "6947e6f6f234d303131ecc1e54ef6703c82257e3",
+        "rev": "3f148b0c7f2d56be65dc55628f6b2e68ee10e231",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                      | Message                                            |
| ------------------------------------------------------------------------------------------- | -------------------------------------------------- |
| [`3f148b0c`](https://github.com/viperML/nh/commit/3f148b0c7f2d56be65dc55628f6b2e68ee10e231) | `` change --nom to --no-nom, remove env reading `` |