### PR TITLE
chore(flake/nixpkgs-unstable): `c99b6678` -> `35fde999`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1639,11 +1639,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1711616573,
-        "narHash": "sha256-FvZiEl6D4iLXqSQ3oGjQ/qehhPZ5E7iTHr/YA1Rw8kY=",
+        "lastModified": 1711810502,
+        "narHash": "sha256-KSmbNHD7Zh/f7cYgu0gwCg6gNGMn48MB7h6mxnP1304=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c99b66784962e8984444b4d9e72d00d3549afdb2",
+        "rev": "35fde99980ebe5533bd75db71ea0894ceba11595",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                        |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| [`59bccda1`](https://github.com/NixOS/nixpkgs/commit/59bccda1532d677d5f69f07d677489f3a995b744) | `` Revert "stdenv: add meta.repository field" ``                                               |
| [`0e8bcaa6`](https://github.com/NixOS/nixpkgs/commit/0e8bcaa661f602db11bbe8347fb46bb271e8e58b) | `` Revert "stdenv/check-meta: Don't create new environments when computing meta.repository" `` |
| [`94805a3d`](https://github.com/NixOS/nixpkgs/commit/94805a3d21e407908ebf1d6de7d21028f01776db) | `` nixos/partition-manager: use qt6 when plasma6 is activated ``                               |
| [`26538d47`](https://github.com/NixOS/nixpkgs/commit/26538d4700c60b9be5329859eae6e8a57e762f04) | `` nixos/partition-manager: remove with with lib, cleanup ``                                   |
| [`c6411f87`](https://github.com/NixOS/nixpkgs/commit/c6411f87ae997fc04e1c0dd0034c88cc30c7b872) | `` tgpt: 2.7.2 -> 2.7.3 ``                                                                     |
| [`ef3bb687`](https://github.com/NixOS/nixpkgs/commit/ef3bb68717e943bf364b4ce147313773de2a6d62) | `` vimPlugins.jupytext-nvim: fix typo in pname ``                                              |
| [`01e1f71f`](https://github.com/NixOS/nixpkgs/commit/01e1f71fdfd12faa2d6f772a710f42114a141231) | `` vimPlugins.improved-search-nvim: init at 2023-12-21 ``                                      |
| [`4363f16d`](https://github.com/NixOS/nixpkgs/commit/4363f16d8fc29ed6c177c8b28901801d8b0a3d10) | `` luaPackages.luadbi-mysql: fix overrides => fix build ``                                     |
| [`afce1683`](https://github.com/NixOS/nixpkgs/commit/afce1683c09ff117d1c15d083f7fe2655662c6d2) | `` gitlab: Simplify gitlab-assets build instructions ``                                        |
| [`774056a4`](https://github.com/NixOS/nixpkgs/commit/774056a4e6ba519797eecf08ba1b1ddcb0f3104a) | `` nixos/gitlab: Rename workhorse binary ``                                                    |
| [`500b187b`](https://github.com/NixOS/nixpkgs/commit/500b187bb95b57cb4e63adabb9bfb44d12761508) | `` gitlab-container-registry: 3.90.0 -> 3.91.0 ``                                              |
| [`1dabbf30`](https://github.com/NixOS/nixpkgs/commit/1dabbf30637cd623d0f2d25f79eefd3ca324a323) | `` gitlab: 16.9.2 -> 16.10.1 ``                                                                |
| [`ba79149c`](https://github.com/NixOS/nixpkgs/commit/ba79149c6658336e533376c26e80cabba781ea24) | `` stdenv/check-meta: don't infrec on unsupported platforms ``                                 |
| [`5eca3b06`](https://github.com/NixOS/nixpkgs/commit/5eca3b06e77995448ae29a95efe79b2d0e6a0e65) | `` dotnet: added shell completion scripts ``                                                   |
| [`02910df6`](https://github.com/NixOS/nixpkgs/commit/02910df6a5616ae0694d7986385ad7e62313d839) | `` typst-live: move to `pkgs/by-name` ``                                                       |
| [`9fc370d8`](https://github.com/NixOS/nixpkgs/commit/9fc370d8ad0ae29a609e0bbcd62d1a1e8fb56350) | `` dotnet-outdated: init at 4.6.0 ``                                                           |
| [`ffdf7f26`](https://github.com/NixOS/nixpkgs/commit/ffdf7f26d86160c344fb223b9129116e73c002b8) | `` python312Packages.speechrecognition: refactor ``                                            |
| [`35065fb2`](https://github.com/NixOS/nixpkgs/commit/35065fb264c7dc29b249eb2fd5946c18e7dd37f0) | `` python312Packages.speechrecognition: 3.10.1 -> 3.10.2 ``                                    |
| [`f92d7f0c`](https://github.com/NixOS/nixpkgs/commit/f92d7f0c870ecace5bca9dd1a85e2c000427e34b) | `` python312Packages.wsgidav: 4.3.1 -> 4.3.2 ``                                                |
| [`347310ed`](https://github.com/NixOS/nixpkgs/commit/347310ed315b807ea467553ee1de2d7df142919c) | `` python312Packages.pyoverkiz: refactor ``                                                    |
| [`0fcaf002`](https://github.com/NixOS/nixpkgs/commit/0fcaf0027e43b3ab497fb49badb55d8c164f3e72) | `` python312Packages.pyoverkiz: 1.13.9 -> 1.13.10 ``                                           |
| [`6299182d`](https://github.com/NixOS/nixpkgs/commit/6299182d1b1d0dfa489740cc91c8fbff567c93fc) | `` python311Packages.mypy-boto3-sagemaker: 1.34.70 -> 1.34.74 ``                               |
| [`a20fd8a1`](https://github.com/NixOS/nixpkgs/commit/a20fd8a10b843a76855370f0b1a3f5b16c4a4dfe) | `` python311Packages.mypy-boto3-marketplace-catalog: 1.34.41 -> 1.34.74 ``                     |
| [`46010775`](https://github.com/NixOS/nixpkgs/commit/460107752aa0c2db52c256b76eeaf6b4e5518ace) | `` python311Packages.mypy-boto3-iotwireless: 1.34.0 -> 1.34.74 ``                              |
| [`6902359c`](https://github.com/NixOS/nixpkgs/commit/6902359c7dc401a8cab690362bbf6ba306986c59) | `` python311Packages.mypy-boto3-internetmonitor: 1.34.48 -> 1.34.74 ``                         |
| [`38b06b5a`](https://github.com/NixOS/nixpkgs/commit/38b06b5ae46f375f64fa733a19beb7783a545838) | `` python311Packages.mypy-boto3-codebuild: 1.34.70 -> 1.34.74 ``                               |
| [`bc4fe62d`](https://github.com/NixOS/nixpkgs/commit/bc4fe62df668644791c220867ffff991cbfad78c) | `` python312Packages.llama-index-vector-stores-qdrant: 0.1.4 -> 0.1.5 ``                       |
| [`a53ce1de`](https://github.com/NixOS/nixpkgs/commit/a53ce1de35b3d70768ea46fe65c3f08bcea15caa) | `` python312Packages.llama-index-vector-stores-postgres: 0.1.3 -> 0.1.4.post1 ``               |
| [`fdb84546`](https://github.com/NixOS/nixpkgs/commit/fdb84546c3c7b9069c03d7ad2557abd2bc65c2ad) | `` python312Packages.llama-index-vector-stores-google: 0.1.4 -> 0.1.5 ``                       |
| [`abfff76b`](https://github.com/NixOS/nixpkgs/commit/abfff76bd50f159861434e3522c5f27f1296f52a) | `` python312Packages.llama-index-readers-file: 0.1.12 -> 0.1.13 ``                             |
| [`0a7244fd`](https://github.com/NixOS/nixpkgs/commit/0a7244fda0a10a25ec9da849aa3067918a7b1f0a) | `` python312Packages.llama-index-llms-openai: 0.1.13 -> 0.1.14 ``                              |
| [`b39c38a5`](https://github.com/NixOS/nixpkgs/commit/b39c38a5b677f403226f9ae374a3984bb2798a94) | `` python312Packages.llama-index-graph-stores-neo4j: 0.1.3 -> 0.1.4 ``                         |
| [`e7b14aa4`](https://github.com/NixOS/nixpkgs/commit/e7b14aa49f56d45983e2172d5f598ffa1dcd5932) | `` python312Packages.boto3-stubs: 1.34.73 -> 1.34.74 ``                                        |
| [`38cee3ef`](https://github.com/NixOS/nixpkgs/commit/38cee3ef97d5f4d3bf4996a84d2756e4dd633fc1) | `` trufflehog: 3.70.3 -> 3.71.2 ``                                                             |
| [`dc49349c`](https://github.com/NixOS/nixpkgs/commit/dc49349c84cc05f9cb50c9f46e4330f053803d0b) | `` stdenv/check-meta: Inherit remaining lib access into scope ``                               |
| [`4b0576b8`](https://github.com/NixOS/nixpkgs/commit/4b0576b803e850cd5c6840b420852a35cbd367fc) | `` clickhouse-backup: 2.4.34 -> 2.4.35 ``                                                      |
| [`f8b091d5`](https://github.com/NixOS/nixpkgs/commit/f8b091d53fdb339a9489551e21ceb4bad84c79e9) | `` stdenv/check-meta: Don't create new environments when computing meta.repository ``          |
| [`a293bb51`](https://github.com/NixOS/nixpkgs/commit/a293bb51b9e34fdd6aeb0198fb28c4c08d2e6f75) | `` crowdin-cli: 3.19.0 -> 3.19.1 ``                                                            |
| [`4adf3fe2`](https://github.com/NixOS/nixpkgs/commit/4adf3fe22fd9db57ba331f63ac0794ddab307f1e) | `` path-of-building.data: 2.41.0 -> 2.42.0 ``                                                  |
| [`e372d445`](https://github.com/NixOS/nixpkgs/commit/e372d44587ecf91c65e62d08a8d3ba3170451eb8) | `` python312Packages.asf-search: 7.0.7 -> 7.0.8 ``                                             |
| [`210d7aa9`](https://github.com/NixOS/nixpkgs/commit/210d7aa90a217b828da73cbb3e78304c7f95c5d9) | `` terragrunt: 0.55.19 -> 0.55.20 ``                                                           |
| [`e681e17a`](https://github.com/NixOS/nixpkgs/commit/e681e17ad2bd41cde29386967addd7e39a4aa45e) | `` heroku: 8.11.0 -> 8.11.1 ``                                                                 |
| [`64963404`](https://github.com/NixOS/nixpkgs/commit/6496340434b489d6e80cba541a3cc948c86aa581) | `` python311Packages.plaid-python: 19.0.0 -> 20.0.1 ``                                         |
| [`3f971d96`](https://github.com/NixOS/nixpkgs/commit/3f971d9676dbb54518ef2d610ffdd822fca31820) | `` refinery-cli: 0.8.12 -> 0.8.13 ``                                                           |
| [`2a90fb93`](https://github.com/NixOS/nixpkgs/commit/2a90fb936848811fd40da52755acb515e5ca1878) | `` pupdate: 3.9.0 -> 3.9.1 ``                                                                  |
| [`ab5000d9`](https://github.com/NixOS/nixpkgs/commit/ab5000d98fe4e2943294a88d40ad7317d15df3da) | `` libremines: 2.0.0 -> 2.0.1 ``                                                               |
| [`3af08320`](https://github.com/NixOS/nixpkgs/commit/3af083202c6dab1a96459e7f891dab746f20c87b) | `` kuma-dp: 2.6.2 -> 2.6.3 ``                                                                  |
| [`19b7c482`](https://github.com/NixOS/nixpkgs/commit/19b7c482df4ecee4d736dd2048d008d658c97712) | `` adwsteamgtk: 0.6.9 -> 0.6.10 ``                                                             |
| [`6d98f510`](https://github.com/NixOS/nixpkgs/commit/6d98f510746c5c0db64976f33a3457b58dc41b67) | `` python311Packages.py3status: 3.56 -> 3.57 ``                                                |
| [`4816fa45`](https://github.com/NixOS/nixpkgs/commit/4816fa452a5f5749dc6abeb83f88bfc56a888b52) | `` starship: 1.18.1 -> 1.18.2 ``                                                               |
| [`81aecc51`](https://github.com/NixOS/nixpkgs/commit/81aecc512a8c85ef535870ca8a95ea6e43f5660f) | `` python311Packages.tempest: 37.0.0 -> 38.0.0 ``                                              |
| [`3506d240`](https://github.com/NixOS/nixpkgs/commit/3506d24084a6f9c52010f85f4c0bf673eef3637b) | `` f3d: 2.3.0 -> 2.3.1 ``                                                                      |
| [`527a8747`](https://github.com/NixOS/nixpkgs/commit/527a8747b105ac3f85ebbc8e346c90b20efe6d69) | `` python312Packages.pytest-relaxed: 2.0.1 -> 2.0.2 ``                                         |
| [`1e350877`](https://github.com/NixOS/nixpkgs/commit/1e3508771875e7748d698fbaaaefb2fd7ba9d40f) | `` python311Packages.phonopy: 2.22.0 -> 2.22.1 ``                                              |
| [`44642361`](https://github.com/NixOS/nixpkgs/commit/44642361a3339191e453e3fcb3ebf2b71c8c3513) | `` python312Packages.clarifai-grpc: refactor ``                                                |
| [`2119fb6f`](https://github.com/NixOS/nixpkgs/commit/2119fb6f84879ee6847aef3db57866b861d369e0) | `` python312Packages.censys: refactor ``                                                       |
| [`993486df`](https://github.com/NixOS/nixpkgs/commit/993486dfc13e92dd131851eb56b7f028d0b23f40) | `` python312Packages.censys: 2.2.11 -> 2.2.12 ``                                               |
| [`215fb23a`](https://github.com/NixOS/nixpkgs/commit/215fb23aed23939fe7d751d283cc03a561eab04d) | `` python312Packages.lacuscore: 1.8.10 -> 1.9.1 ``                                             |
| [`bb0f1655`](https://github.com/NixOS/nixpkgs/commit/bb0f16553ff40bf1615520993d9ba0fe495dc4d2) | `` python312Packages.playwrightcapture: 1.23.14 -> 1.24.1 ``                                   |
| [`5559282b`](https://github.com/NixOS/nixpkgs/commit/5559282b101ba3dca92170f60e8bc661b5fe4970) | `` python312Packages.meshtastic: 2.3.0 -> 2.3.3 ``                                             |
| [`d7f0e554`](https://github.com/NixOS/nixpkgs/commit/d7f0e554831ff218093bd8fac6ac6b0eb4bc458d) | `` python312Packages.pygatt: refactor ``                                                       |
| [`e1395913`](https://github.com/NixOS/nixpkgs/commit/e13959136e4bf082b4d1ec67f505ee62a1e1841d) | `` signal-desktop: 7.3.1 -> 7.4.0 ``                                                           |
| [`45cccd28`](https://github.com/NixOS/nixpkgs/commit/45cccd284355b768279256ebb4f3b5c00edef6d4) | `` python311Packages.flask-paginate: 2023.10.24 -> 2024.3.28 ``                                |
| [`38c7df60`](https://github.com/NixOS/nixpkgs/commit/38c7df605e19bb25165a81a75bbfee725726b128) | `` python311Packages.tox: 4.14.1 -> 4.14.2 ``                                                  |
| [`2da0dd80`](https://github.com/NixOS/nixpkgs/commit/2da0dd80a75cb0e9dcdab9e25622d803b12cdbf7) | `` python311Packages.requirements-parser: 0.6.0 -> 0.7.0 ``                                    |
| [`cf4a88db`](https://github.com/NixOS/nixpkgs/commit/cf4a88db7932a493f548c15b93989b04bfe86566) | `` nixos/incus: fix OVMF path for existing VMs ``                                              |
| [`f41583a8`](https://github.com/NixOS/nixpkgs/commit/f41583a8bf0c9ec38c1a105d6965a21e64b53bec) | `` squeezelite: 2.0.0.1473 -> 2.0.0.1476 ``                                                    |
| [`1fd8c79e`](https://github.com/NixOS/nixpkgs/commit/1fd8c79e1f35db41c48517957d4b56b1a4e9d23c) | `` python312Packages.langsmith: 0.1.36 -> 0.1.38 ``                                            |
| [`7e1443ab`](https://github.com/NixOS/nixpkgs/commit/7e1443abbba99e9dac29ce2ad01c1c4e4fb66070) | `` stdenv: add meta.repository field ``                                                        |
| [`2179e629`](https://github.com/NixOS/nixpkgs/commit/2179e629c698ed6d024bcf998847cd5652818a88) | `` latex2html: 2023.2 -> 2024 ``                                                               |
| [`19b2b804`](https://github.com/NixOS/nixpkgs/commit/19b2b8046dbefaf3e92d3ae6f9fb6119557cd44d) | `` nixos/invidious-router: init module ``                                                      |
| [`982c5169`](https://github.com/NixOS/nixpkgs/commit/982c5169b41b9e1f10983e3d92418ace4db79d13) | `` python311Packages.scalene: init at 1.5.38 ``                                                |
| [`27662492`](https://github.com/NixOS/nixpkgs/commit/276624921a196180387832713961b1b8d06ec178) | `` advcpmv: remove ``                                                                          |
| [`9ff9e8c5`](https://github.com/NixOS/nixpkgs/commit/9ff9e8c5366064fa58ddc4d9436664de05dcc41d) | `` python312Packages.reptor: 0.14 -> 0.16 ``                                                   |
| [`08edcc88`](https://github.com/NixOS/nixpkgs/commit/08edcc88254cc6aa79483b300cb08c926f57101d) | `` python312Packages.clarifai-grpc: 10.2.2 -> 10.2.3 ``                                        |
| [`5c37a959`](https://github.com/NixOS/nixpkgs/commit/5c37a95922ca5d556189fbd0867b3e0833e9f8ca) | `` python312Packages.argilla: 1.26.0 -> 1.26.1 ``                                              |
| [`6712c6b4`](https://github.com/NixOS/nixpkgs/commit/6712c6b4330b0c851778a53acb353735b0467d54) | `` aliyun-cli: 3.0.200 -> 3.0.201 ``                                                           |
| [`a233581e`](https://github.com/NixOS/nixpkgs/commit/a233581eaadd62fca797146eda5fa94ed612f80f) | `` railway-travel: init at 2.4.0 ``                                                            |
| [`23dfaa9b`](https://github.com/NixOS/nixpkgs/commit/23dfaa9b0b3d57b803892b382d36327e82c7da25) | `` python311Packages.pylacus: 1.8.2 -> 1.9.0 ``                                                |
| [`927d6ca7`](https://github.com/NixOS/nixpkgs/commit/927d6ca7e43eeabfb750ed39a071b0060bb51a50) | `` octopus: 13.0 -> 14.0, switch to cmake ``                                                   |
| [`46149042`](https://github.com/NixOS/nixpkgs/commit/46149042db61bbc8f5c9592b46816e3404654a98) | `` scalapack: fix generated cmake files ``                                                     |
| [`de6412ca`](https://github.com/NixOS/nixpkgs/commit/de6412caddbc0307144ec8c5e91918e921653d39) | `` nixseparatedebuginfod: use system jemalloc ``                                               |
| [`6738f9d3`](https://github.com/NixOS/nixpkgs/commit/6738f9d39555aa1bf51159bf77bad314eab510bb) | `` python311Packages.django-webpush: refactor ``                                               |
| [`c782d770`](https://github.com/NixOS/nixpkgs/commit/c782d7704c352258f0dec71fb8c2addfddd8fb8e) | `` python312Packages.pywebpush: 1.14.1 -> 2.0.0 ``                                             |
| [`b86d875b`](https://github.com/NixOS/nixpkgs/commit/b86d875b4ad05fc9a61d2ea3df2619230d4b2e57) | `` maintainers: add lilacious ``                                                               |
| [`fedd84da`](https://github.com/NixOS/nixpkgs/commit/fedd84da415fe0226acb7d75cdad130ebb1e3fdc) | `` fido2luks: fix build ``                                                                     |
| [`3da6ce6c`](https://github.com/NixOS/nixpkgs/commit/3da6ce6c182cb79b38d2e98af6df974458cb3f29) | `` python311Packages.pywebpush: refactor ``                                                    |
| [`33a1770e`](https://github.com/NixOS/nixpkgs/commit/33a1770eaf5c0bcaac38c9bb9d7f5149430c00a2) | `` lubelogger: 1.2.8 -> 1.2.9 ``                                                               |
| [`7f308fc2`](https://github.com/NixOS/nixpkgs/commit/7f308fc2f7e910e624cb1628cd7de5013d5ce1c8) | `` fido2luks: remove prusnak as maintainer ``                                                  |
| [`4b92ad9e`](https://github.com/NixOS/nixpkgs/commit/4b92ad9effb5455b382b8990c6d36a997079af17) | `` oculante: 0.8.16 -> 0.8.17 ``                                                               |
| [`e6dcb475`](https://github.com/NixOS/nixpkgs/commit/e6dcb475217113304b88650e776f94399487dcce) | `` granted: 0.21.1 -> 0.22.0 ``                                                                |
| [`193e698d`](https://github.com/NixOS/nixpkgs/commit/193e698d5af7cc2fbf830627d9da5a6d81e1d18c) | `` spotify-player: 0.17.1 -> 0.17.2 ``                                                         |
| [`fe252a1d`](https://github.com/NixOS/nixpkgs/commit/fe252a1d500e8d38ab5d38c7661168ac87baba0c) | `` python311Packages.findpython: 0.5.1 -> 0.6.0 ``                                             |
| [`8273075e`](https://github.com/NixOS/nixpkgs/commit/8273075e61866a83ac05085667df6074c8fc736f) | `` idris2Packages.buildIdris: better nix-shell support via shellHook ``                        |
| [`4df67ea4`](https://github.com/NixOS/nixpkgs/commit/4df67ea446a6cfe342861b7b04ea5793345d8cec) | `` aws-iam-authenticator: 0.6.18 -> 0.6.19 ``                                                  |