### PR TITLE
chore(flake/nh): `393cffa0` -> `60c019a9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -676,11 +676,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710352788,
-        "narHash": "sha256-gpvOzL+7PP22juK6yI01EiGUEVVo4lHGXCs5OmCAX+s=",
+        "lastModified": 1710573382,
+        "narHash": "sha256-oGPasBk516A6pNE7iBEOmtrNsbqd+frR7O+z9lr1cLw=",
         "owner": "viperML",
         "repo": "nh",
-        "rev": "393cffa098ab7aa8887134c9faa1bc98251cbfc7",
+        "rev": "60c019a930e1718f1c5b6638f16dc221bf667d61",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                      | Message                                                                               |
| ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`60c019a9`](https://github.com/viperML/nh/commit/60c019a930e1718f1c5b6638f16dc221bf667d61) | `` Add comment to raise interest into https://github.com/NixOS/nixpkgs/pull/294923 `` |