### PR TITLE
chore(flake/hyprland): `fc0a7af7` -> `b7d71bc0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -664,11 +664,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712070655,
-        "narHash": "sha256-EJpuvOfX6F1Hm7SynhRFy98m0WL62abz7GAZiPalnVo=",
+        "lastModified": 1712189807,
+        "narHash": "sha256-hmEBPDk1GbpPzpa0gLhJ0XJ5rvt+dMddKNQGr9J8XyA=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "fc0a7af7ba5c52f7a70309020f5cb27c19d068e6",
+        "rev": "b7d71bc0e1084bc1a296ae906503709a74fde4d9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                |
| ------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------- |
| [`b7d71bc0`](https://github.com/hyprwm/Hyprland/commit/b7d71bc0e1084bc1a296ae906503709a74fde4d9) | `` keybinds: fix spammy warning ``                                     |
| [`9cf56306`](https://github.com/hyprwm/Hyprland/commit/9cf563065ad5069baea1472b665b56bdcbde3776) | `` layouts: add missing include ``                                     |
| [`36a8ae9b`](https://github.com/hyprwm/Hyprland/commit/36a8ae9bda4c2e150707e7ee0cb13ef3e8841728) | `` input: allow focus to bottom layers on maximized in reserved ``     |
| [`949eb426`](https://github.com/hyprwm/Hyprland/commit/949eb426136aef2690c31acc6389016aa8755ac8) | `` hyprctl: improve help pages (#5385) ``                              |
| [`d605e475`](https://github.com/hyprwm/Hyprland/commit/d605e475118fd66e625a5a23c687cd01a34b302c) | `` renderer: block screen shader on screencopy ``                      |
| [`10146f5e`](https://github.com/hyprwm/Hyprland/commit/10146f5ec50caeae2d835f5f6296137e2ac6f243) | `` core: fix some crash conditions around workspace ptrs in CWindow `` |
| [`d88d5898`](https://github.com/hyprwm/Hyprland/commit/d88d5898807bf6f2462cecfb977b7624dafbf52e) | `` swipe: add events ``                                                |
| [`93915502`](https://github.com/hyprwm/Hyprland/commit/93915502d2677b70382b7cba09620b445f6b832e) | `` blur: block modif only on no new optimize ``                        |
| [`91061a20`](https://github.com/hyprwm/Hyprland/commit/91061a2084f4b3b2f64c955b4d02b8f5c94541be) | `` opengl: fix modif in blur ``                                        |
| [`64964c4e`](https://github.com/hyprwm/Hyprland/commit/64964c4e3beaf890fc9d12eb0e1804373f0fabe6) | `` renderer: render back layer for workspace-less passes ``            |
| [`3981f85e`](https://github.com/hyprwm/Hyprland/commit/3981f85e9487224e8c193160cbd7ae7137a11204) | `` opengl: log framebuffer errors ``                                   |
| [`efdc1af0`](https://github.com/hyprwm/Hyprland/commit/efdc1af04420b59917f8530a20ccfabe658f636a) | `` renderer: some fixes for renderModif ``                             |
| [`347b8390`](https://github.com/hyprwm/Hyprland/commit/347b83903474ab9e95fa9d4ba123f6f78ab38d40) | `` workspaces: add visible flag ``                                     |
| [`fbdaf74a`](https://github.com/hyprwm/Hyprland/commit/fbdaf74a82b38e11a0a6914b3c9f7cb934ac1624) | `` master: fix swapped workspaces (#5397) ``                           |
| [`3965faaf`](https://github.com/hyprwm/Hyprland/commit/3965faafacf18f6e43be91ba326ddfce3948eb3d) | `` master: fix center resizing (#5394) ``                              |
| [`153c8f35`](https://github.com/hyprwm/Hyprland/commit/153c8f35ce5f24b066de916269a94fce1d4f3357) | `` workspace: fix special unnamed workspace rules (#5390) ``           |
| [`ef23ef60`](https://github.com/hyprwm/Hyprland/commit/ef23ef60c5641c5903f9cf40571ead7ad6aba1b9) | `` Workspace/core: Refactor workspace storage (#5380) ``               |