### PR TITLE
chore(flake/chaotic): `2952a351` -> `1520b69f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -129,11 +129,11 @@
         "yafas": "yafas"
       },
       "locked": {
-        "lastModified": 1710954445,
-        "narHash": "sha256-vU2OGteZS6dMKZcu+btwsNN4HxIwhEb8dzP+h5NgKps=",
+        "lastModified": 1711229481,
+        "narHash": "sha256-mugLPd8wlCx1s1PDv/sIFJq5xK3sycf+fROFHvE8boE=",
         "owner": "chaotic-cx",
         "repo": "nyx",
-        "rev": "2952a351037582a8aeb11be9cf57901d872bcf30",
+        "rev": "1520b69fa40d96c5e95b6e0da65831d3c7130fb0",
         "type": "github"
       },
       "original": {
@@ -1317,12 +1317,12 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1710806803,
-        "narHash": "sha256-qrxvLS888pNJFwJdK+hf1wpRCSQcqA6W5+Ox202NDa0=",
-        "rev": "b06025f1533a1e07b6db3e75151caa155d1c7eb3",
-        "revCount": 598982,
+        "lastModified": 1711163522,
+        "narHash": "sha256-YN/Ciidm+A0fmJPWlHBGvVkcarYWSC+s3NTPk/P+q3c=",
+        "rev": "44d0940ea560dee511026a53f0e2e2cde489b4d4",
+        "revCount": 601756,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.598982%2Brev-b06025f1533a1e07b6db3e75151caa155d1c7eb3/018e577a-86bd-7b2f-b434-442e9ada5378/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.601756%2Brev-44d0940ea560dee511026a53f0e2e2cde489b4d4/018e6c73-b9c2-7b70-a778-9c1546525f10/source.tar.gz"
       },
       "original": {
         "type": "tarball",


### PR DESCRIPTION
| Commit                                                                                          | Message                                                       |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`1520b69f`](https://github.com/chaotic-cx/nyx/commit/1520b69fa40d96c5e95b6e0da65831d3c7130fb0) | `` failures: update ``                                        |
| [`2a4d2101`](https://github.com/chaotic-cx/nyx/commit/2a4d2101e26a2d2c0713cb8767c17c586bb68913) | `` nix-flake-schemas_git: fix source repository URL (#647) `` |
| [`a68e1385`](https://github.com/chaotic-cx/nyx/commit/a68e13853eb32439cbc84a251e11262d3121012f) | `` nixpkgs: bump to 20240323 ``                               |
| [`a0748e5f`](https://github.com/chaotic-cx/nyx/commit/a0748e5f103adf8e4d84a0dc4be9edff302bd80f) | `` failures: update ``                                        |
| [`eb06e246`](https://github.com/chaotic-cx/nyx/commit/eb06e246e3bb50bb32c9e6d572f8f86833c89968) | `` nixpkgs: bump to 20240322 ``                               |