### PR TITLE
chore(flake/emacs-overlay): `593fd771` -> `619dd15c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -371,11 +371,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1711604862,
-        "narHash": "sha256-unfcrYWtZn+xIAcwfXNh2s1/ZpG9HObEHJG6I7yBliI=",
+        "lastModified": 1711616736,
+        "narHash": "sha256-eQFYDnfxZAm8WLzC0zqjBSkotoERJQvR45jwnELELXI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "593fd7712944cec2a04b0f5d54b22e35fe03290b",
+        "rev": "619dd15c78edea5b3236c841f25a03d77f260154",
         "type": "github"
       },
       "original": {
@@ -1655,11 +1655,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1711333969,
-        "narHash": "sha256-5PiWGn10DQjMZee5NXzeA6ccsv60iLu+Xtw+mfvkUAs=",
+        "lastModified": 1711523803,
+        "narHash": "sha256-UKcYiHWHQynzj6CN/vTcix4yd1eCu1uFdsuarupdCQQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "57e6b3a9e4ebec5aa121188301f04a6b8c354c9b",
+        "rev": "2726f127c15a4cc9810843b96cad73c7eb39e443",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`619dd15c`](https://github.com/nix-community/emacs-overlay/commit/619dd15c78edea5b3236c841f25a03d77f260154) | `` Updated emacs ``        |
| [`89b9788c`](https://github.com/nix-community/emacs-overlay/commit/89b9788ca819ee2f25606c2df4825612bdc8d9ac) | `` Updated melpa ``        |
| [`57bef37f`](https://github.com/nix-community/emacs-overlay/commit/57bef37f7da3ab0f1c5924aa7e19fdf09d6d9618) | `` Updated flake inputs `` |