### PR TITLE
chore(flake/nixpkgs): `bda93c22` -> `ce8e7baf`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -901,11 +901,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1710513883,
-        "narHash": "sha256-MKYur1pNCrk8bU7agCpMRi3dCCEbv3GwH3pS0XuM1Ps=",
+        "lastModified": 1710629476,
+        "narHash": "sha256-N8Xu868Km6PdyvPDPBKY4LWlZwZaN8CJC/4I/EDWYXM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bda93c2221bc4185056723795c62e1b4cc661c4b",
+        "rev": "ce8e7baf9bc8e342237ed840b59e23a92e9a0b5f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                           |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
| [`2b003c02`](https://github.com/NixOS/nixpkgs/commit/2b003c0269a9e7d09bccee3b8c1a055a0d11e354) | `` nixos/pretix: make state directory world-readable ``                           |
| [`f6f5d461`](https://github.com/NixOS/nixpkgs/commit/f6f5d4610d41f4732135bd149f0e1b2b41a05b19) | `` electrum: 4.5.3 -> 4.5.4 ``                                                    |
| [`b87393f6`](https://github.com/NixOS/nixpkgs/commit/b87393f6c8bc8e87a28943d8c87d90f9346a5987) | `` electrum: add missing deps for hw support ``                                   |
| [`54bea470`](https://github.com/NixOS/nixpkgs/commit/54bea4702bcf038be9d09b70022ffa7730cbe088) | `` electrum: pin ledger-bitcoin to 0.2.1 ``                                       |
| [`f3180908`](https://github.com/NixOS/nixpkgs/commit/f31809086c872b185314e15bb7fbd7ffbd91a4d2) | `` cargo-component: 0.10.0 -> 0.10.1 ``                                           |
| [`a21f5e24`](https://github.com/NixOS/nixpkgs/commit/a21f5e24e84b191b452d7e47cb9c275b46ed01c3) | `` vimPlugins.virt-column-nvim: init at 2023-11-13 ``                             |
| [`0656b960`](https://github.com/NixOS/nixpkgs/commit/0656b96023ca0f9acfbdf75060e60502db554075) | `` libajantv2: remove sebtm as maintainer ``                                      |
| [`81c6ae3a`](https://github.com/NixOS/nixpkgs/commit/81c6ae3aceb65efa16ebd1338a4329412b5e1155) | `` swww: cleanup ``                                                               |
| [`236cd757`](https://github.com/NixOS/nixpkgs/commit/236cd757afa836b6e789e5ff2282490964b84703) | `` electrum: add chewblacka to package maintainers ``                             |
| [`a1581a36`](https://github.com/NixOS/nixpkgs/commit/a1581a3647763319d2865e589b63c73dbe67a550) | `` doc: fix and simplify stylesheets for the manuals, fix nrd bug (#295847) ``    |
| [`4645c677`](https://github.com/NixOS/nixpkgs/commit/4645c67723a68f688636fea1a501000d751d35fd) | `` libtiff: mark available on windows ``                                          |
| [`cc42446b`](https://github.com/NixOS/nixpkgs/commit/cc42446bd1bac88ca61e4d821521e250b3cfd1f6) | `` libmng: mark available on windows ``                                           |
| [`ff85f1bd`](https://github.com/NixOS/nixpkgs/commit/ff85f1bd4d2721a5e1607052ce5ebca4a07a9b8d) | `` libdeflate: mark available on windows ``                                       |
| [`1aa92a8b`](https://github.com/NixOS/nixpkgs/commit/1aa92a8baad12468ee72edef42cb46bb4cbebef1) | `` giflib: mark available on windows ``                                           |
| [`0537bbd0`](https://github.com/NixOS/nixpkgs/commit/0537bbd04297ffbe784a32f75afe043167f517bc) | `` pdns: 4.8.4 -> 4.9.0 ``                                                        |
| [`95fde80a`](https://github.com/NixOS/nixpkgs/commit/95fde80ac24a8199e01d0573c1b2c5164451f0ef) | `` libajantv2: Add hint about new upstream/build failure with obs-studio ``       |
| [`ac97c071`](https://github.com/NixOS/nixpkgs/commit/ac97c071c9523b17c08aebe3206e3a670422e451) | `` php82: 8.2.16 -> 8.2.17 ``                                                     |
| [`b23ee19e`](https://github.com/NixOS/nixpkgs/commit/b23ee19ea055ccdd2d60153039a979803fcbd8b8) | `` anilibria-winmaclinux: 1.2.14 -> 1.2.15 ``                                     |
| [`9d43a51a`](https://github.com/NixOS/nixpkgs/commit/9d43a51a5534bf69831f64e1d266a131caefc1f7) | `` metasploit: 6.3.59 -> 6.3.60 ``                                                |
| [`4dbb8d8b`](https://github.com/NixOS/nixpkgs/commit/4dbb8d8bc270967ff4a818a25b43f96f6e967684) | `` shell_gpt: 1.0.1 -> 1.4.0 ``                                                   |
| [`5ed4f2a3`](https://github.com/NixOS/nixpkgs/commit/5ed4f2a3cb64f729adb430bc04f4ea35a5819c1e) | `` python3.pkgs.instructor: init at 0.6.4 ``                                      |
| [`10d3a3a9`](https://github.com/NixOS/nixpkgs/commit/10d3a3a9b088f35e6185d35a697c780a31b11a0a) | `` sing-box: 1.8.8 -> 1.8.9 ``                                                    |
| [`907b859d`](https://github.com/NixOS/nixpkgs/commit/907b859d8310ab0e41226dd88ac91c1af9570017) | `` python312Packages.snapcast: 2.3.5 -> 2.3.6 ``                                  |
| [`af08fb56`](https://github.com/NixOS/nixpkgs/commit/af08fb56643c0ae787b77408b71f20fc285bac3f) | `` exploitdb: 2024-03-13 -> 2024-03-15 ``                                         |
| [`ee2e4218`](https://github.com/NixOS/nixpkgs/commit/ee2e4218651034319c1622161b92953425552de0) | `` labelife-label-printer: init at 1.2.1 ``                                       |
| [`a2154947`](https://github.com/NixOS/nixpkgs/commit/a21549471d73ce42f848a837b7feab72d35d130f) | `` home-manager: unstable-2024-03-12 -> unstable-2024-03-15 ``                    |
| [`847a5374`](https://github.com/NixOS/nixpkgs/commit/847a53742c6021774cff7377f828812a3142cddd) | `` nixos/networkmanager: ensure-profiles, make sure networkmanager is running ``  |
| [`ae5d5a6b`](https://github.com/NixOS/nixpkgs/commit/ae5d5a6b9c57036092ded4af9fbd2258d47acde7) | `` vale: set meta.mainProgram ``                                                  |
| [`2210ac77`](https://github.com/NixOS/nixpkgs/commit/2210ac77645b0e72e5f4e916fcf86a45dac23d62) | `` nixos/scrutiny: Order scrutiny.service after influxdb2.service ``              |
| [`7d691708`](https://github.com/NixOS/nixpkgs/commit/7d6917088cd27899e6d9c929b8f0746e950cddde) | `` nixos/scrutiny: Dont enable influxdb when only using scrutiny-collector ``     |
| [`bdc55d2f`](https://github.com/NixOS/nixpkgs/commit/bdc55d2f8671881b81d6797928b3e7569235b1ba) | `` nixos/steam: provide example in extraCompatPackages ``                         |
| [`74c55dbb`](https://github.com/NixOS/nixpkgs/commit/74c55dbb254680170610c931fb839966d7c0bad2) | `` proton-ge-bin: make $out provide an error when added to an env ``              |
| [`ac37f3f7`](https://github.com/NixOS/nixpkgs/commit/ac37f3f75475afe6641aa35ce50e7fca9ece0134) | `` proton-ge-bin: simplify ``                                                     |
| [`c67a030a`](https://github.com/NixOS/nixpkgs/commit/c67a030aa25b97e0067fd751237b745254f4d1b0) | `` steam: passthru steam's args ``                                                |
| [`2b619c23`](https://github.com/NixOS/nixpkgs/commit/2b619c23146b7b791ed25a174add5cc8d99c8654) | `` nixos/steam: use steamcompattool output for extraCompatPackages ``             |
| [`1b42f2ff`](https://github.com/NixOS/nixpkgs/commit/1b42f2ffbf5c12044b9792a77f5828f6877ccae1) | `` proton-ge-bin: init at init at 9-1 ``                                          |
| [`b9b30333`](https://github.com/NixOS/nixpkgs/commit/b9b30333db6329109b86397544eebd2fc7339aeb) | `` poetryPlugins.poetry-plugin-export: 1.6.0 -> 1.7.0 ``                          |
| [`07d99149`](https://github.com/NixOS/nixpkgs/commit/07d99149de9c653b7b545cf6d19cf364e19cfaed) | `` micronaut: 4.3.5 -> 4.3.6 ``                                                   |
| [`d150ed53`](https://github.com/NixOS/nixpkgs/commit/d150ed53b105933242408ef7a3f21c7989005dcc) | `` dwl: project migrated from GitHub to Codeberg ``                               |
| [`39b26c31`](https://github.com/NixOS/nixpkgs/commit/39b26c31ceb6437d11d0b09e8c052b02e466b621) | `` mpd-discord-rpc: 1.7.1 -> 1.7.2 ``                                             |
| [`424d609d`](https://github.com/NixOS/nixpkgs/commit/424d609df48f52345869c66979a4791f3bc856b4) | `` linux: uncurse arguments ``                                                    |
| [`428564f7`](https://github.com/NixOS/nixpkgs/commit/428564f7529d94ca2dd2c505ce573699d3153916) | `` electron: support v29 binary option (#296218) ``                               |
| [`07f534a6`](https://github.com/NixOS/nixpkgs/commit/07f534a66c5b7d27874fa75164f3f846cd3a4f87) | `` cargo-graph: remove ``                                                         |
| [`5e979472`](https://github.com/NixOS/nixpkgs/commit/5e97947218df1dc551f8453b110ebc178534b297) | `` python311Packages.css-inline: fix darwin build ``                              |
| [`a87c4617`](https://github.com/NixOS/nixpkgs/commit/a87c4617ef71cf38454f4960c85be9ee218fa7b1) | `` clog-cli: mark as broken ``                                                    |
| [`039ecec2`](https://github.com/NixOS/nixpkgs/commit/039ecec2bf814e40e2626ac3ff33933acefd6ff8) | `` panopticon: mark as broken ``                                                  |
| [`22663c58`](https://github.com/NixOS/nixpkgs/commit/22663c585e4d82f6128fc631e3542b48cb5d6bbb) | `` wl-clipboard-rs: add myself as maintainer ``                                   |
| [`c7b11a59`](https://github.com/NixOS/nixpkgs/commit/c7b11a593d26db175aea12415c5bce23e0963e6e) | `` wl-clipboard-rs: 0.8.0-unstable-2023-11-27 -> 0.8.1 ``                         |
| [`b2699f7e`](https://github.com/NixOS/nixpkgs/commit/b2699f7ea66e001be51e629fd8518e83eef38d32) | `` vdrPlugins.softhddevice: 2.1.1 -> 2.1.2 ``                                     |
| [`11e7015e`](https://github.com/NixOS/nixpkgs/commit/11e7015ec70b99d3c9f20a11bff4fb92fa42196b) | `` CODEOWNERS: watch pretix ``                                                    |
| [`bf273971`](https://github.com/NixOS/nixpkgs/commit/bf273971289fccb96f3e833f2fc7ab023a7aba8f) | `` tbls: 1.73.2 -> 1.73.3 ``                                                      |
| [`102f7b22`](https://github.com/NixOS/nixpkgs/commit/102f7b22eb60b960ecb863e123ba82ffaccda95a) | `` redpanda-client: 23.3.7 -> 23.3.8 ``                                           |
| [`29315a95`](https://github.com/NixOS/nixpkgs/commit/29315a952e6596f5bb8519382f056eb4bcffc58f) | `` python312Packages.snapcast: 2.3.5 -> 2.3.6 ``                                  |
| [`d964fa00`](https://github.com/NixOS/nixpkgs/commit/d964fa004db275a7cc4c250712fd178c2b1767fd) | `` vultr-cli: 3.0.2 -> 3.0.3 ``                                                   |
| [`8b47aafe`](https://github.com/NixOS/nixpkgs/commit/8b47aafe798b7dd655b095bb7395832b9e6fe5d0) | `` python312Packages.manifestoo-core: 1.4 -> 1.5 ``                               |
| [`caa1206b`](https://github.com/NixOS/nixpkgs/commit/caa1206b99a44669b566e6fd422ef432e189dcde) | `` python311Packages.paypalrestsdk: refactor ``                                   |
| [`c28c053c`](https://github.com/NixOS/nixpkgs/commit/c28c053ccfdd3d0dfc4ab18bacfe4276b636f210) | `` pretix.plugins.stretchgoals: init at unstable-2023-11-27 ``                    |
| [`72b6d17b`](https://github.com/NixOS/nixpkgs/commit/72b6d17b9605e15c8e53ac77395ec06a0561ee3f) | `` pretix.plugins.reluctant-stripe: init at unstable-2023-08-03 ``                |
| [`67c66d87`](https://github.com/NixOS/nixpkgs/commit/67c66d87d15f13e92fcaf3e62588851e6d089c3c) | `` pretix.plugins.pages: init at 1.6.0 ``                                         |
| [`b36b95af`](https://github.com/NixOS/nixpkgs/commit/b36b95afa176fe4b39ca1c2752623311927fc3c9) | `` pretix.plugins.passbook: init at 1.13.1 ``                                     |
| [`577eb95b`](https://github.com/NixOS/nixpkgs/commit/577eb95b085ac8ac4f7125d6d4d3b1b1a48a6962) | `` python311Packages.wallet-py3k: init at 0.0.4 ``                                |
| [`a01acbce`](https://github.com/NixOS/nixpkgs/commit/a01acbcefe650e830857ad402dad36d6045de090) | `` nixos/tests/pretix: init ``                                                    |
| [`b05a529f`](https://github.com/NixOS/nixpkgs/commit/b05a529fd6eadeccc2b6350201a379af2344fbc8) | `` nixos/pretix: init ``                                                          |
| [`1e20aea8`](https://github.com/NixOS/nixpkgs/commit/1e20aea884bdd44787da343ca8e8e8b9f95ea86b) | `` pretix: init at 2024.2.0 ``                                                    |
| [`7422c41c`](https://github.com/NixOS/nixpkgs/commit/7422c41cb3245faf9647d23a63b716c7b633c150) | `` swww: migrate to by-name ``                                                    |
| [`87bdd731`](https://github.com/NixOS/nixpkgs/commit/87bdd731fa3e463d3572d925cba837f796f2915e) | `` python311Packages.django-statici18n: 2.3.1 -> 2.4.0 ``                         |
| [`11d81797`](https://github.com/NixOS/nixpkgs/commit/11d81797250f8a6c0e31f4b7bdceabca75c6d7d9) | `` python311Packages.django-compressor: convert to pep517 build ``                |
| [`1e89c248`](https://github.com/NixOS/nixpkgs/commit/1e89c24853e98652142b4b978768304882aa93d5) | `` python311Packages.django-otp: 1.1.3 -> 1.3.0post1 ``                           |
| [`cea012f9`](https://github.com/NixOS/nixpkgs/commit/cea012f9b27d23644828b17c55c6fd7ff9a8c583) | `` Revert "python311Packages.paypalrestsdk: drop" ``                              |
| [`53de5242`](https://github.com/NixOS/nixpkgs/commit/53de524216684a39bc1273a63507923b9944a8d3) | `` vimPlugins.nvim-treesitter: update-grammars ``                                 |
| [`61b70347`](https://github.com/NixOS/nixpkgs/commit/61b703478848962850ce2f307a79c77cd5da611f) | `` vimPlugins: resolve github repository redirects ``                             |
| [`a1185388`](https://github.com/NixOS/nixpkgs/commit/a118538862a91aed41873ebc1dd4c9b390aac128) | `` vimPlugins: update on 2024-03-16 ``                                            |
| [`328e43e9`](https://github.com/NixOS/nixpkgs/commit/328e43e941112f410e647b06174aa355056cf776) | `` miniserve: 0.26.0 -> 0.27.1 ``                                                 |
| [`0a6df72f`](https://github.com/NixOS/nixpkgs/commit/0a6df72f32fa6f079deede082ae8304a33bdfb00) | `` nerdctl: 1.7.4 -> 1.7.5 ``                                                     |
| [`ab31938d`](https://github.com/NixOS/nixpkgs/commit/ab31938d525b372db133f761f613528f6151b28b) | `` riffdiff: 3.0.0 -> 3.0.1 ``                                                    |
| [`e218b92a`](https://github.com/NixOS/nixpkgs/commit/e218b92a6c2ef24fe9ade8a09622a9ffcebf5226) | `` python312Packages.types-markdown: 3.5.0.20240311 -> 3.6.0.20240316 ``          |
| [`b78f4552`](https://github.com/NixOS/nixpkgs/commit/b78f45524ae4b68c2c6ad6038578b9b9b756dd6d) | `` vimPlugins.hardhat-nvim: init at 2024-03-14 ``                                 |
| [`0a3e5425`](https://github.com/NixOS/nixpkgs/commit/0a3e5425c9500e3e41f8dce7e3e56ba41a63a829) | `` vimPlugins.neotest-bash: init at 2023-11-18 ``                                 |
| [`fed22e89`](https://github.com/NixOS/nixpkgs/commit/fed22e89b9afbf27dc8bf606e6012ce7661dd317) | `` vimPlugins.neotest-gradle: init at 2023-12-05 ``                               |
| [`1811fe4e`](https://github.com/NixOS/nixpkgs/commit/1811fe4e60990bc77e428cc5fccc210ebbb9dd2a) | `` vimPlugins.neotest-gtest: init at 2023-12-10 ``                                |
| [`f0038970`](https://github.com/NixOS/nixpkgs/commit/f0038970550e015331ce05265a3b5e8d5dadcf2c) | `` vimPlugins.neotest-zig: init at 2023-12-10 ``                                  |
| [`4c2e5e85`](https://github.com/NixOS/nixpkgs/commit/4c2e5e85bdbb6c0e8ae3bf3e8b4d8e85fe3e9eb9) | `` vimPlugins.neotest-foundry: init at 2024-02-03 ``                              |
| [`0c6fd848`](https://github.com/NixOS/nixpkgs/commit/0c6fd848935070636c419bf8593429bbe4409d68) | `` vimPlugins.neotest-java: init at 2024-02-11 ``                                 |
| [`270f91ab`](https://github.com/NixOS/nixpkgs/commit/270f91abea0ca3d9168446b9854416cf7b9a0346) | `` vimPlugins.neotest-minitest: init at 2023-11-05 ``                             |
| [`27f0f13a`](https://github.com/NixOS/nixpkgs/commit/27f0f13a8e902572b857c1a0c3eb2aab3a6717b3) | `` vimPlugins.neotest-playwright: init at 2024-02-23 ``                           |
| [`2f145902`](https://github.com/NixOS/nixpkgs/commit/2f1459023384dca870dbb2db28fde59997ba8c93) | `` home-assistant-custom-components.moonraker: init at v1.1.1 (#296366) ``        |
| [`cfa2922e`](https://github.com/NixOS/nixpkgs/commit/cfa2922e6b833a80a29469cc8ae4f88dfe851eb8) | `` home-assistant0-custom-components.epex_spot: init at v2.3.5 (#296362) ``       |
| [`d8c9226f`](https://github.com/NixOS/nixpkgs/commit/d8c9226f0ec8ada2ccfb43a532ade2bf53a9baa3) | `` vdrPlugins.markad: 3.4.6 -> 3.4.12 ``                                          |
| [`5517aff9`](https://github.com/NixOS/nixpkgs/commit/5517aff997d5ae7fc45e0fac2e0190939a3fc8b1) | `` python312Packages.stupidartnet: 1.4.0 -> 1.5.0 ``                              |
| [`3c49b067`](https://github.com/NixOS/nixpkgs/commit/3c49b06788c04d1378ac8665708bae656281ecb2) | `` vimPlugins.neotest-pest: switch to maintained fork ``                          |
| [`1c707932`](https://github.com/NixOS/nixpkgs/commit/1c707932de74e05faa346222560a434e0ecc5b24) | `` kyverno-chainsaw: 0.1.7 -> 0.1.9 ``                                            |
| [`7de4580c`](https://github.com/NixOS/nixpkgs/commit/7de4580c91bcf551928676e37cedf28c068a60d0) | `` cockpit: 312 -> 313 ``                                                         |
| [`968a917e`](https://github.com/NixOS/nixpkgs/commit/968a917e5d2324cb123500cf508d71a1881ba2b5) | `` autorestic: 1.8.0 -> 1.8.1 ``                                                  |
| [`abc169d4`](https://github.com/NixOS/nixpkgs/commit/abc169d4f5a4ec01e5976ffd0550f95ce9e37e40) | `` spicetify-cli: 2.34.0 -> 2.34.1 ``                                             |
| [`796b530b`](https://github.com/NixOS/nixpkgs/commit/796b530be5c239f1265c3e702ca2c0e659b33814) | `` qownnotes: 24.3.1 -> 24.3.3 ``                                                 |
| [`e4514298`](https://github.com/NixOS/nixpkgs/commit/e451429850e55987f1ee076a033ae7cbe4088cba) | `` balena-cli: 18.0.4 -> 18.1.5 ``                                                |
| [`430b479f`](https://github.com/NixOS/nixpkgs/commit/430b479f5c6aa187d744efd75b6126fdc41a3221) | `` warp-terminal: 0.2024.03.05.08.02.stable_01 -> 0.2024.03.12.08.02.stable_01 `` |
| [`8f4f5381`](https://github.com/NixOS/nixpkgs/commit/8f4f53815c4c1ce04b56779765790c7c2d298855) | `` srb2kart: add desktop item ``                                                  |
| [`731e9507`](https://github.com/NixOS/nixpkgs/commit/731e9507090c139e2a77ea86d538708f6a25184d) | `` srb2kart: refactor ``                                                          |
| [`b9beaf5e`](https://github.com/NixOS/nixpkgs/commit/b9beaf5e0ba30c932375bad5734cba09e5998846) | `` rauc: 1.11.2 -> 1.11.3 ``                                                      |
| [`d59524c9`](https://github.com/NixOS/nixpkgs/commit/d59524c9086dbf0e276f62c95238d299e7f427f3) | `` python311Packages.streamlit: 1.32.1 -> 1.32.2 ``                               |
| [`9551a142`](https://github.com/NixOS/nixpkgs/commit/9551a142106f04d2623ac36487b69d0b9d00ff09) | `` lima: 0.20.1 -> 0.20.2 ``                                                      |
| [`52afac21`](https://github.com/NixOS/nixpkgs/commit/52afac21e747bc9549690e505c12a94c7727963a) | `` python311Packages.pcbnew-transition: 0.4.0 -> 0.4.1 ``                         |
| [`e9cc2cae`](https://github.com/NixOS/nixpkgs/commit/e9cc2cae29697b2f07f22b2beb9ebb2171b2f600) | `` python311Packages.a2wsgi: 1.10.2 -> 1.10.4 ``                                  |
| [`987f2bbc`](https://github.com/NixOS/nixpkgs/commit/987f2bbce30ca611df3bdab6dadf6de60d8a5ecb) | `` mise: 2024.3.1 -> 2024.3.2 ``                                                  |
| [`de52cb51`](https://github.com/NixOS/nixpkgs/commit/de52cb5114a1749fc3d0cba449e1c51696a19c62) | `` labwc-menu-generator: unstable-2024-03-11 -> unstable-2024-03-12 ``            |
| [`6d5fedf9`](https://github.com/NixOS/nixpkgs/commit/6d5fedf9f7ae05ef38bb39f0ff2f99bb3ea36313) | `` mycelium: add flokli to maintainers ``                                         |