### PR TITLE
chore(flake/emacs-overlay): `5dee04f5` -> `d8c28bca`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -225,11 +225,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712021653,
-        "narHash": "sha256-Yr+cDDESdm2E9C/nj1nlhrMpyYt1/Va9yXvlRYD9SyA=",
+        "lastModified": 1712196574,
+        "narHash": "sha256-wiA16ORjj6VSRzUlhgKio9eIoqt86c/56fAkdmcBrOk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "5dee04f5269dffad92faf3a8210c03e639d86db2",
+        "rev": "d8c28bca43275f1503a029cc73629cd1aa585af7",
         "type": "github"
       },
       "original": {
@@ -1153,11 +1153,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711703276,
-        "narHash": "sha256-iMUFArF0WCatKK6RzfUJknjem0H9m4KgorO/p3Dopkk=",
+        "lastModified": 1712122226,
+        "narHash": "sha256-pmgwKs8Thu1WETMqCrWUm0CkN1nmCKX3b51+EXsAZyY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d8fe5e6c92d0d190646fb9f1056741a229980089",
+        "rev": "08b9151ed40350725eb40b1fe96b0b86304a654b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`d8c28bca`](https://github.com/nix-community/emacs-overlay/commit/d8c28bca43275f1503a029cc73629cd1aa585af7) | `` Updated emacs ``        |
| [`3a2a6fd5`](https://github.com/nix-community/emacs-overlay/commit/3a2a6fd5bbfe5066377afcae6e001698e5dcdf81) | `` Updated melpa ``        |
| [`46294460`](https://github.com/nix-community/emacs-overlay/commit/462944602d2eaa43bf51b958e7f453887e9ba3c1) | `` Updated elpa ``         |
| [`7480617f`](https://github.com/nix-community/emacs-overlay/commit/7480617fd05f6ed921ee879af6948bbbda53f731) | `` Updated flake inputs `` |
| [`caa3f53e`](https://github.com/nix-community/emacs-overlay/commit/caa3f53e460e97f0499f1006de35cf3f898a66d9) | `` Updated emacs ``        |
| [`451efa21`](https://github.com/nix-community/emacs-overlay/commit/451efa21977d503139fa2235de324f99e6d99c05) | `` Updated melpa ``        |
| [`9ff3efce`](https://github.com/nix-community/emacs-overlay/commit/9ff3efceeec20ae2b8c3d42d6057cae2f1f55f36) | `` Updated elpa ``         |
| [`5d0a1093`](https://github.com/nix-community/emacs-overlay/commit/5d0a10938c32f3cb95d1f1f18127948d239c6720) | `` Updated emacs ``        |
| [`d20dbcb7`](https://github.com/nix-community/emacs-overlay/commit/d20dbcb705e84848953212db68d5067d5bb99b05) | `` Updated melpa ``        |
| [`7bfcd741`](https://github.com/nix-community/emacs-overlay/commit/7bfcd7412b5b0c0677d41444ff3c4f5d23ee74d8) | `` Updated elpa ``         |
| [`a8983cd1`](https://github.com/nix-community/emacs-overlay/commit/a8983cd18bcca841368f2c56aae4d7efd0bc049e) | `` Updated melpa ``        |
| [`66655d2a`](https://github.com/nix-community/emacs-overlay/commit/66655d2a1b6faf4a354722bf8f6ef8df80f7524c) | `` Updated elpa ``         |
| [`a5e600b3`](https://github.com/nix-community/emacs-overlay/commit/a5e600b3947b736643670367d8380317420f3b33) | `` Updated melpa ``        |