### PR TITLE
chore(flake/emacs-overlay): `1c772b55` -> `5d141af6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712367860,
-        "narHash": "sha256-OqabNuHSXMYeugAwBIrJ6uNW9HXI02gC3SaarhLDCsw=",
+        "lastModified": 1712451792,
+        "narHash": "sha256-vJKBs9YdwyoSFNynYZkTW1SwSRJ99tSotjX4JtSGwYU=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1c772b55c22f91a1b26c4318671deb1788628f24",
+        "rev": "5d141af64a57b0cfdf12a4c4156ecd44ae802057",
         "type": "github"
       },
       "original": {
@@ -1260,11 +1260,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1712168706,
-        "narHash": "sha256-XP24tOobf6GGElMd0ux90FEBalUtw6NkBSVh/RlA6ik=",
+        "lastModified": 1712310679,
+        "narHash": "sha256-XgC/a/giEeNkhme/AV1ToipoZ/IVm1MV2ntiK4Tm+pw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1487bdea619e4a7a53a4590c475deabb5a9d1bfb",
+        "rev": "72da83d9515b43550436891f538ff41d68eecc7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`5d141af6`](https://github.com/nix-community/emacs-overlay/commit/5d141af64a57b0cfdf12a4c4156ecd44ae802057) | `` Updated elpa ``         |
| [`57048e83`](https://github.com/nix-community/emacs-overlay/commit/57048e832be022087f098c998f9b4d3481a1ccf5) | `` Updated emacs ``        |
| [`d6438783`](https://github.com/nix-community/emacs-overlay/commit/d6438783e19983886e460462b2f114a34b7a6d74) | `` Updated melpa ``        |
| [`015a0575`](https://github.com/nix-community/emacs-overlay/commit/015a05757ddf4c5d0f10cd628d78cac23ca8110c) | `` Updated elpa ``         |
| [`b09fd02f`](https://github.com/nix-community/emacs-overlay/commit/b09fd02f2e2cd256965a8f92d4f94b0de3074b68) | `` Updated flake inputs `` |
| [`149186b1`](https://github.com/nix-community/emacs-overlay/commit/149186b1156c0da8d9624bde981d2e5c02aa1376) | `` Updated emacs ``        |
| [`71596f24`](https://github.com/nix-community/emacs-overlay/commit/71596f248d13b1d0f5a1b22851c4cb56bf79f9a3) | `` Updated melpa ``        |