### PR TITLE
chore(flake/hyprland): `c4f52d19` -> `0387528c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -460,11 +460,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1710531093,
-        "narHash": "sha256-ksLCXlZVOFLtklDYsNjycIIEubijTGbonNT98pAXvmo=",
+        "lastModified": 1710634512,
+        "narHash": "sha256-dqYzqSsGB9PhwxG2H3oVRpqAMWziVuQ7k+02ASku8T4=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "c4f52d19792696b8b297877b9152bd86d0f4624b",
+        "rev": "0387528c56c4d9faf93946cbc9426973de6ef61b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                   |
| ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
| [`0387528c`](https://github.com/hyprwm/Hyprland/commit/0387528c56c4d9faf93946cbc9426973de6ef61b) | `` master: fix moving fullscreen workspace and remove duplicate code (#5131) ``           |
| [`0e87a08e`](https://github.com/hyprwm/Hyprland/commit/0e87a08e15c023325b64920d9e1159f38a090695) | `` renderer: disable surface adjustments for misaligned reported when manual resizing ``  |
| [`3162739e`](https://github.com/hyprwm/Hyprland/commit/3162739e1b555ba7d7b4643bf1ea4debd31007ce) | `` renderer: don't translate surface box on interactive resizes with non-updated sizes `` |
| [`e566be78`](https://github.com/hyprwm/Hyprland/commit/e566be7847b1d32c11291edb99b169f6b64fcebb) | `` LICENSE: Update year (#5132) ``                                                        |
| [`bd332a79`](https://github.com/hyprwm/Hyprland/commit/bd332a79e7669f1dc05ce7ea6b5d78028f1f02bc) | `` Nix: match derivation to Nixpkgs ``                                                    |
| [`c5e28ebc`](https://github.com/hyprwm/Hyprland/commit/c5e28ebcfe00a510922779b2c568cfa52a317445) | `` props: bump ver 0.37.1 ``                                                              |
| [`c942ce6d`](https://github.com/hyprwm/Hyprland/commit/c942ce6dce7f01415f71e5207da69b6989d3818c) | `` renderer: add better multi monitor animations (#5126) ``                               |
| [`5e5d7e2a`](https://github.com/hyprwm/Hyprland/commit/5e5d7e2abcd91c83058ba80ec64ec5054cae5bfa) | `` renderer: fix non-reported sizes window box calculations ``                            |
| [`19c90048`](https://github.com/hyprwm/Hyprland/commit/19c90048d65a5660384d2fb865926a366696d6be) | `` props: bump ver to 0.37.0 ``                                                           |
| [`3f5f5f54`](https://github.com/hyprwm/Hyprland/commit/3f5f5f5491149d16ef721454616c3dd0f96018e5) | `` splashes: add 2ya splash ``                                                            |
| [`2a2da608`](https://github.com/hyprwm/Hyprland/commit/2a2da6082e5f1501731004b755d35a8dbb605fde) | `` renderer: fix invalid access on non-assigned surfaces ``                               |