### PR TITLE
chore(flake/nh): `3f148b0c` -> `393cffa0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -946,11 +946,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709714234,
-        "narHash": "sha256-fnuVQqdK48c66EC4mL8t7uLhwsY6JDyn7H5tjRpx9Sg=",
+        "lastModified": 1710352788,
+        "narHash": "sha256-gpvOzL+7PP22juK6yI01EiGUEVVo4lHGXCs5OmCAX+s=",
         "owner": "viperML",
         "repo": "nh",
-        "rev": "3f148b0c7f2d56be65dc55628f6b2e68ee10e231",
+        "rev": "393cffa098ab7aa8887134c9faa1bc98251cbfc7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                      | Message                                      |
| ------------------------------------------------------------------------------------------- | -------------------------------------------- |
| [`9f4529ad`](https://github.com/viperML/nh/commit/9f4529adfb95781f82307cf5e87419d736485c1b) | `` modify update arg based on Nix version `` |
| [`1073bcd7`](https://github.com/viperML/nh/commit/1073bcd7e134f07eddf1d2e4619ec4a012a8e712) | `` fix --update on newer nix versions ``     |
| [`b9368e38`](https://github.com/viperML/nh/commit/b9368e38dccc665e0335a2a4c6ab2ba9be6c2302) | `` fix typo ``                               |
| [`f7458d3f`](https://github.com/viperML/nh/commit/f7458d3f9f0249dd73faaef24421184fbdaaec52) | `` bump version ``                           |
| [`216ed4f8`](https://github.com/viperML/nh/commit/216ed4f8651a822247edb7b0517d10cf70cdaa86) | `` add hyperlink support to nh search ``     |