### PR TITLE
chore(flake/home-manager): `c781b28a` -> `206f457f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -410,11 +410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1710527391,
-        "narHash": "sha256-3uM8+g/nb7ROgzSmJwOrKefctZpjR5uBJtUz4lpwWJI=",
+        "lastModified": 1710532761,
+        "narHash": "sha256-SUXGZNrXX05YA9G6EmgupxhOr3swI1gcxLUeDMUhrEY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "c781b28add41b74423ab2e64496d4fc91192e13a",
+        "rev": "206f457fffdb9a73596a4cb2211a471bd305243d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                   |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`206f457f`](https://github.com/nix-community/home-manager/commit/206f457fffdb9a73596a4cb2211a471bd305243d) | `` prezto: be caseSensitive by default `` |