### PR TITLE
chore(flake/nixpkgs-unstable): `38760f86` -> `c99b6678`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1639,11 +1639,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1711572435,
-        "narHash": "sha256-O90CV8yeChD44TenDStUhOqcWAJ862ghfA7/l5jUTfk=",
+        "lastModified": 1711616573,
+        "narHash": "sha256-FvZiEl6D4iLXqSQ3oGjQ/qehhPZ5E7iTHr/YA1Rw8kY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "38760f86d61431987e82108a6afb672e8a236bd8",
+        "rev": "c99b66784962e8984444b4d9e72d00d3549afdb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                            |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
| [`bc5ee2b8`](https://github.com/NixOS/nixpkgs/commit/bc5ee2b8f8c1b6a0f1e80a103ccd77febe85f8cc) | `` treewide: Switch markdown placeholder from "..." to <...> ``                    |
| [`fcc95ff8`](https://github.com/NixOS/nixpkgs/commit/fcc95ff8172cc68a0d2d52aa1e8ef2120d2904ec) | `` treewide: Fix all Nix ASTs in all markdown files ``                             |
| [`bc77c7a9`](https://github.com/NixOS/nixpkgs/commit/bc77c7a9730833c7668c92288c6af950e7270cb5) | `` treewide: Mark Nix blocks in markdown as Nix ``                                 |
| [`cb6a1bc1`](https://github.com/NixOS/nixpkgs/commit/cb6a1bc179eb6340562d25c1d13b815eedb9c40c) | `` python312Packages.microsoft-kiota-abstractions: refactor ``                     |
| [`6699cb24`](https://github.com/NixOS/nixpkgs/commit/6699cb2452e5f643dd62683a0badd28e549e1c47) | `` python311Packages.flask-restx: refactor ``                                      |
| [`c24a0835`](https://github.com/NixOS/nixpkgs/commit/c24a08353f4c7c05df2e3946ba0f62a05598691a) | `` checkov: 3.2.47 -> 3.2.48 ``                                                    |
| [`14c3a770`](https://github.com/NixOS/nixpkgs/commit/14c3a770df358fb80fb349ea13e5028a0b07d40e) | `` python312Packages.dirigera: refactor ``                                         |
| [`32ba122a`](https://github.com/NixOS/nixpkgs/commit/32ba122a7a84d9015eff0173c0515a16f46ca5fa) | `` cnspec: 10.8.4 -> 10.9.1 ``                                                     |
| [`8dc27b10`](https://github.com/NixOS/nixpkgs/commit/8dc27b10854531fed934724768c7697e67e27852) | `` python312Packages.awswrangler: refactor ``                                      |
| [`63ff59e6`](https://github.com/NixOS/nixpkgs/commit/63ff59e61b3e6a02ab846cd63b83b20fc3e599ec) | `` python312Packages.pyenphase: 1.20.0 -> 1.20.1 ``                                |
| [`81e43b97`](https://github.com/NixOS/nixpkgs/commit/81e43b9760a2b87e69f2bf4b4996cbb48749df38) | `` python312Packages.google-cloud-pubsub: 2.20.3 -> 2.21.0 ``                      |
| [`0df1dae8`](https://github.com/NixOS/nixpkgs/commit/0df1dae88b5bb9542dff0ca92a1d026f49c7062b) | `` llvm/update-git.py: fix ``                                                      |
| [`fba75829`](https://github.com/NixOS/nixpkgs/commit/fba7582947e1e36d013997885770e2eb19fb8776) | `` treewide: remove explicit `-trimpath` from Go pkgs ``                           |
| [`63a052eb`](https://github.com/NixOS/nixpkgs/commit/63a052eb57590c79a94372af7bc329e698dec5ba) | `` buildGoModule: warn if `-trimpath` or `-mod=` is used ``                        |
| [`e86bae7b`](https://github.com/NixOS/nixpkgs/commit/e86bae7be28bb19c67aabc6179dfffb5b2e3405a) | `` flarectl: 0.91.0 -> 0.92.0 ``                                                   |
| [`e0188a42`](https://github.com/NixOS/nixpkgs/commit/e0188a425eb0b221701e56a5e7b028713ffc7b62) | `` coqPackages_8_19.HoTT: init at 8.19 ``                                          |
| [`08883e58`](https://github.com/NixOS/nixpkgs/commit/08883e586472a17e44f892b3d605ceefcd327631) | `` coqPackages_8_19.dpdgraph: init at 1.0+8.19 ``                                  |
| [`3e2b29d5`](https://github.com/NixOS/nixpkgs/commit/3e2b29d58a3d69927fdca31c3c754bbcdf7b4664) | `` libretranslate: fix build ``                                                    |
| [`7b937aac`](https://github.com/NixOS/nixpkgs/commit/7b937aac12795e55a3c1df7808c240eb561523c0) | `` ctranslate2: 4.0.0 -> 4.1.1 ``                                                  |
| [`0a0e9ec3`](https://github.com/NixOS/nixpkgs/commit/0a0e9ec3e91f0884601f93325582d6b09a3b7be4) | `` python312Packages.awswrangler: 3.7.1 -> 3.7.2 ``                                |
| [`19280a7c`](https://github.com/NixOS/nixpkgs/commit/19280a7ce470e2cfd2418d90939c48d204425384) | `` shim-unsigned: install all targets as data ``                                   |
| [`c6c3e07c`](https://github.com/NixOS/nixpkgs/commit/c6c3e07cfc59e76546a7c27010a2de6704b3931d) | `` teams.llvm: add RossComputerGuy to team ``                                      |
| [`e2a9e8c4`](https://github.com/NixOS/nixpkgs/commit/e2a9e8c41268764f7789a6d97d2a7baa0dad82e4) | `` llvmPackages_git: update to 19.0.0-unstable-2024-03-16 ``                       |
| [`aac3118a`](https://github.com/NixOS/nixpkgs/commit/aac3118ab56b878f5775b4302c70afc654de75ba) | `` llvmPackages_18: init ``                                                        |
| [`d65e36e5`](https://github.com/NixOS/nixpkgs/commit/d65e36e5dbc197a0351cb715bc459837e16b88c8) | `` php83Extensions.mongodb: 1.17.3 -> 1.18.0 ``                                    |
| [`5ad6d050`](https://github.com/NixOS/nixpkgs/commit/5ad6d05005b0d649bc7fd84b0a2b661d42fb33fa) | `` python311Packages.preshed: skip bulk updates ``                                 |
| [`4655e033`](https://github.com/NixOS/nixpkgs/commit/4655e033958d4d5139f662102596bdee54edc5b7) | `` Revert "python3Packages.preshed: 3.0.9 -> 4.0.0" ``                             |
| [`58432231`](https://github.com/NixOS/nixpkgs/commit/584322317f4ab858549293005c4633dde3f2ebaf) | `` iferr: fix meta eval ``                                                         |
| [`c9c67342`](https://github.com/NixOS/nixpkgs/commit/c9c6734202debbb43e8a4bda57801eebd2a445dc) | `` backblaze-b2: skip broken tests causing build failure (#299394) ``              |
| [`3e444c62`](https://github.com/NixOS/nixpkgs/commit/3e444c62c0e62109071296204ea6e2066bbd453c) | `` esphome: 2024.3.0 -> 2024.3.1 ``                                                |
| [`432205b4`](https://github.com/NixOS/nixpkgs/commit/432205b461bea68beadaca5b95665302614e2757) | `` python312Packages.dirigera: 1.0.11 -> 1.0.12 ``                                 |
| [`c71c0972`](https://github.com/NixOS/nixpkgs/commit/c71c0972826fa1d8350b561dfdb4f03f8b398711) | `` nixos/nix-ld: fix typo ``                                                       |
| [`3f935066`](https://github.com/NixOS/nixpkgs/commit/3f935066b4e1101ae18094da7724a190b286a182) | `` python312Packages.glean-parser: 13.0.0 -> 13.0.1 ``                             |
| [`4fe3b9ae`](https://github.com/NixOS/nixpkgs/commit/4fe3b9aec312b773dc842f03416deed06cf5a34f) | `` imgbrd-grabber: add `meta.mainProgram` for `nix run` ``                         |
| [`74bb9f3f`](https://github.com/NixOS/nixpkgs/commit/74bb9f3f170314160c68849c74971ea3c55395b2) | `` bpftop: 0.3.0 -> 0.4.0 ``                                                       |
| [`28be04a0`](https://github.com/NixOS/nixpkgs/commit/28be04a060ee315f95fe1199bcf9ed1e559cc01e) | `` boxbuddy: 2.1.4 -> 2.1.5 ``                                                     |
| [`6df88425`](https://github.com/NixOS/nixpkgs/commit/6df88425c8242bbeb40099a95b1b25662c13aa52) | `` nixos/nix-ld: move default libraries to config ``                               |
| [`132a796a`](https://github.com/NixOS/nixpkgs/commit/132a796a457607ff6a360fd44fb0d820438d14e2) | `` jazz2: 2.5.0 -> 2.6.0 ``                                                        |
| [`3e99abb8`](https://github.com/NixOS/nixpkgs/commit/3e99abb8fedcac79a9892fce6a004cf3491f7090) | `` lunar-client: 3.2.3 -> 3.2.4 ``                                                 |
| [`99fc3b19`](https://github.com/NixOS/nixpkgs/commit/99fc3b19ba48f12d47c83d6d5ec562e44eb13511) | `` python312Packages.mscerts: refactor ``                                          |
| [`9eb85af9`](https://github.com/NixOS/nixpkgs/commit/9eb85af9307a6aa14d74aabba2c0987d8b1472a9) | `` python312Packages.mscerts: 2024.2.28 -> 2024.3.27 ``                            |
| [`efbc4f3a`](https://github.com/NixOS/nixpkgs/commit/efbc4f3a01fc1cff72f8d826e089c54b406cf94d) | `` reshape: fix compilation on Darwin ``                                           |
| [`52e72b5e`](https://github.com/NixOS/nixpkgs/commit/52e72b5ea6ddf15599f8136c869a796bb4d8f85b) | `` mediawriter: 5.0.9 -> 5.1.1 ``                                                  |
| [`6929a744`](https://github.com/NixOS/nixpkgs/commit/6929a7444d4ffc4e0caaff77fd9e47cb8d6d8c15) | `` gtkhash: init at 1.5 ``                                                         |
| [`da8f2e09`](https://github.com/NixOS/nixpkgs/commit/da8f2e0978cd8816cd4249c90818369a21eae9ec) | `` flyctl: 0.2.17 → 0.2.25 ``                                                      |
| [`3922d07d`](https://github.com/NixOS/nixpkgs/commit/3922d07d15a2ec325b2e9b8bb3981d365f9240ac) | `` python312Packages.aiounifi: refactor ``                                         |
| [`57cfd14f`](https://github.com/NixOS/nixpkgs/commit/57cfd14f85c9baadd0e89325bfcffc374785f805) | `` python312Packages.aiounifi: 72 -> 73 ``                                         |
| [`67187dfd`](https://github.com/NixOS/nixpkgs/commit/67187dfd9884bf999696b17866079650e5dc0150) | `` lsd: 1.1.1 -> 1.1.2 ``                                                          |
| [`7ca999bd`](https://github.com/NixOS/nixpkgs/commit/7ca999bdb1f89181647079d499db889021d31549) | `` python312Packages.bases: init at 0.3.0 ``                                       |
| [`da779ed0`](https://github.com/NixOS/nixpkgs/commit/da779ed05b5a84317e5e999d11cd0d5012ac341e) | `` python311Packages.plotnine: 0.13.2 -> 0.13.3 ``                                 |
| [`3cc34c0d`](https://github.com/NixOS/nixpkgs/commit/3cc34c0d9c592160a18363965cfc7f8a8199acae) | `` elixir-ls: fix building with elixir_1_16 ``                                     |
| [`cf1e9d2c`](https://github.com/NixOS/nixpkgs/commit/cf1e9d2cf9a110a928b3285095cfc0c1485adf4c) | `` qtpass: 1.3.2 -> 1.4.0 ``                                                       |
| [`334b49ce`](https://github.com/NixOS/nixpkgs/commit/334b49ce2a030b237d84a3fbdeaf7ac55850c72d) | `` postgresql13Packages.lantern: 0.2.1 -> 0.2.2 ``                                 |
| [`5eacd952`](https://github.com/NixOS/nixpkgs/commit/5eacd9525df561b50fb78c7b103c256e10deb6a2) | `` ooniprobe-cli: 3.20.1 -> 3.21.0 ``                                              |
| [`f97761e4`](https://github.com/NixOS/nixpkgs/commit/f97761e47b21761b4cce6a14183a385b19c4168d) | `` badchars: refactor ``                                                           |
| [`a3e9e673`](https://github.com/NixOS/nixpkgs/commit/a3e9e6739bbc43577f8e4b4c94f1ba3d644c37f6) | `` bitwarden-directory-connector-cli: 2023.10.0 -> 2024.3.1 ``                     |
| [`e141994d`](https://github.com/NixOS/nixpkgs/commit/e141994dbb1a50027f41255adf6a7d9e2f16d9e7) | `` dvc: refactor ``                                                                |
| [`c751bdda`](https://github.com/NixOS/nixpkgs/commit/c751bddad43363a818814d14cf58ad4c8890a180) | `` catnip: 1.8.0 -> 1.8.5 ``                                                       |
| [`3875d6ca`](https://github.com/NixOS/nixpkgs/commit/3875d6cab220a0052186ae54a2850fa50aa0502d) | `` dvc-with-remotes: 3.48.4 -> 3.49.0 ``                                           |
| [`b4efe534`](https://github.com/NixOS/nixpkgs/commit/b4efe534c95d8d35aec842c103c54cbb5256c58d) | `` sipvicious: refactor ``                                                         |
| [`a50a0100`](https://github.com/NixOS/nixpkgs/commit/a50a01003fd408574d11d987dcd934b7a091099b) | `` ldeep: refactor ``                                                              |
| [`a2ac9a5f`](https://github.com/NixOS/nixpkgs/commit/a2ac9a5f605f377aea7b9728ecd751628c1f9bde) | `` pdal: 2.7.0 -> 2.7.1 ``                                                         |
| [`92ebcf7d`](https://github.com/NixOS/nixpkgs/commit/92ebcf7d4da14fd08c7f597162408f046edc9d03) | `` python311Packages.llama-index-agent-openai: 0.10.22 -> 0.2.0 ``                 |
| [`381fbde3`](https://github.com/NixOS/nixpkgs/commit/381fbde3efd2ffc2b885f89a18c737e3e9743a13) | `` python311Packages.llama-index-llms-openai: 0.1.12 -> 0.1.13 ``                  |
| [`76c6e155`](https://github.com/NixOS/nixpkgs/commit/76c6e1555fc85fcee3d925ba88b1fbe38894a29a) | `` python311Packages.llama-index-program-openai: relax llama-index-agent-openai `` |
| [`b212b74a`](https://github.com/NixOS/nixpkgs/commit/b212b74accc3d14c232b7dd3869bcef48d815d64) | `` python311Packages.llama-index-core: 0.10.23 -> 0.10.24 ``                       |
| [`4409f04b`](https://github.com/NixOS/nixpkgs/commit/4409f04b235f02e80efbc5913d72b3438e14ec08) | `` snyk: refactor ``                                                               |
| [`bbf22353`](https://github.com/NixOS/nixpkgs/commit/bbf22353376ecc6a055f93f8c43ee5e8122bbc08) | `` tailscale: 1.62.0 -> 1.62.1 ``                                                  |
| [`9505dd8f`](https://github.com/NixOS/nixpkgs/commit/9505dd8fc1fbb2521275773e68350df7f89ffb3b) | `` snyk: 1.1284.0 -> 1.1286.0 ``                                                   |
| [`7426aa70`](https://github.com/NixOS/nixpkgs/commit/7426aa704ccecd6f007466ca51e343714df2e487) | `` python312Packages.karton-core: refactor ``                                      |
| [`77d41ead`](https://github.com/NixOS/nixpkgs/commit/77d41ead1371b0d169f0c4bfa66000ce08ac9d37) | `` python312Packages.microsoft-kiota-abstractions: 1.3.1 -> 1.3.2 ``               |
| [`4e7e219a`](https://github.com/NixOS/nixpkgs/commit/4e7e219a93572097e47c0e13fc2c728a8884ed64) | `` python312Packages.karton-core: 5.3.3 -> 5.3.4 ``                                |
| [`f0887fa0`](https://github.com/NixOS/nixpkgs/commit/f0887fa04002e9dcdb687c91588dea09fd645a6c) | `` virtualbox: fix guest additions resize support ``                               |
| [`c635984e`](https://github.com/NixOS/nixpkgs/commit/c635984e73c4c50215da7188732888ad8cc7abb5) | `` llvmPackages_18: init ``                                                        |
| [`23392b61`](https://github.com/NixOS/nixpkgs/commit/23392b616f0eab24943aade091a76d73c74b739d) | `` python311Packages.flask-restx: fix build on Darwin ``                           |
| [`771fc3ee`](https://github.com/NixOS/nixpkgs/commit/771fc3eea5ef0fd41e38e5af1f2f9f7ea677221e) | `` bt-migrate: init at 0-unstable-2023-08-17 ``                                    |
| [`83495070`](https://github.com/NixOS/nixpkgs/commit/8349507010698f640d0753d95ffc6715bccec676) | `` sqlite_orm: init at 1.8.2 ``                                                    |
| [`914d4dd2`](https://github.com/NixOS/nixpkgs/commit/914d4dd262cdaa462e686ba3c4d0c77fc80a1c5b) | `` digestpp: init at 0-unstable-2023-11-07 ``                                      |
| [`2b7d08ce`](https://github.com/NixOS/nixpkgs/commit/2b7d08ce89348d24977a4e0d8fd4fdeb99117b72) | `` postgres-lsp: unstable-2024-01-11 -> 0-unstable-2024-03-24 ``                   |
| [`3ed42083`](https://github.com/NixOS/nixpkgs/commit/3ed420832799a01b99932a0a459baf15deb56743) | `` quickwit: 0.6.4 -> 0.8.0 ``                                                     |
| [`730e570c`](https://github.com/NixOS/nixpkgs/commit/730e570c2990dcd722936aaa6c986ff8335364d2) | `` ryujinx: 1.1.1239 -> 1.1.1242 ``                                                |
| [`1d45945b`](https://github.com/NixOS/nixpkgs/commit/1d45945b3319554d8d72bbac2a47d41ae4ff3055) | `` microsoft-identity-broker: 1.7.0 -> 2.0.0 ``                                    |
| [`3f99c895`](https://github.com/NixOS/nixpkgs/commit/3f99c895320e3c7380801db442eb551288b4296e) | `` iferr: 2018-06-15 -> 0-unstable-2024-01-22 ``                                   |
| [`00af5222`](https://github.com/NixOS/nixpkgs/commit/00af52229ec39be87e7633db7f2dbc090adc3dff) | `` fastqc: init at 0.12.1 ``                                                       |
| [`54f1d8f1`](https://github.com/NixOS/nixpkgs/commit/54f1d8f19990c9be8887ca945c90abd82edb5daf) | `` maintainers: add dflores ``                                                     |
| [`ad152c62`](https://github.com/NixOS/nixpkgs/commit/ad152c62f8c1cb75e37d04a9f5741001d13cd20b) | ``  rime-data: 0.38.20211002 -> 0.38.20231116 ``                                   |