### PR TITLE
chore(flake/emacs-overlay): `a230393b` -> `28c564cc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -290,11 +290,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1710091554,
-        "narHash": "sha256-p4CFIo9dAIgL6KMp1woJxVISoqYKblPGjAgTPkzeOWI=",
+        "lastModified": 1710522300,
+        "narHash": "sha256-9PYmC6X8qQiUExjkRmJp5d1B+cPYglvHuIg80Virvuo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "a230393bb7e2db667c63c3f5c279a6e26d8b1c5a",
+        "rev": "28c564ccf915615c65c4c1334504f1535192dee2",
         "type": "github"
       },
       "original": {
@@ -523,11 +523,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1709126324,
-        "narHash": "sha256-q6EQdSeUZOG26WelxqkmR7kArjgWCdw5sfJVHPH/7j8=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "d465f4819400de7c8d874d50b982301f28a84605",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -1249,11 +1249,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1710021367,
-        "narHash": "sha256-FuMVdWqXMT38u1lcySYyv93A7B8wU0EGzUr4t4jQu8g=",
+        "lastModified": 1710420202,
+        "narHash": "sha256-MvFKESbq4rUWuaf2RKPNYENaSZEw/jaCLo2gU6oREcM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b94a96839afcc56de3551aa7472b8d9a3e77e05d",
+        "rev": "878ef7d9721bee9f81f8a80819f9211ad1f993da",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`28c564cc`](https://github.com/nix-community/emacs-overlay/commit/28c564ccf915615c65c4c1334504f1535192dee2) | `` Updated emacs ``        |
| [`553f68ee`](https://github.com/nix-community/emacs-overlay/commit/553f68ee98a5d36c188f563f4e0851adbc132eda) | `` Updated melpa ``        |
| [`7115e70b`](https://github.com/nix-community/emacs-overlay/commit/7115e70bb490c73a00b576b2a7040403e9460a09) | `` Updated elpa ``         |
| [`e32cd426`](https://github.com/nix-community/emacs-overlay/commit/e32cd426fb92d6328a94ce87de87a343ceaac2aa) | `` Updated flake inputs `` |
| [`ee3a92b1`](https://github.com/nix-community/emacs-overlay/commit/ee3a92b17a377d2ac2bb8293638f7e87f74953ee) | `` Updated emacs ``        |
| [`96bcdc62`](https://github.com/nix-community/emacs-overlay/commit/96bcdc62af503632cfbf0fcd58fa1ae244947223) | `` Updated melpa ``        |
| [`45dcc834`](https://github.com/nix-community/emacs-overlay/commit/45dcc83490fe6befb6c1fd5bacf9ded14cdf0554) | `` Updated emacs ``        |
| [`a257259d`](https://github.com/nix-community/emacs-overlay/commit/a257259d041d08eaa52701a7d4f617d25656ea45) | `` Updated melpa ``        |
| [`218be052`](https://github.com/nix-community/emacs-overlay/commit/218be052c69487035e61fea04287da0d17275199) | `` Updated elpa ``         |
| [`c37b349f`](https://github.com/nix-community/emacs-overlay/commit/c37b349fb9713102d8b2d13e720f269f4c45d864) | `` Updated nongnu ``       |
| [`c75e9d97`](https://github.com/nix-community/emacs-overlay/commit/c75e9d9702989e0dccdbdf9691ec393e1428099b) | `` Updated flake inputs `` |
| [`c1b23815`](https://github.com/nix-community/emacs-overlay/commit/c1b23815c2e28419e9fadbd254c5bdd47cc6707d) | `` Updated emacs ``        |
| [`c00e6807`](https://github.com/nix-community/emacs-overlay/commit/c00e68074c8782f2e7befe496a7c5e0fbf9ce76b) | `` Updated melpa ``        |
| [`5bad4af0`](https://github.com/nix-community/emacs-overlay/commit/5bad4af097f771c2329f4806a4828cac76dcb444) | `` Updated elpa ``         |
| [`33414e0b`](https://github.com/nix-community/emacs-overlay/commit/33414e0b88fe7408884b4542b86818397d9fe44c) | `` Updated emacs ``        |
| [`eeab94f5`](https://github.com/nix-community/emacs-overlay/commit/eeab94f5941e95a272de6316e7bb8650bbb92570) | `` Updated melpa ``        |
| [`2be142e8`](https://github.com/nix-community/emacs-overlay/commit/2be142e8ad86fd395ad4738e2aa66886592db930) | `` Updated emacs ``        |
| [`0e783a96`](https://github.com/nix-community/emacs-overlay/commit/0e783a9604517f65aa2032af98fee6539f5be1e5) | `` Updated melpa ``        |
| [`ab8d51e7`](https://github.com/nix-community/emacs-overlay/commit/ab8d51e727e7b1caafb11dc378ec9c3ec417dc15) | `` Updated elpa ``         |
| [`2587b8bc`](https://github.com/nix-community/emacs-overlay/commit/2587b8bcc1c54aa24452d2280364d10099109725) | `` Updated nongnu ``       |
| [`70d8a682`](https://github.com/nix-community/emacs-overlay/commit/70d8a682934e97ef4a76630678ecf76ab9b08380) | `` Updated emacs ``        |
| [`c53e8dc6`](https://github.com/nix-community/emacs-overlay/commit/c53e8dc6260294bcfb2298701ee512089365d912) | `` Updated melpa ``        |
| [`453a1468`](https://github.com/nix-community/emacs-overlay/commit/453a1468961b409ae7425dc693f1a1be3997735e) | `` Updated elpa ``         |
| [`ad824e2d`](https://github.com/nix-community/emacs-overlay/commit/ad824e2db6498f90ac4b0ff0c17d1e8cb703e100) | `` Updated flake inputs `` |
| [`c68aeff6`](https://github.com/nix-community/emacs-overlay/commit/c68aeff603f1b5c4cc7a57b876cf5e7101f2f21c) | `` Updated emacs ``        |
| [`9b66dbef`](https://github.com/nix-community/emacs-overlay/commit/9b66dbef5285b09ceebc337c76dc498e077c6a1f) | `` Updated melpa ``        |
| [`cfb8d4a7`](https://github.com/nix-community/emacs-overlay/commit/cfb8d4a721073302d61539010ff04b91d5031689) | `` Updated flake inputs `` |
| [`69e03a14`](https://github.com/nix-community/emacs-overlay/commit/69e03a148e6c604aed3579d81989aabccbba4d67) | `` Updated emacs ``        |
| [`80f8e5e4`](https://github.com/nix-community/emacs-overlay/commit/80f8e5e418f5a20831f2f38478ec719f627f0673) | `` Updated melpa ``        |
| [`ca5deb0f`](https://github.com/nix-community/emacs-overlay/commit/ca5deb0fc98adf4dfcb9ca0dfdb6ca203ac7f95e) | `` Updated elpa ``         |
| [`383aeb1b`](https://github.com/nix-community/emacs-overlay/commit/383aeb1bf3e2fdf14e7b1b66a35123228d7a0edb) | `` Updated emacs ``        |
| [`7746ff73`](https://github.com/nix-community/emacs-overlay/commit/7746ff739b6a31a7fcef7258ee50dc9450d0af53) | `` Updated melpa ``        |
| [`cadc4a6d`](https://github.com/nix-community/emacs-overlay/commit/cadc4a6d3652b00376a39e9575b4e7992629f449) | `` Updated elpa ``         |
| [`455c16ff`](https://github.com/nix-community/emacs-overlay/commit/455c16ffba92352443eb5f5f1a76fb8732fcb75b) | `` Updated emacs ``        |
| [`4f2b503c`](https://github.com/nix-community/emacs-overlay/commit/4f2b503c128466683e2beacf68310985d156d188) | `` Updated melpa ``        |
| [`ef8c23de`](https://github.com/nix-community/emacs-overlay/commit/ef8c23deac5611eeebbb2292da740846ce3ded43) | `` Updated flake inputs `` |
| [`7e07cbc3`](https://github.com/nix-community/emacs-overlay/commit/7e07cbc381897f0090e12cb9f442cedb10d94360) | `` Updated melpa ``        |
| [`68478abb`](https://github.com/nix-community/emacs-overlay/commit/68478abbc2484dc059e797de119bebe46910aa32) | `` Updated elpa ``         |
| [`30fdb303`](https://github.com/nix-community/emacs-overlay/commit/30fdb303a64d5fcbbaf0609b75d3c9c783af7869) | `` Updated emacs ``        |
| [`f8ec23ab`](https://github.com/nix-community/emacs-overlay/commit/f8ec23ab79ad9f5c9d75eeca35f672ccf8b31c40) | `` Updated melpa ``        |
| [`5bd6ccde`](https://github.com/nix-community/emacs-overlay/commit/5bd6ccdea4d7f4672de5922c7eaf791adc928eed) | `` Updated elpa ``         |
| [`38821439`](https://github.com/nix-community/emacs-overlay/commit/388214396e9868ecd648bce9ccfc4d6074e6aee5) | `` Updated flake inputs `` |
| [`b7ec159f`](https://github.com/nix-community/emacs-overlay/commit/b7ec159f704bf8b55accd190dc7d0e84182f9a45) | `` Updated emacs ``        |
| [`e60b2a8b`](https://github.com/nix-community/emacs-overlay/commit/e60b2a8b58cc767057fb5daf0d7d5fd305fe4999) | `` Updated melpa ``        |
| [`65f195e9`](https://github.com/nix-community/emacs-overlay/commit/65f195e937a170adac199b12eab303b8488bf38b) | `` Updated emacs ``        |
| [`95c9c9cc`](https://github.com/nix-community/emacs-overlay/commit/95c9c9cc198e6f579ab80f32c8c0e93a381c25b9) | `` Updated melpa ``        |
| [`b182b289`](https://github.com/nix-community/emacs-overlay/commit/b182b289866f512e2756444ce9f1877920d99bf1) | `` Updated elpa ``         |
| [`76ee24cf`](https://github.com/nix-community/emacs-overlay/commit/76ee24cfe3d9866cc55881a89d91d5f9403f9ee8) | `` Updated nongnu ``       |