### PR TITLE
chore(flake/nixpkgs-unstable): `5476cea4` -> `d9b45d7e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1266,11 +1266,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1712004559,
-        "narHash": "sha256-87vZKDepF3ZqpinX5zarC5Xb9dwpGgmfcl4Woy26lYA=",
+        "lastModified": 1712178806,
+        "narHash": "sha256-gHlWooOsAkA4sr9fH8c+rgH9uHSiugD+t15KqGNdyto=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5476cea4892cedbf6f8bbebdb93ba07e3f5f5e38",
+        "rev": "d9b45d7e7200adb65aae6c9b2fe01a6202f8882d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                       |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
| [`36cac1a5`](https://github.com/NixOS/nixpkgs/commit/36cac1a5f09457ce7c52c24bfe1dd96f962950ad) | `` raycast: add passthru.updateScript ``                                      |
| [`cb860be4`](https://github.com/NixOS/nixpkgs/commit/cb860be46180e66b7d921e361f5406080a3fcbe9) | `` python312Packages.pyeapi: use nixfmt ``                                    |
| [`2f12e41d`](https://github.com/NixOS/nixpkgs/commit/2f12e41de3d4823823adb3231de94aff823a2730) | `` python312Packages.pyeapi: add patch to replace imp ``                      |
| [`f0324935`](https://github.com/NixOS/nixpkgs/commit/f03249355c36f4f0b6ccf7795877ccb1647aafe7) | `` python311Packages.pyeapi: refactor ``                                      |
| [`732c1337`](https://github.com/NixOS/nixpkgs/commit/732c13373e57970fe4ecf87b60b9f6144e6ec751) | `` python312Packages.netutils: use nixfmt ``                                  |
| [`14036488`](https://github.com/NixOS/nixpkgs/commit/14036488ad68208e1452be67f240eed805677c86) | `` python312Packages.netutils: 1.7.0 -> 1.8.0 ``                              |
| [`9753f67e`](https://github.com/NixOS/nixpkgs/commit/9753f67e5ee087b434a9e64e488639b36bd84af4) | `` prowler: relax azure-storage-blob ``                                       |
| [`a20f661a`](https://github.com/NixOS/nixpkgs/commit/a20f661a2c04c550c234f262e92526b5d0d89b3f) | `` workflows/check-nix-format.yml: pin nixpkgs (fix staging) ``               |
| [`be705806`](https://github.com/NixOS/nixpkgs/commit/be705806042e170fe684dfc0483fe88039a9b80e) | `` python311Packages.msgraph-sdk:refactor ``                                  |
| [`57442397`](https://github.com/NixOS/nixpkgs/commit/57442397aab8adf03d8e6ffd4e13d39bb3c8dff3) | `` python311Packages.msgraph-sdk: use nixfmt ``                               |
| [`fc9d7691`](https://github.com/NixOS/nixpkgs/commit/fc9d76911a46dded5c6d1f6f666cf22f03b44a6b) | `` prowler: refactor ``                                                       |
| [`d4d00d7c`](https://github.com/NixOS/nixpkgs/commit/d4d00d7caa292b2080770b2f7f775acf097cff05) | `` prowler: use nixfmt ``                                                     |
| [`2dd1ea18`](https://github.com/NixOS/nixpkgs/commit/2dd1ea1829772522a529c5ef2f7df68782dcaecd) | `` prowler: 3.12.1 -> 3.13.0 ``                                               |
| [`82f1bfba`](https://github.com/NixOS/nixpkgs/commit/82f1bfba2d41ae260f497af3d96152059cae6ba6) | `` python311Packages.msgraph-sdk: init at 1.1.0 ``                            |
| [`faaf1975`](https://github.com/NixOS/nixpkgs/commit/faaf197579739319a9bb75927718cfc218118389) | `` phpactor: change maintainer & move to by-name ``                           |
| [`8dab54e2`](https://github.com/NixOS/nixpkgs/commit/8dab54e2b3c4d0c946e1a24cad6bf23e552b2b36) | `` nixos/gogs: prefer 'umask' over 'chmod' ``                                 |
| [`2796277f`](https://github.com/NixOS/nixpkgs/commit/2796277f0aea3a0d3dcc4d8e08180905aedfe2e4) | `` maintainers: remove andsild (#301248) ``                                   |
| [`9f4df77d`](https://github.com/NixOS/nixpkgs/commit/9f4df77db0b6a3e9104c88b9441fc0cdd5349470) | `` python312Packages.dploot: use nixfmt ``                                    |
| [`0192867d`](https://github.com/NixOS/nixpkgs/commit/0192867d5332f7871b1bc0b006c81f99ad998ee6) | `` python312Packages.dploot: 2.7.0 -> 2.7.1 ``                                |
| [`a5639cb6`](https://github.com/NixOS/nixpkgs/commit/a5639cb6a870a9e5479b06d24312aba804080698) | `` rmenu: init at 1.2.0 ``                                                    |
| [`1484678e`](https://github.com/NixOS/nixpkgs/commit/1484678e2fffc3abc1689eeacffefca2cbc9a51a) | `` _64gram: fix uppercase letter in pname ``                                  |
| [`f324f30d`](https://github.com/NixOS/nixpkgs/commit/f324f30d7c618992da2d72009ef09bed6b2f85d7) | `` python311Packages.lingva: use nixfmt ``                                    |
| [`9ddf3411`](https://github.com/NixOS/nixpkgs/commit/9ddf34110a1f0f32a2cf7991816825c4c3db6845) | `` python312Pacakges.holidays: use nixfmt ``                                  |
| [`c709c603`](https://github.com/NixOS/nixpkgs/commit/c709c6033367976ad961df084f381d788a41a815) | `` python312Packages.holidays: 0.44 -> 0.46 ``                                |
| [`8611a6c2`](https://github.com/NixOS/nixpkgs/commit/8611a6c2c168607b34fa9081b65f51436f6ba112) | `` python311Packages.lingva: init at 5.0.2 ``                                 |
| [`4a900b9f`](https://github.com/NixOS/nixpkgs/commit/4a900b9fb04d342b12ac13b96d2d74043fe1098e) | `` python311Packages.holidays: refactor ``                                    |
| [`fab46df7`](https://github.com/NixOS/nixpkgs/commit/fab46df7639328c77c575e55bf18a5c54374d4a0) | `` gh-f: package as standalone command ``                                     |
| [`4d86fa53`](https://github.com/NixOS/nixpkgs/commit/4d86fa5350fdaa60924495e1e9931c92ad67eb00) | `` mumble: Add Yuchen He as package maintainer ``                             |
| [`1a1bfe08`](https://github.com/NixOS/nixpkgs/commit/1a1bfe0857813661d51eee402c88b5a4f0189c21) | `` gh-notify: init at 0-unstable-2024-03-19 ``                                |
| [`24af99ca`](https://github.com/NixOS/nixpkgs/commit/24af99ca711e60bdddf54dc84ab722e36607d088) | `` linux-rt_5_15: 5.15.148-rt74 -> 5.15.153-rt75 ``                           |
| [`505b96c9`](https://github.com/NixOS/nixpkgs/commit/505b96c94c6370c929d779bf3b3622f83c876875) | `` linux_6_1: 6.1.83 -> 6.1.84 ``                                             |
| [`26b1b707`](https://github.com/NixOS/nixpkgs/commit/26b1b707e8d40a148876d84c6195fed366adaefa) | `` linux_6_6: 6.6.23 -> 6.6.24 ``                                             |
| [`073a26ea`](https://github.com/NixOS/nixpkgs/commit/073a26ea454df46ae180207c752ef8c6f6e6ea85) | `` linux_6_7: 6.7.11 -> 6.7.12 ``                                             |
| [`b1a006e8`](https://github.com/NixOS/nixpkgs/commit/b1a006e80e93486fed50c51ea5c212dfffd306fe) | `` linux_6_8: 6.8.2 -> 6.8.3 ``                                               |
| [`deef0a9d`](https://github.com/NixOS/nixpkgs/commit/deef0a9d5fc96b7f0e4f9d0506712ba524b05507) | `` vimPlugins.cmp_yanky: Added homepage ``                                    |
| [`b4c207c4`](https://github.com/NixOS/nixpkgs/commit/b4c207c41de6c31e9b303534814c9b652db65b98) | `` vimPlugins.cmp_yanky: init at 2023-11-16 ``                                |
| [`e113e819`](https://github.com/NixOS/nixpkgs/commit/e113e8197a68b0a7500a30b28da4277b6c529ca9) | `` vimPlugins.competitest-nvim: init at 2024-01-23 ``                         |
| [`8d385d2b`](https://github.com/NixOS/nixpkgs/commit/8d385d2b5aec2da14c411f9be5be8f9014e04f57) | `` gopatch: 0.3.0 -> 0.4.0 ``                                                 |
| [`84419346`](https://github.com/NixOS/nixpkgs/commit/84419346a958d1478cfb2ab5691fa926509f7f3a) | `` firefox-bin-unwrapped: 124.0.1 -> 124.0.2 ``                               |
| [`014a603d`](https://github.com/NixOS/nixpkgs/commit/014a603d23c57b6fcd9c6f7a47f8745a07d442a1) | `` firefox-unwrapped: 124.0.1 -> 124.0.2 ``                                   |
| [`3532edfb`](https://github.com/NixOS/nixpkgs/commit/3532edfb2b68b5be70037713cdee6f52358d0ff7) | `` bitcoin: 26.0 -> 26.1 ``                                                   |
| [`bc4802a7`](https://github.com/NixOS/nixpkgs/commit/bc4802a7d67d5f5cb2bf4eee7f51601ecfc3f8c8) | `` kstars: 3.6.9 -> 3.7.0 + fixing build failure ``                           |
| [`853a4402`](https://github.com/NixOS/nixpkgs/commit/853a440235bb8c02488935aa454aaec34976b9a5) | `` neocmakelsp: 0.6.20 -> 0.6.22 ``                                           |
| [`b33c8f42`](https://github.com/NixOS/nixpkgs/commit/b33c8f42af0a58984c76832da577ec2e937b1626) | `` parquet-tools: 0.2.14 -> 0.2.16 ``                                         |
| [`51912b15`](https://github.com/NixOS/nixpkgs/commit/51912b15f834ad07536783f4eea62fb50341d0f8) | `` parquet-tools: support Moto 5.x ``                                         |
| [`bb7d4890`](https://github.com/NixOS/nixpkgs/commit/bb7d48902891e8e9b2081ad0178f836258ab1b87) | `` python312Packages.reptor: 0.16 -> 0.17 ``                                  |
| [`0eed0f13`](https://github.com/NixOS/nixpkgs/commit/0eed0f1309446e65bdedb3495a16befe06b926ba) | `` libvirt: Use valid runstatedir for Darwin ``                               |
| [`f3a9c375`](https://github.com/NixOS/nixpkgs/commit/f3a9c375cc9a550fd5b8160542da629cc2a63b66) | `` epub-thumbnailer: 0-unstable-2024-03-16 -> 0-unstable-2024-03-26 ``        |
| [`1597810a`](https://github.com/NixOS/nixpkgs/commit/1597810a9ea03ba8407f1f45ae70cbbe0642970f) | `` st: remove andsild as maintainer (#301201) ``                              |
| [`8352227f`](https://github.com/NixOS/nixpkgs/commit/8352227f58e76cf53262633cda6b06924a4c86f6) | `` python311Packages.oslo-log: 5.5.0 -> 5.5.1 ``                              |
| [`912d84a6`](https://github.com/NixOS/nixpkgs/commit/912d84a6d84aaab59bf5e4da4050abea6a7be00b) | `` makeFontsConf: refactor for readibility (#299220) ``                       |
| [`cd467b60`](https://github.com/NixOS/nixpkgs/commit/cd467b6063fd8d16dd0e2912dc2f30c9cc5e5c3d) | `` rwpspread: 0.2.4 -> 0.2.5 ``                                               |
| [`30edf658`](https://github.com/NixOS/nixpkgs/commit/30edf65874e2e87871afdd0f1c37263fe8c3acf2) | `` risor: 1.5.1 -> 1.5.2 ``                                                   |
| [`b1288490`](https://github.com/NixOS/nixpkgs/commit/b1288490f7ca908825002b8983a8e884d31387b5) | `` ddns-go: 6.3.0 -> 6.3.1 ``                                                 |
| [`ffa73a66`](https://github.com/NixOS/nixpkgs/commit/ffa73a6608ed1b218b030d537b26c57c3edd398d) | `` phpactor: 2023.12.03.0 -> 2024.03.09.0 ``                                  |
| [`7ab1a0dd`](https://github.com/NixOS/nixpkgs/commit/7ab1a0dd456218b8ed5322e0d079354fd4c3d494) | `` vscode-extensions.hbenl.vscode-test-explorer: init at 2.21.1 ``            |
| [`0d7427ea`](https://github.com/NixOS/nixpkgs/commit/0d7427ea73375adabcff66a895fd50863ccdfcc7) | `` python312Packages.google-ai-generativelanguage: use nixfmt ``              |
| [`f060f646`](https://github.com/NixOS/nixpkgs/commit/f060f64619f304dc42cb35cc21c7f73495ccdd9f) | `` python312Packages.google-ai-generativelanguage: 0.6.0 -> 0.6.1 ``          |
| [`3d286c09`](https://github.com/NixOS/nixpkgs/commit/3d286c09f074c8d25955d2f4b48619152c5bd93c) | `` python312Packages.tabcmd: use nixfmt ``                                    |
| [`e774c5f8`](https://github.com/NixOS/nixpkgs/commit/e774c5f8b84bc3adb2aea239ca1a370b9bd534bb) | `` python312Packages.tabcmd: refactor ``                                      |
| [`eb903959`](https://github.com/NixOS/nixpkgs/commit/eb903959af7fb6b1ce9f91cb59f1cb3934e3986a) | `` kubeshark: 52.1.77 -> 52.2.1 ``                                            |
| [`01cf5df0`](https://github.com/NixOS/nixpkgs/commit/01cf5df08191d13ac08567d3b0468179e0fafff6) | `` python312Packages.types-requests:: use nixfmt ``                           |
| [`b245e3ef`](https://github.com/NixOS/nixpkgs/commit/b245e3efce3546364803585689858c8346f7c9f0) | `` python312Packages.types-requests: refactor ``                              |
| [`b64bb811`](https://github.com/NixOS/nixpkgs/commit/b64bb81129608fad78cd65bc95b723636890ce41) | `` bambu-studio: move LICENSE.txt ``                                          |
| [`553ea1aa`](https://github.com/NixOS/nixpkgs/commit/553ea1aaedae325b4b33899a6f45901148012405) | `` python312Packages.types-requests: 2.31.0.20240311 -> 2.31.0.20240403 ``    |
| [`c0ce798d`](https://github.com/NixOS/nixpkgs/commit/c0ce798d8114d958b622f32055f4582e85c88855) | `` python3Packages.numba: fix: make free again ``                             |
| [`ee457b8b`](https://github.com/NixOS/nixpkgs/commit/ee457b8b080168886039694a61ce098750fb1b79) | `` Avoid top-level `with ...;` in pkgs/development/lua-modules/aliases.nix `` |
| [`0e83dd50`](https://github.com/NixOS/nixpkgs/commit/0e83dd50eac2964453c5ec3c85c61c820fe84108) | `` deepin.deepin-picker: 6.0.0 -> 6.0.1 ``                                    |
| [`1616ab21`](https://github.com/NixOS/nixpkgs/commit/1616ab211b88b5a4f0cea12d3ba2ef34d8d4701c) | `` diffutils: disable tests in diffutils on riscv64 ``                        |
| [`0af71da0`](https://github.com/NixOS/nixpkgs/commit/0af71da007a45577f1cdf57c21bfee059eda9fe4) | `` python311Packages.cle: 9.2.96 -> 9.2.97 ``                                 |
| [`4a755e8f`](https://github.com/NixOS/nixpkgs/commit/4a755e8f7ffa1a4473adabe89a3f8bc6544233bb) | `` python311Packages.angr: 9.2.96 -> 9.2.97 ``                                |
| [`51a3f306`](https://github.com/NixOS/nixpkgs/commit/51a3f306e4959c7f9e714d35fb0ae4410411f470) | `` python311Packages.claripy: 9.2.96 -> 9.2.97 ``                             |
| [`8ff983d7`](https://github.com/NixOS/nixpkgs/commit/8ff983d740235a49b6a254ff4a4f6eece2b19f83) | `` python311Packages.pyvex: 9.2.96 -> 9.2.97 ``                               |
| [`7bb71960`](https://github.com/NixOS/nixpkgs/commit/7bb7196075e60352f07d3306f3faae2d5ebf9bc6) | `` python311Packages.ailment: 9.2.96 -> 9.2.97 ``                             |
| [`8d780366`](https://github.com/NixOS/nixpkgs/commit/8d780366e589bf82ceed58fbcbeee015b7d3cc9c) | `` python311Packages.archinfo: 9.2.96 -> 9.2.97 ``                            |
| [`39ecf67d`](https://github.com/NixOS/nixpkgs/commit/39ecf67d17e6508ab532831efdab6a630bb4d093) | `` python311Packages.angr: add optional-dependencies ``                       |
| [`fcae6f8d`](https://github.com/NixOS/nixpkgs/commit/fcae6f8db8315a87e5dd4a3d817b98d56c020529) | `` mystmd: 1.1.48 -> 1.1.50 ``                                                |
| [`2275d54d`](https://github.com/NixOS/nixpkgs/commit/2275d54d337d89724276ede52167530d404545f0) | `` ripes: 2.2.6-unstable-2024-03-03 -> 2.2.6-unstable-2024-04-02 ``           |
| [`fe01395d`](https://github.com/NixOS/nixpkgs/commit/fe01395de21d2e28fbaa9933cfbdc453643c76ea) | `` qolibri: 2.1.4 -> 2.1.5-unstable-2024-03-17 ``                             |
| [`c8497682`](https://github.com/NixOS/nixpkgs/commit/c8497682546f35861bbfc89453b59c247b5ddaf3) | `` xgboost: use pkgs.autoAddDriverRunpath ``                                  |
| [`eef06fe9`](https://github.com/NixOS/nixpkgs/commit/eef06fe93ea548dc7b84e8bafa9399fbcbbe2ce7) | `` foot: 1.16.2 -> 1.17.0 ``                                                  |
| [`865f976d`](https://github.com/NixOS/nixpkgs/commit/865f976ddd33b90c47e72299030f492cc746e2e5) | `` nixos/v2raya: fix nftables support ``                                      |
| [`efd45198`](https://github.com/NixOS/nixpkgs/commit/efd4519818ebc4bb24fcdf907a2ff1f2a10b15be) | `` python311Packages.peaqevcore: refactor ``                                  |
| [`b213b627`](https://github.com/NixOS/nixpkgs/commit/b213b627a9c9db6a9610566ffb03eae08837b7da) | `` vulnix: 1.10.1 -> 1.10.1-unstable-2024-04-02 ``                            |
| [`b385c0ea`](https://github.com/NixOS/nixpkgs/commit/b385c0ea8ead5613694606de0755e39b051ae00f) | `` gotestwaf: 0.4.17 -> 0.4.18 ``                                             |
| [`768747ee`](https://github.com/NixOS/nixpkgs/commit/768747ee572409e107be01daa1b266866fb825f0) | `` rain: 1.8.2 -> 1.8.3 ``                                                    |
| [`381e517d`](https://github.com/NixOS/nixpkgs/commit/381e517d36e45b9097b0f46b390821c5ef7deb3d) | `` python312Packages.boto3-stubs: 1.34.74 -> 1.34.76 ``                       |
| [`8a0bef62`](https://github.com/NixOS/nixpkgs/commit/8a0bef6221295f723cbccdac4535a477ec5df57a) | `` python312Packages.edk2-pytool-library: refactor ``                         |
| [`45b46c84`](https://github.com/NixOS/nixpkgs/commit/45b46c84c44adca69ee596c552760691c6a4d0bb) | `` python312Packages.google-cloud-firestore: refactor ``                      |
| [`f191c7b0`](https://github.com/NixOS/nixpkgs/commit/f191c7b0d4df45febde1785074c6303ec4ab96d4) | `` python312Packages.mkdocstrings: refactor ``                                |
| [`51152898`](https://github.com/NixOS/nixpkgs/commit/51152898b908c958c0d2481a5ddf784edb3b21a0) | `` python312Packages.tencentcloud-sdk-python: 3.0.1121 -> 3.0.1122 ``         |