### PR TITLE
chore(flake/niri): `e1d0da19` -> `ea420052`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -226,11 +226,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1708135620,
-        "narHash": "sha256-O8FgwfMR8LgJjIX1RjEmme67sLscMUlmkJLlkb83RyY=",
+        "lastModified": 1710450631,
+        "narHash": "sha256-frfM5jdRvnhU4w+omLhkdfesP2Bwf7qB86vLXWO/cIk=",
         "owner": "nix-community",
         "repo": "crate2nix",
-        "rev": "7eb26c517fa5b4b2056cc5e2e288e0117306e600",
+        "rev": "e494b56b7445ba59ef049bcfdc889f5c558768d4",
         "type": "github"
       },
       "original": {
@@ -1016,11 +1016,11 @@
     "niri-unstable": {
       "flake": false,
       "locked": {
-        "lastModified": 1710079150,
-        "narHash": "sha256-eUhKSNtROMCTXUGynz8BooVXCijjvOd+8opsHwgfKqE=",
+        "lastModified": 1710525749,
+        "narHash": "sha256-LpV/mJLeShTPecVQZnIAb9PTCGziuMuGOJQUeAb2u/w=",
         "owner": "YaLTeR",
         "repo": "niri",
-        "rev": "40cec34aa4a7f99ab12b30cba1a0ee83a706a413",
+        "rev": "0c57815fbf47c69af9ed11fa8ebc1b52158a3ba2",
         "type": "github"
       },
       "original": {
@@ -1038,11 +1038,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1710097611,
-        "narHash": "sha256-J0SICrTQo//lRrsc/6NjAEqB9wtw0M7j1MMFWcBEJcM=",
+        "lastModified": 1710530725,
+        "narHash": "sha256-lYtJOBO3nyf1VuSTcT/wsQeV8W7P0moT6AybEsYh8IU=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "e1d0da19b185b02ef9fec750288bdc3aeed9cddc",
+        "rev": "ea420052706b2b3f60a510ce0e05dbf91955b181",
         "type": "github"
       },
       "original": {
@@ -1327,11 +1327,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1709961763,
-        "narHash": "sha256-6H95HGJHhEZtyYA3rIQpvamMKAGoa8Yh2rFV29QnuGw=",
+        "lastModified": 1710451336,
+        "narHash": "sha256-pP86Pcfu3BrAvRO7R64x7hs+GaQrjFes+mEPowCfkxY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3030f185ba6a4bf4f18b87f345f104e6a6961f34",
+        "rev": "d691274a972b3165335d261cc4671335f5c67de9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                              | Message                                                                            |
| --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`ea420052`](https://github.com/sodiboo/niri-flake/commit/ea420052706b2b3f60a510ce0e05dbf91955b181) | `` refactor delimit thingy ``                                                      |
| [`f1bd118d`](https://github.com/sodiboo/niri-flake/commit/f1bd118d306707ed44e8d3d0ae8141bac6d24c17) | `` flake.lock: Update ``                                                           |
| [`ad81f812`](https://github.com/sodiboo/niri-flake/commit/ad81f812f02cb14668205e877528f8693ea49019) | `` flake.lock: Update ``                                                           |
| [`4e583940`](https://github.com/sodiboo/niri-flake/commit/4e5839408849d86b8c31591bd0b03e7b1843a29f) | `` expand on binary cache ``                                                       |
| [`34b80543`](https://github.com/sodiboo/niri-flake/commit/34b80543a0cdec33ebcd783e92b35da98b1a4d8d) | `` refactor nixpkgs link ``                                                        |
| [`2309975c`](https://github.com/sodiboo/niri-flake/commit/2309975cf4a4f61be954c1f6886b8ae23e74d9b6) | `` flake.lock: Update ``                                                           |
| [`d4996194`](https://github.com/sodiboo/niri-flake/commit/d4996194f5a072474a258c0f3a7e55ce7a860846) | `` flake.lock: Update ``                                                           |
| [`93e49e2a`](https://github.com/sodiboo/niri-flake/commit/93e49e2ab2a2d6cf64450d50ed92925b7ae097f5) | `` refactor docs: more links, fix typos, combine "module" and "opts for module" `` |
| [`4f68ff0b`](https://github.com/sodiboo/niri-flake/commit/4f68ff0b97c475bda089aab0ead9950b65c92b02) | `` give the correct niri overlay path lol ``                                       |
| [`856608f5`](https://github.com/sodiboo/niri-flake/commit/856608f52cca1ee19a4dedfee23f59d02a14a39f) | `` reorder packages before modules ``                                              |
| [`72ce0ad0`](https://github.com/sodiboo/niri-flake/commit/72ce0ad0395c3c6b927cc43d311d43b48bc7344b) | `` properly format potential future lists ``                                       |
| [`b32fae04`](https://github.com/sodiboo/niri-flake/commit/b32fae048e326d92ce89f68509315b8c071ee376) | `` machinery to fuck with sort order of real options; abuse for animations ``      |
| [`a79283d3`](https://github.com/sodiboo/niri-flake/commit/a79283d3b02056500249e04ace3c9155688ae20d) | `` flake.lock: Update ``                                                           |
| [`bb45e326`](https://github.com/sodiboo/niri-flake/commit/bb45e3268665ebd9082eb481b8de9e60edb50945) | `` docs.nix -> generate-docs.nix ``                                                |
| [`d81dd6d9`](https://github.com/sodiboo/niri-flake/commit/d81dd6d9784d1079729dae248835ced810a11d21) | `` fix anchor gen; don't delete the hyphens, silly. ``                             |
| [`ac73fadd`](https://github.com/sodiboo/niri-flake/commit/ac73fadd902cddbb24494a97d95537a6014f90e0) | `` post-commit: leave my rebase alone ``                                           |
| [`7eddbb3a`](https://github.com/sodiboo/niri-flake/commit/7eddbb3a62ef720e3ab62843b10adecf0a010405) | `` multiline default literals ``                                                   |
| [`88df1990`](https://github.com/sodiboo/niri-flake/commit/88df1990561dd6eb52067137bb0b13a10db7f682) | `` more thorough documentation; lots of hyperlinks ``                              |
| [`cc1e32b6`](https://github.com/sodiboo/niri-flake/commit/cc1e32b6ca9a20519d91062e79ddfd36ece8c0a0) | `` mark docs linguist-generated ``                                                 |
| [`df8b66e9`](https://github.com/sodiboo/niri-flake/commit/df8b66e9e871777481349ddfcd5b8a9c2be4f4a7) | `` flake.lock: Update ``                                                           |
| [`fcc9ec28`](https://github.com/sodiboo/niri-flake/commit/fcc9ec28393f76d269a58db18f6c48595a0da56d) | `` add post-commit hook ``                                                         |
| [`66467a1e`](https://github.com/sodiboo/niri-flake/commit/66467a1ea690c476e867315bb5cd656a26a0bc36) | `` add initial docs; document toplevel options ``                                  |
| [`10d50ceb`](https://github.com/sodiboo/niri-flake/commit/10d50cebcb206bbd25cc67cb4e9a2e000d93bba6) | `` make kdl option descs finite; "kdl document" alt name ``                        |
| [`c0496a0a`](https://github.com/sodiboo/niri-flake/commit/c0496a0a042a37c2eaf79b76bc958bb0f640835f) | `` emptyOr equivalent to nullOr for default-width ``                               |
| [`66436f65`](https://github.com/sodiboo/niri-flake/commit/66436f65c76a484ca7fa0c3538949f3dd29b74a9) | `` rename tagged-union to variant, improve its metadata ``                         |
| [`7806d359`](https://github.com/sodiboo/niri-flake/commit/7806d3596ebaab6b73b2bc74dc186dd0f0440c32) | `` use record for match rules ``                                                   |
| [`d7ec5e71`](https://github.com/sodiboo/niri-flake/commit/d7ec5e71bbdbd84062df8302d6ae4b07a813f8b8) | `` cleanup imports to settings module ``                                           |
| [`1f41fc2e`](https://github.com/sodiboo/niri-flake/commit/1f41fc2e8f1486132f79a14a721003b99153f8c4) | `` use tagged union for preset width ``                                            |
| [`88cbf46e`](https://github.com/sodiboo/niri-flake/commit/88cbf46e19853965f79cb066f31544426d41c047) | `` add default-config.kdl.nix ``                                                   |
| [`e574da0c`](https://github.com/sodiboo/niri-flake/commit/e574da0c64443c85744f0e04684ced31502ae006) | `` flake.lock: Update ``                                                           |
| [`6cc70ee1`](https://github.com/sodiboo/niri-flake/commit/6cc70ee165047834878a7c6cc72620c0b6e0e707) | `` flake.lock: Update ``                                                           |
| [`b6168da0`](https://github.com/sodiboo/niri-flake/commit/b6168da05501852544c72ea741f6a4e472680d2d) | `` flake.lock: Update ``                                                           |
| [`a3d9364f`](https://github.com/sodiboo/niri-flake/commit/a3d9364fd3706c6d40f740bec0e7b5f37627918b) | `` flake.lock: Update ``                                                           |
| [`e1da5aa3`](https://github.com/sodiboo/niri-flake/commit/e1da5aa3c9983697663813e11b9da65b9b1e6713) | `` flake.lock: Update ``                                                           |
| [`fa81ce1a`](https://github.com/sodiboo/niri-flake/commit/fa81ce1a5d0d58a59d0a710308526f8a70083a37) | `` flake.lock: Update ``                                                           |
| [`859f7cc2`](https://github.com/sodiboo/niri-flake/commit/859f7cc25eb46f7007249212cb69bd3a0e35e217) | `` flake.lock: Update ``                                                           |
| [`4ec45745`](https://github.com/sodiboo/niri-flake/commit/4ec457454b69b4ef426d3c591a84dd0cc3ce1853) | `` oh yeah it already has branch protections ``                                    |
| [`85b3bf5a`](https://github.com/sodiboo/niri-flake/commit/85b3bf5a5ebd2fc37eb2eaa64311e40ba4140999) | `` name field for mergify? ``                                                      |
| [`02d65b17`](https://github.com/sodiboo/niri-flake/commit/02d65b1726cdb16a626e9366aab83f8ed961638d) | `` oopsie broke automations. inform mergify about renamed jobs. ``                 |
| [`69dfcdcb`](https://github.com/sodiboo/niri-flake/commit/69dfcdcb0518805f365d452737515a10bc6dceea) | `` nullable settings; preserve "no set values" ``                                  |
| [`d59cab2f`](https://github.com/sodiboo/niri-flake/commit/d59cab2fb0190f04880f8a5981df99686b0f0e10) | `` nix fmt ``                                                                      |
| [`de79e080`](https://github.com/sodiboo/niri-flake/commit/de79e08023fa19cc1ba0625b7771d859d7740f58) | `` document kdl, settings, stylix ``                                               |
| [`096097c1`](https://github.com/sodiboo/niri-flake/commit/096097c1511f2a85f6c418dd44049c71593074f6) | `` add trailing newline to README.md ``                                            |
| [`8916e8b4`](https://github.com/sodiboo/niri-flake/commit/8916e8b4edaf61c15506e273f5883b4b9b5e7fb2) | `` generally cleanup ``                                                            |
| [`14812925`](https://github.com/sodiboo/niri-flake/commit/14812925dcf743eb5af1c7d1d4bd452c3f3a4709) | `` remove additional-nodes ``                                                      |
| [`43c8f5c8`](https://github.com/sodiboo/niri-flake/commit/43c8f5c8687e992f10d62928ddebba8cfec87589) | `` add stylix module ``                                                            |
| [`3bf4c764`](https://github.com/sodiboo/niri-flake/commit/3bf4c764cd06953b4adabca2a4da20dbed9ab427) | `` "stabilize" settings ``                                                         |
| [`960c9a42`](https://github.com/sodiboo/niri-flake/commit/960c9a42300306aaa7ffce06d336812a7c714b8b) | `` remove obsolete attribute from borderish ``                                     |
| [`0c17f655`](https://github.com/sodiboo/niri-flake/commit/0c17f65583acfdf9c55b10e78c61fee2d14fdf25) | `` refactor settings; separate module and render ``                                |
| [`255eb95a`](https://github.com/sodiboo/niri-flake/commit/255eb95aca5d917f7f8234c908a85a522bf9bbc0) | `` separate nixos-unstable and nixos-stable build jobs ``                          |