### PR TITLE
chore(flake/emacs-overlay): `619dd15c` -> `b58ea7d9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -371,11 +371,11 @@
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1711616736,
-        "narHash": "sha256-eQFYDnfxZAm8WLzC0zqjBSkotoERJQvR45jwnELELXI=",
+        "lastModified": 1711846974,
+        "narHash": "sha256-VJR6ddmMPdLTHwPsyiO3Ua60ZhuBc4PdHDyXTplRH4U=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "619dd15c78edea5b3236c841f25a03d77f260154",
+        "rev": "b58ea7d9c253d9eea3bbf4d5153a9f1f7bc21722",
         "type": "github"
       },
       "original": {
@@ -1591,11 +1591,11 @@
     },
     "nixpkgs-stable_2": {
       "locked": {
-        "lastModified": 1711460390,
-        "narHash": "sha256-akSgjDZL6pVHEfSE6sz1DNSXuYX6hq+P/1Z5IoYWs7E=",
+        "lastModified": 1711668574,
+        "narHash": "sha256-u1dfs0ASQIEr1icTVrsKwg2xToIpn7ZXxW3RHfHxshg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "44733514b72e732bd49f5511bd0203dea9b9a434",
+        "rev": "219951b495fc2eac67b1456824cc1ec1fd2ee659",
         "type": "github"
       },
       "original": {
@@ -1655,11 +1655,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1711523803,
-        "narHash": "sha256-UKcYiHWHQynzj6CN/vTcix4yd1eCu1uFdsuarupdCQQ=",
+        "lastModified": 1711703276,
+        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2726f127c15a4cc9810843b96cad73c7eb39e443",
+        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                     |
| ------------------------------------------------------------------------------------------------------------ | --------------------------- |
| [`b58ea7d9`](https://github.com/nix-community/emacs-overlay/commit/b58ea7d9c253d9eea3bbf4d5153a9f1f7bc21722) | `` Updated elpa ``          |
| [`33f182c7`](https://github.com/nix-community/emacs-overlay/commit/33f182c768a59d1a403bd00f1f1614a0bc3595ef) | `` Updated nongnu ``        |
| [`ccd0043a`](https://github.com/nix-community/emacs-overlay/commit/ccd0043a3fb5758b0d17a92e907872cdc4f63ab7) | `` Updated elpa ``          |
| [`f8ad90d4`](https://github.com/nix-community/emacs-overlay/commit/f8ad90d467e2a48cf91aa0b3b75ac7929dc07425) | `` Updated emacs ``         |
| [`af307726`](https://github.com/nix-community/emacs-overlay/commit/af307726ea14d3be3627790a40ab6d6b2ae1938f) | `` Updated melpa ``         |
| [`082f1fc8`](https://github.com/nix-community/emacs-overlay/commit/082f1fc8593b304c201439d700c4d89bf08d9a03) | `` Updated melpa ``         |
| [`0986a439`](https://github.com/nix-community/emacs-overlay/commit/0986a439e17fadf35e618f049f48722c3bc46557) | `` Updated elpa ``          |
| [`ac7d8c8a`](https://github.com/nix-community/emacs-overlay/commit/ac7d8c8afeb66f66cd1e72194de52f9fb00de25b) | `` Updated nongnu ``        |
| [`307fe8bd`](https://github.com/nix-community/emacs-overlay/commit/307fe8bd8599c228f6062e37dd70c10d981434f2) | `` Updated flake inputs ``  |
| [`b2b55327`](https://github.com/nix-community/emacs-overlay/commit/b2b55327ffdc55cbc873f86335503ca65a489034) | `` Updated melpa ``         |
| [`825ea7a5`](https://github.com/nix-community/emacs-overlay/commit/825ea7a501bae55ceea334b3e83a0ac740b137ac) | `` Manually update Emacs `` |
| [`63c6ebdb`](https://github.com/nix-community/emacs-overlay/commit/63c6ebdb1426947d8e5f3daa3f29f247f8eac218) | `` Update patch ``          |
| [`734cfa5f`](https://github.com/nix-community/emacs-overlay/commit/734cfa5f4f5183076552cb14497768f768be9904) | `` Updated elpa ``          |
| [`82e74326`](https://github.com/nix-community/emacs-overlay/commit/82e74326336ef6fd3b802207bf073ee5c52c4441) | `` Updated nongnu ``        |
| [`673b9304`](https://github.com/nix-community/emacs-overlay/commit/673b93046cd4bf71ad5284e29e9df96e50ef4c82) | `` Updated melpa ``         |
| [`8dbeee1c`](https://github.com/nix-community/emacs-overlay/commit/8dbeee1c4befdeb36fbb3a951d5c3bf2b7f1ae05) | `` Updated emacs ``         |
| [`8189846d`](https://github.com/nix-community/emacs-overlay/commit/8189846d4d123e9056541088a75c255c6cde3c2d) | `` Updated melpa ``         |
| [`04518449`](https://github.com/nix-community/emacs-overlay/commit/04518449b13898684d17bb14baf5213e66cbf602) | `` Updated elpa ``          |
| [`0ecb38ec`](https://github.com/nix-community/emacs-overlay/commit/0ecb38ec45621eaacffb62fcbf9595d7bc200c7f) | `` Updated elpa ``          |