### PR TITLE
chore(flake/nixpkgs): `207107bb` -> `e389a113`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1309,11 +1309,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1709558755,
-        "narHash": "sha256-hx4FIbk4X4ve1oiHLOj+VE6dzO4CtXBR5RSU6kaq34M=",
+        "lastModified": 1709987164,
+        "narHash": "sha256-W3KoCToX0gnwpZARkRteYd8Ns0Kie3C4u057YepUP5I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "207107bbc7d6d19a8b2c36a088d3756d03490243",
+        "rev": "e389a1133d14925b942e0ad76ce75f32637db20d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
| [`88bb68b4`](https://github.com/NixOS/nixpkgs/commit/88bb68b42e6f0b19e606eeb0f96d676cae0309dc) | `` zeal: set meta.mainProgram ``                                                       |
| [`2e60b54d`](https://github.com/NixOS/nixpkgs/commit/2e60b54d0dc4f42d911943e8e78eba8979868250) | `` i3: set meta.mainProgram ``                                                         |
| [`41fcc1d0`](https://github.com/NixOS/nixpkgs/commit/41fcc1d0f36228c3d7861adc77eb7c66539edbf8) | `` arandr: set meta.mainProgram ``                                                     |
| [`dc994ed6`](https://github.com/NixOS/nixpkgs/commit/dc994ed6e551822351419c931d9918d6561d859f) | `` python311Packages.bandit: refactor ``                                               |
| [`e1e28237`](https://github.com/NixOS/nixpkgs/commit/e1e282374de39b9b3e0d3d347d318d657774e7aa) | `` phoc: 0.36.0 -> 0.37.0 ``                                                           |
| [`ccd2165a`](https://github.com/NixOS/nixpkgs/commit/ccd2165aec0d94a523a58ec5c8b8499c636d461d) | `` nushellPlugins.regex: remove ``                                                     |
| [`04da186e`](https://github.com/NixOS/nixpkgs/commit/04da186e0b6e18a8852fb927fb08ca4704fd535b) | `` pcloud: 1.14.4 -> 1.14.5 ``                                                         |
| [`d14b092b`](https://github.com/NixOS/nixpkgs/commit/d14b092bc7378ca52654bd1ddb986447fc37d759) | `` python311Packages.llama-index: 0.10.17 -> 0.10.18 ``                                |
| [`79461832`](https://github.com/NixOS/nixpkgs/commit/7946183293beea5a7363b876b0483ddebaafffbb) | `` python311Packages.llama-parse: 0.3.7 -> 0.3.8 ``                                    |
| [`004613a6`](https://github.com/NixOS/nixpkgs/commit/004613a60f3c731658a9e3fc8e20713058fea1fc) | `` mailmanPackages.hyperkitty: 1.3.8 -> 1.3.9 ``                                       |
| [`c5c65870`](https://github.com/NixOS/nixpkgs/commit/c5c658700ec86d721a9d1403513353ccb6ce0032) | `` python312Packages.fake-useragent: 1.4.0 -> 1.5.0 ``                                 |
| [`0158738e`](https://github.com/NixOS/nixpkgs/commit/0158738e0ddeae2617d8cd3798c58aa2d68a5361) | `` fangfrisch: 1.8.1 -> 1.9.0 ``                                                       |
| [`1b7d1bd6`](https://github.com/NixOS/nixpkgs/commit/1b7d1bd6e1d6297d785f4c20a906a155be7b6ed3) | `` python311Packages.guidance: 0.1.6 -> 0.1.11 ``                                      |
| [`472d27b8`](https://github.com/NixOS/nixpkgs/commit/472d27b846cb7f5a907303b242207e8080d7a275) | `` python311Packages.pgmpy: 0.1.24 -> 0.1.25 ``                                        |
| [`7a2394e7`](https://github.com/NixOS/nixpkgs/commit/7a2394e7926a16d9d3c43936734553827273ef8b) | `` python311Packages.anywidget: 0.9.2 -> 0.9.3 ``                                      |
| [`553e34df`](https://github.com/NixOS/nixpkgs/commit/553e34dfd6d63e576822c64266d2f4ffdacbe51e) | `` python311Packages.minio: 7.2.4 -> 7.2.5 ``                                          |
| [`6ca85622`](https://github.com/NixOS/nixpkgs/commit/6ca856220afde1fa658dbcd725340d4e9885abc9) | `` littlefs-fuse: 2.7.5 -> 2.7.6 ``                                                    |
| [`659b0549`](https://github.com/NixOS/nixpkgs/commit/659b05493104c056ef6b9ab5ac0ee9c55cc8adee) | `` grpc_cli: 1.62.0 -> 1.62.1 ``                                                       |
| [`d616b59f`](https://github.com/NixOS/nixpkgs/commit/d616b59f557388d6703d3b345b0cb52ca43172ef) | `` chamber: 2.14.0 -> 2.14.1 ``                                                        |
| [`7eddbc3f`](https://github.com/NixOS/nixpkgs/commit/7eddbc3ff5e1c87dc866a914aa238fe9e9c70699) | `` python311Packages.bandit: 1.7.7 -> 1.7.8 ``                                         |
| [`82898955`](https://github.com/NixOS/nixpkgs/commit/82898955e2c88cce35022581df78ca223c406251) | `` python311Packages.chromedb: allow local networking on darwin ``                     |
| [`cfef06f5`](https://github.com/NixOS/nixpkgs/commit/cfef06f5c4db47c55ee4818ce02698209ef42609) | `` python311Packages.opentelemetry-util-http: 0.43b0 -> 0.44b0 ``                      |
| [`32b24345`](https://github.com/NixOS/nixpkgs/commit/32b24345277cdf77c0a060584cc1d7f0981756ed) | `` python311Packages.opentelemetry-instrumentation-wsgi: 0.43b0 -> 0.44b0 ``           |
| [`2dba2d7c`](https://github.com/NixOS/nixpkgs/commit/2dba2d7c21297abb1300a3150426b3527fd2c4f3) | `` python311Packages.opentelemetry-instrumentation-grpc: 0.43b0 -> 0.44b0 ``           |
| [`f242db71`](https://github.com/NixOS/nixpkgs/commit/f242db71c9fd8d04e9f937f4fc860dffaf7dd9a3) | `` python311Packages.opentelemetry-instrumentation-flask: 0.43b0 -> 0.44b0 ``          |
| [`cb4a763b`](https://github.com/NixOS/nixpkgs/commit/cb4a763b662c1e97f94b0e2c2dfcddf0a557c062) | `` python311Packages.opentelemetry-instrumentation-fastapi: 0.43b0 -> 0.44b0 ``        |
| [`76d6fa55`](https://github.com/NixOS/nixpkgs/commit/76d6fa55c84f56b007379a53f5ce63cd9191fd40) | `` python311Packages.opentelemetry-instrumentation-django: 0.43b0 -> 0.44b0 ``         |
| [`f3209f12`](https://github.com/NixOS/nixpkgs/commit/f3209f125f3f3aaf77d8f05333a82660d5471b2b) | `` python311Packages.opentelemetry-instrumentation-asgi: 0.43b0 -> 0.44b0 ``           |
| [`d83e6337`](https://github.com/NixOS/nixpkgs/commit/d83e6337d529cbd5f33fe13fd6f0aa150ed0da27) | `` python311Packages.opentelemetry-instrumentation-aiohttp-client: 0.43b0 -> 0.44b0 `` |
| [`4d988611`](https://github.com/NixOS/nixpkgs/commit/4d9886114f8ed2af9133ec1f6ee9701541c6f073) | `` python311Packages.opentelemetry-instrumentation: 0.43b0 -> 0.44b0 ``                |
| [`b1a9c453`](https://github.com/NixOS/nixpkgs/commit/b1a9c453103efc91b24c62363d427f7829ba5111) | `` agkozak-zsh-prompt: 3.11.2 -> 3.11.3 ``                                             |
| [`53841109`](https://github.com/NixOS/nixpkgs/commit/538411090b8595e63babade0cb4b966f188363e7) | `` python311Packages.opentelemetry-test-utils: 1.22.0 -> 0.44b0 ``                     |
| [`461f3c17`](https://github.com/NixOS/nixpkgs/commit/461f3c17156112e1b9b7a1f0c0da89b1ffdbb88a) | `` python311Packages.opentelemetry-semantic-conventions: 1.22.0 -> 0.44b0 ``           |
| [`b24a7f8b`](https://github.com/NixOS/nixpkgs/commit/b24a7f8b416a3d398efc5f6f7c9910f7697bad33) | `` python311Packages.opentelemetry-sdk: 1.22.0 -> 1.23.0 ``                            |
| [`2065c54c`](https://github.com/NixOS/nixpkgs/commit/2065c54ca3ebc65333fcf209b60ca5c99939204f) | `` python311Packages.opentelemetry-proto: 1.22.0 -> 1.23.0 ``                          |
| [`21fd95be`](https://github.com/NixOS/nixpkgs/commit/21fd95be7d5791c54cdf338d936351a2f65f317e) | `` python311Packages.opentelemetry-exporter-prometheus: 1.22.0 -> 0.44b0 ``            |
| [`c9eb088b`](https://github.com/NixOS/nixpkgs/commit/c9eb088b0e18f3e535668544a77693b6ebae1e8f) | `` python311Packages.opentelemetry-exporter-otlp-proto-http: 1.22.0 -> 1.23.0 ``       |
| [`7f821539`](https://github.com/NixOS/nixpkgs/commit/7f821539ac82c8dee431193105f420ac54bdc7f8) | `` python311Packages.opentelemetry-exporter-otlp-proto-grpc: 1.22.0 -> 1.23.0 ``       |
| [`65254c32`](https://github.com/NixOS/nixpkgs/commit/65254c32c608ebda29ad0a516f9e6c52f0bf69e4) | `` python311Packages.opentelemetry-exporter-otlp-proto-common: 1.22.0 -> 1.23.0 ``     |
| [`e6570c57`](https://github.com/NixOS/nixpkgs/commit/e6570c57c354d8a53ab56fe7260f9cb0245d4d0e) | `` python311Packages.opentelemetry-exporter-otlp: 1.22.0 -> 1.23.0 ``                  |
| [`cb103d5f`](https://github.com/NixOS/nixpkgs/commit/cb103d5f14009770fe4922c70d566a196692e162) | `` python311Packages.opentelemetry-api: 1.22.0 -> 1.23.0 ``                            |
| [`20acfe37`](https://github.com/NixOS/nixpkgs/commit/20acfe375abeac1d00d2be8862694ddffbf98ed3) | `` convco: 0.5.0 -> 0.5.1 ``                                                           |
| [`e86b258c`](https://github.com/NixOS/nixpkgs/commit/e86b258c5d53396841e2c381aeaaef30ccc55c50) | `` python311Packages.axis: 50 -> 52 ``                                                 |
| [`8310b61c`](https://github.com/NixOS/nixpkgs/commit/8310b61c16e0c5a0999379bf53f606b80ad45039) | `` thunderbird-unwrapped: 115.8.0 -> 115.8.1 ``                                        |
| [`53d9101d`](https://github.com/NixOS/nixpkgs/commit/53d9101d8d75dafdb08971a694691a7bd589c6c7) | `` flexget: 3.11.21 -> 3.11.22 ``                                                      |
| [`69412ced`](https://github.com/NixOS/nixpkgs/commit/69412cedd728c81170ddbc6819eecc18a100df1f) | `` python311Packages.bless: refactor ``                                                |
| [`2f222445`](https://github.com/NixOS/nixpkgs/commit/2f2224456a3d498e92d9cb49738ed79b3b182f56) | `` zsync: migrate to by-name ``                                                        |
| [`8f41fb68`](https://github.com/NixOS/nixpkgs/commit/8f41fb68ff7443836f280323674a6a4a5e7fa0a3) | `` zsync: fix build with clang ``                                                      |
| [`eef817b5`](https://github.com/NixOS/nixpkgs/commit/eef817b55e176e0dcf00bfad1eefce766331e103) | `` python311Packages.bless: 0.2.5 -> 0.2.6 ``                                          |
| [`ebf346ff`](https://github.com/NixOS/nixpkgs/commit/ebf346ff0416630c21166bb8568812075ae853bf) | `` buildbot: tie the knot through a scope to make it overridable ``                    |
| [`60145c2f`](https://github.com/NixOS/nixpkgs/commit/60145c2f12ffff5d88b3d3a981eefee1b7767c19) | `` git-releaser: 0.1.3 -> 0.1.6 ``                                                     |
| [`af147603`](https://github.com/NixOS/nixpkgs/commit/af147603cfd2096bb3c9e00e0106200d548d3c3f) | `` metasploit: 6.3.58 -> 6.3.59 ``                                                     |
| [`891ee492`](https://github.com/NixOS/nixpkgs/commit/891ee4927200605b1602ca0d946ef3f8d84fb56a) | `` python311Packages.google-cloud-container: 2.41.0 -> 2.43.0 ``                       |
| [`34093f4f`](https://github.com/NixOS/nixpkgs/commit/34093f4fa8b1b0ccb58f1f4f1532823c33c9d970) | `` beeper: 3.98.16 -> 3.99.22 ``                                                       |
| [`2038c77b`](https://github.com/NixOS/nixpkgs/commit/2038c77b0bcd6ebe35617ea05dee86a7ee98f3f6) | `` gpxsee: 13.16 -> 13.17 ``                                                           |
| [`9e53c1e8`](https://github.com/NixOS/nixpkgs/commit/9e53c1e876d8de692d92cb69b8d28f4910327e9b) | `` wttrbar: 0.8.2 -> 0.9.0 ``                                                          |
| [`1495f6e9`](https://github.com/NixOS/nixpkgs/commit/1495f6e9f87909aa7bfcd41a7a44f215f458357f) | `` portfolio: 0.67.3 -> 0.68.0 ``                                                      |
| [`2bbfc235`](https://github.com/NixOS/nixpkgs/commit/2bbfc235467466b195c755e2516305a83d1e2c11) | `` go-task: 3.35.0 -> 3.35.1 ``                                                        |
| [`921210c8`](https://github.com/NixOS/nixpkgs/commit/921210c8779364397f1cb5fda155c5b94cd9ebff) | `` sesh: init at 0.12.0 ``                                                             |
| [`c339d2e2`](https://github.com/NixOS/nixpkgs/commit/c339d2e256ae55d27ff677a93ef7451d9f589121) | `` evcc: 0.124.7 -> 0.124.8 ``                                                         |
| [`ff80a002`](https://github.com/NixOS/nixpkgs/commit/ff80a002ee244cb10e228bff214d2d52f2c6af41) | `` treewide: remove ThomasMader as maintainer from Dlang packages (#291338) ``         |
| [`95658590`](https://github.com/NixOS/nixpkgs/commit/95658590c6cf17be61adf44254f6a809c33c17e1) | `` cosmic-applibrary: unstable-2024-01-03 -> 0-unstable-2024-02-09 (#288987) ``        |
| [`291759e9`](https://github.com/NixOS/nixpkgs/commit/291759e93665f285619225c22ea9bb1c2471b8ba) | `` python311Packages.langsmith: 0.1.22 -> 0.1.23 ``                                    |
| [`f5ba7fc8`](https://github.com/NixOS/nixpkgs/commit/f5ba7fc8079b4f41d4069ad8e16d54c2d9d39fe5) | `` python3Packages.tinysegmenter: 0.3 -> 0.4 ``                                        |
| [`3cb8ac5d`](https://github.com/NixOS/nixpkgs/commit/3cb8ac5dc461aa82c8e5704fa65ac0a63dc476b5) | `` scala-cli: 1.1.3 -> 1.2.0 ``                                                        |
| [`e0763a61`](https://github.com/NixOS/nixpkgs/commit/e0763a61ab0ec8b425ea35b0459a6555da9079d2) | `` abcmidi: 2024.03.02 -> 2024.03.05 ``                                                |
| [`a345ed5c`](https://github.com/NixOS/nixpkgs/commit/a345ed5ca43c1c075216536e5ccf99674bf1a686) | `` python3Packages.tinysegmenter: init at 0.3 ``                                       |
| [`11907c59`](https://github.com/NixOS/nixpkgs/commit/11907c593abc7eb4e2334692238cf916828fcb00) | `` hyprlang: 0.4.1 -> 0.5.0 ``                                                         |
| [`a8b7297f`](https://github.com/NixOS/nixpkgs/commit/a8b7297fb9af2998fb0a5f49522d01894221dfe5) | `` python312Packages.iocsearcher: init at 2.3-unstable-2024-03-04 ``                   |
| [`a9109b9c`](https://github.com/NixOS/nixpkgs/commit/a9109b9c1e1e3fa09096af562bf676cc1dd8a22f) | `` svdtools: 0.3.10 -> 0.3.11 ``                                                       |
| [`f2596237`](https://github.com/NixOS/nixpkgs/commit/f25962377f3d9259c7da9027b29617c8d867c697) | `` storj-uplink: 1.99.1 -> 1.99.3 ``                                                   |
| [`572619fa`](https://github.com/NixOS/nixpkgs/commit/572619fa62a4aab31593c34ed4815fd55fa9d582) | `` python312Packages.readabilipy: init at 0.2.0 ``                                     |
| [`1dc4d4a8`](https://github.com/NixOS/nixpkgs/commit/1dc4d4a8c65a883977ced44e6968c202b28cab16) | `` python311Packages.cashaddress: init at 1.0.6-unstable-2015-05-19 ``                 |
| [`05b35434`](https://github.com/NixOS/nixpkgs/commit/05b354348e8b4f549e92b2ac0e5032d1a42e85a0) | `` ruplacer: 0.8.2 -> 0.8.3 ``                                                         |
| [`93aafcf1`](https://github.com/NixOS/nixpkgs/commit/93aafcf1fb86462cceabc57643cd4ba3bea75552) | `` linuxPackages.nvidiaPackages.vulkan_beta: 550.40.53 -> 550.40.55 ``                 |
| [`25f5537d`](https://github.com/NixOS/nixpkgs/commit/25f5537d622bc6cb71b75c023bc176f00c95a427) | `` python312Packages.recipe-scrapers: 14.54.0 -> 14.55.0 ``                            |
| [`4e3ae720`](https://github.com/NixOS/nixpkgs/commit/4e3ae720d088714b3b2952ee64ae7a42fdbe6d29) | `` python312Packages.linknlink: 0.1.9 -> 0.2.0 ``                                      |
| [`74dc5196`](https://github.com/NixOS/nixpkgs/commit/74dc5196395e66a962cf6f7b48e47083a0173761) | `` python3Packages.feedfinder2: init at 0.0.4 ``                                       |
| [`2337837b`](https://github.com/NixOS/nixpkgs/commit/2337837bfc863d8f51ed106edc1368d5eea4f22c) | `` python312Packages.keyring-pass: 0.9.2 -> 0.9.3 ``                                   |
| [`7c444ebc`](https://github.com/NixOS/nixpkgs/commit/7c444ebc5bea0c0dbee8097334c167355a31f5b3) | `` ton: 2024.01 -> 2024.02 ``                                                          |
| [`e27ddbd1`](https://github.com/NixOS/nixpkgs/commit/e27ddbd1cf7ddc8aaa034a508d239ad8b3e241a2) | `` python312Packages.clickhouse-connect: 0.7.1 -> 0.7.2 ``                             |
| [`a939e05d`](https://github.com/NixOS/nixpkgs/commit/a939e05d3c9474ee53736997b552611d777fc005) | `` python311Packages.fiona: 1.9.5 -> 1.9.6 ``                                          |
| [`fd35ba6c`](https://github.com/NixOS/nixpkgs/commit/fd35ba6cadbb06a95b0f21c82e6b98ca399a649e) | `` cmctl: 1.14.3 -> 1.14.4 ``                                                          |
| [`2876de89`](https://github.com/NixOS/nixpkgs/commit/2876de899173d3117e710fc5a8bf703176f5d427) | `` linuxKernel.kernels.linux_lqx: 6.7.6-lqx1 -> 6.7.9-lqx1 ``                          |
| [`a97c56c4`](https://github.com/NixOS/nixpkgs/commit/a97c56c47e29d6ff6fd8b5341ad3d0c4b6c3e909) | `` Revert "python311Packages.kubernetes: 28.1.0 -> 29.0.0" ``                          |
| [`349d8e0c`](https://github.com/NixOS/nixpkgs/commit/349d8e0c5c276d7d9a8ad1829465c8d532127538) | `` linuxKernel.kernels.linux_zen: 6.7.7-zen1 -> 6.7.9-zen1 ``                          |
| [`7e90be2a`](https://github.com/NixOS/nixpkgs/commit/7e90be2a25599dbb349661033c1a5bcc5dda96d2) | `` nom: 2.1.3 -> 2.1.4 ``                                                              |
| [`ff248e39`](https://github.com/NixOS/nixpkgs/commit/ff248e39167590597817f509347e9b7d506ef6f3) | `` infisical: 0.17.1 -> 0.18.0 ``                                                      |
| [`dfb956db`](https://github.com/NixOS/nixpkgs/commit/dfb956dbe903d851e5f2f70784f80d5051350de7) | `` maintainers: add daniel-fahey ``                                                    |
| [`fc88a67b`](https://github.com/NixOS/nixpkgs/commit/fc88a67b54bce990243d3dcd147e94c5d7a76636) | `` sentry-native: 0.6.7 -> 0.7.0 ``                                                    |
| [`66455205`](https://github.com/NixOS/nixpkgs/commit/66455205b3362398b958d32bc0033b42a21a49fb) | `` python311Packages.faraday-agent-parameters-types: 1.5.0 -> 1.5.1 ``                 |
| [`a76caa38`](https://github.com/NixOS/nixpkgs/commit/a76caa3827e36d5a286820fb81da167ee7c65b7e) | `` gallia: 1.5.0 -> 1.6.0 ``                                                           |
| [`f51256cc`](https://github.com/NixOS/nixpkgs/commit/f51256cc653ce13d174addbd032fbd014972a81f) | `` python311Packages.mlflow: use pyproject format ``                                   |
| [`6e2a59e5`](https://github.com/NixOS/nixpkgs/commit/6e2a59e5afe94ac0bdf61d2774072b9fbbd7d91b) | `` python311Packages.mlflow: 2.10.2 -> 2.11.1 ``                                       |