### PR TITLE
chore(flake/nur): `223ac289` -> `585df78a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -917,11 +917,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1710534350,
-        "narHash": "sha256-M0AvAlyCADNRvzey4r9w44CwIolx7lQEUCZpXCKaQoQ=",
+        "lastModified": 1710635641,
+        "narHash": "sha256-/SrPq8jfTCooM7QeRcpOvCoeGOn08NMDRC74oF/snJA=",
         "owner": "nix-community",
         "repo": "nur",
-        "rev": "223ac289c896f9f0e35aea66f886f008114c5fb6",
+        "rev": "585df78aeb0bf632a4370891de15a4b99070f1a3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                             | Message                       |
| -------------------------------------------------------------------------------------------------- | ----------------------------- |
| [`585df78a`](https://github.com/nix-community/NUR/commit/585df78aeb0bf632a4370891de15a4b99070f1a3) | `` automatic update ``        |
| [`cbb38b5c`](https://github.com/nix-community/NUR/commit/cbb38b5c51960bbc785a85a9ed827104c80b64e0) | `` automatic update ``        |
| [`e826440f`](https://github.com/nix-community/NUR/commit/e826440f924a69c254ae92a14d0c3c2076f30707) | `` automatic update ``        |
| [`476c8bb0`](https://github.com/nix-community/NUR/commit/476c8bb001802513f934a105544a936e03734941) | `` fix order ``               |
| [`4a31d441`](https://github.com/nix-community/NUR/commit/4a31d44192ea80a130751898e91b8c7b403fa0b0) | `` Update repos.json ``       |
| [`d38b6f7c`](https://github.com/nix-community/NUR/commit/d38b6f7c4db4fe70123e7c4afaa5d3ef33912166) | `` automatic update ``        |
| [`79bcc2c4`](https://github.com/nix-community/NUR/commit/79bcc2c4379e84adc24275842b4cf64fa74b622f) | `` automatic update ``        |
| [`6dc38199`](https://github.com/nix-community/NUR/commit/6dc3819962101fb0448bef49e6969c6477b1bef0) | `` automatic update ``        |
| [`b870db41`](https://github.com/nix-community/NUR/commit/b870db4117d587a8c5c2c8c9e2d311d7fa4befe2) | `` automatic update ``        |
| [`bd5a1fd4`](https://github.com/nix-community/NUR/commit/bd5a1fd48fd7e897dac1e9489d6b967ce2901191) | `` automatic update ``        |
| [`b51d28a7`](https://github.com/nix-community/NUR/commit/b51d28a744558df0e8472b2eb1aeffd0209708d7) | `` automatic update ``        |
| [`01f5bb8e`](https://github.com/nix-community/NUR/commit/01f5bb8e5231eaff5b2ffa35bfe32c8348004cee) | `` automatic update ``        |
| [`b94873af`](https://github.com/nix-community/NUR/commit/b94873af47d357463c71e894736becf6c345cfd5) | `` automatic update ``        |
| [`4ac24e33`](https://github.com/nix-community/NUR/commit/4ac24e3329bc69f3c6dff959e6a23496a27eba99) | `` automatic update ``        |
| [`529316cb`](https://github.com/nix-community/NUR/commit/529316cbfebac4d81ada47c2b0fb597cbd252e1e) | `` automatic update ``        |
| [`e4039d98`](https://github.com/nix-community/NUR/commit/e4039d98858a4df66adbf7ee887ca05700a831e6) | `` automatic update ``        |
| [`54bec0a0`](https://github.com/nix-community/NUR/commit/54bec0a068abc4136cac463409023005559f1aa4) | `` automatic update ``        |
| [`00bfd6c9`](https://github.com/nix-community/NUR/commit/00bfd6c95f2ce5f8a6af842f39618e8a999f2677) | `` automatic update ``        |
| [`31e8abbb`](https://github.com/nix-community/NUR/commit/31e8abbb9d0723b3bb21f323fb5d1983283efeed) | `` automatic update ``        |
| [`50ff1124`](https://github.com/nix-community/NUR/commit/50ff11243b19c1c64b45ee90a01126de0e995413) | `` add tarantoj repository `` |
| [`74be87c9`](https://github.com/nix-community/NUR/commit/74be87c9af6c629ad29c3456377edac9fea3bcf5) | `` automatic update ``        |
| [`1be7b848`](https://github.com/nix-community/NUR/commit/1be7b8486af579a66bef032907b287dffb16bcb9) | `` automatic update ``        |
| [`83d42a3e`](https://github.com/nix-community/NUR/commit/83d42a3e31f6f4bfd88ffd2a89c111d2e193f742) | `` automatic update ``        |
| [`7412501b`](https://github.com/nix-community/NUR/commit/7412501b811a9b6e9349763f4914152c71cb6068) | `` automatic update ``        |
| [`339c47d3`](https://github.com/nix-community/NUR/commit/339c47d3995e8d2870163272a9ee4f2ea0d267d4) | `` automatic update ``        |
| [`9056cab1`](https://github.com/nix-community/NUR/commit/9056cab1d18a352c7187a03fe4ef788e9e7117d0) | `` automatic update ``        |
| [`ee6b56a3`](https://github.com/nix-community/NUR/commit/ee6b56a34c6f526c8d40fd7ecf471f7758eb38f5) | `` automatic update ``        |
| [`b5d47f96`](https://github.com/nix-community/NUR/commit/b5d47f9660c814897c04a97e99d1b47cd5eb796d) | `` automatic update ``        |
| [`cf3f4ffc`](https://github.com/nix-community/NUR/commit/cf3f4ffc5fe844489802c4c3a4ac5cef3abb15a9) | `` automatic update ``        |
| [`ec86cea0`](https://github.com/nix-community/NUR/commit/ec86cea0e44abf2cd2e701e42962ff78e77a5c91) | `` add raizyr repository ``   |
| [`d26f400f`](https://github.com/nix-community/NUR/commit/d26f400fc66e5adeae34255ce31275af1dd3d616) | `` automatic update ``        |
| [`4f0465af`](https://github.com/nix-community/NUR/commit/4f0465af50e744c21ec8c760dbd874c15f4bcc8e) | `` automatic update ``        |
| [`c9a5577a`](https://github.com/nix-community/NUR/commit/c9a5577a6b3574a4637995d50cf9c8b1bb6cd722) | `` automatic update ``        |
| [`a166d134`](https://github.com/nix-community/NUR/commit/a166d1340879d3adb7f6d825751cf742c757d02b) | `` add progsyn repository ``  |