### PR TITLE
chore(flake/home-manager): `3142bdcc` -> `c0ef0dab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -846,11 +846,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711604890,
-        "narHash": "sha256-vbI/gxRTq/gHW1Q8z6D/7JG/qGNl3JTimUDX+MwnC3A=",
+        "lastModified": 1711625603,
+        "narHash": "sha256-W+9dfqA9bqUIBV5u7jaIARAzMe3kTq/Hp2SpSVXKRQw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3142bdcc470e1e291e1fbe942fd69e06bd00c5df",
+        "rev": "c0ef0dab55611c676ad7539bf4e41b3ec6fa87d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------- |
| [`c0ef0dab`](https://github.com/nix-community/home-manager/commit/c0ef0dab55611c676ad7539bf4e41b3ec6fa87d2) | `` home-environment: fix formatting `` |