### PR TITLE
chore(flake/hyprland): `24734fbf` -> `9f1604e4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -385,7 +385,7 @@
     },
     "flake-utils_11": {
       "inputs": {
-        "systems": "systems_7"
+        "systems": "systems_6"
       },
       "locked": {
         "lastModified": 1710146030,
@@ -451,7 +451,7 @@
     },
     "flake-utils_5": {
       "inputs": {
-        "systems": "systems_6"
+        "systems": "systems_5"
       },
       "locked": {
         "lastModified": 1710146030,
@@ -645,7 +645,10 @@
     },
     "hyprcursor": {
       "inputs": {
-        "hyprlang": "hyprlang",
+        "hyprlang": [
+          "hyprland",
+          "hyprlang"
+        ],
         "nixpkgs": [
           "hyprland",
           "nixpkgs"
@@ -656,11 +659,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711466786,
-        "narHash": "sha256-sArxGyUBiCA1in+q6t0QqT+ZJiZ1PyBp7cNPKLmREM0=",
+        "lastModified": 1712339458,
+        "narHash": "sha256-j8pv3tL2EFLGuvFoO64dHWD8YzNvD77hRb4EEx5ADgE=",
         "owner": "hyprwm",
         "repo": "hyprcursor",
-        "rev": "d3876f34779cc03ee51e4aafc0d00a4f187c7544",
+        "rev": "981b6617822dadc40246a6c70194d02dfc12e4c6",
         "type": "github"
       },
       "original": {
@@ -673,22 +676,22 @@
       "inputs": {
         "hyprcursor": "hyprcursor",
         "hyprland-protocols": "hyprland-protocols",
-        "hyprlang": "hyprlang_2",
+        "hyprlang": "hyprlang",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_5",
+        "systems": "systems_4",
         "wlroots": "wlroots",
         "xdph": [
           "xdph"
         ]
       },
       "locked": {
-        "lastModified": 1712369360,
-        "narHash": "sha256-4GOmo5J10j8bAhG3T4IvLUCmx7tx83VRNDPHFx1uRBI=",
+        "lastModified": 1712448441,
+        "narHash": "sha256-dQ+5CYpy/dbpX0hvIFBYF/FDjWal4wAYpTHfUzGoDRg=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "24734fbf1d341a725d3ed1192b9bf5f55828208f",
+        "rev": "9f1604e4b0afec40cfa9bc095d6613a7f749b2c1",
         "type": "github"
       },
       "original": {
@@ -751,17 +754,19 @@
       "inputs": {
         "nixpkgs": [
           "hyprland",
-          "hyprcursor",
           "nixpkgs"
         ],
-        "systems": "systems_4"
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
       },
       "locked": {
-        "lastModified": 1709914708,
-        "narHash": "sha256-bR4o3mynoTa1Wi4ZTjbnsZ6iqVcPGriXp56bZh5UFTk=",
+        "lastModified": 1711671891,
+        "narHash": "sha256-C/Wwsy/RLxHP1axFFl+AnwJRWfd8gxDKKoa8nt8Qk3c=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "a685493fdbeec01ca8ccdf1f3655c044a8ce2fe2",
+        "rev": "c1402612146ba06606ebf64963a02bc1efe11e74",
         "type": "github"
       },
       "original": {
@@ -773,35 +778,10 @@
     "hyprlang_2": {
       "inputs": {
         "nixpkgs": [
-          "hyprland",
-          "nixpkgs"
-        ],
-        "systems": [
-          "hyprland",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1711250455,
-        "narHash": "sha256-LSq1ZsTpeD7xsqvlsepDEelWRDtAhqwetp6PusHXJRo=",
-        "owner": "hyprwm",
-        "repo": "hyprlang",
-        "rev": "b3e430f81f3364c5dd1a3cc9995706a4799eb3fa",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprlang",
-        "type": "github"
-      }
-    },
-    "hyprlang_3": {
-      "inputs": {
-        "nixpkgs": [
           "xdph",
           "nixpkgs"
         ],
-        "systems": "systems_8"
+        "systems": "systems_7"
       },
       "locked": {
         "lastModified": 1708681732,
@@ -1750,16 +1730,16 @@
     },
     "systems_5": {
       "locked": {
-        "lastModified": 1689347949,
-        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
-        "repo": "default-linux",
-        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "default-linux",
+        "repo": "default",
         "type": "github"
       }
     },
@@ -1780,21 +1760,6 @@
     },
     "systems_7": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_8": {
-      "locked": {
         "lastModified": 1689347949,
         "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
         "owner": "nix-systems",
@@ -1808,7 +1773,7 @@
         "type": "github"
       }
     },
-    "systems_9": {
+    "systems_8": {
       "locked": {
         "lastModified": 1689347949,
         "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
@@ -1865,11 +1830,11 @@
     "xdph": {
       "inputs": {
         "hyprland-protocols": "hyprland-protocols_2",
-        "hyprlang": "hyprlang_3",
+        "hyprlang": "hyprlang_2",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_9"
+        "systems": "systems_8"
       },
       "locked": {
         "lastModified": 1709299639,


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                                                   |
| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
| [`9f1604e4`](https://github.com/hyprwm/Hyprland/commit/9f1604e4b0afec40cfa9bc095d6613a7f749b2c1) | `` input: Dont set active monitor when simulating mouse movement (#5465) ``                               |
| [`e80bccad`](https://github.com/hyprwm/Hyprland/commit/e80bccad513d0761cbb83038478fce72ddc51c01) | `` master: fix workspace orientation not being restored after workspace rule no longer applies (#5463) `` |
| [`ff114cf6`](https://github.com/hyprwm/Hyprland/commit/ff114cf6f9f45b2ccc5eed95a95738b7c1a61003) | `` input: fix focus on maximized bg surfaces ``                                                           |
| [`d846e828`](https://github.com/hyprwm/Hyprland/commit/d846e82832e53e1ec0b9b71fee3ca530601e17c2) | `` makefile: add patch option to make asan ``                                                             |
| [`fa79aace`](https://github.com/hyprwm/Hyprland/commit/fa79aacea30eff5c4e3e094ceb98c316d53caefa) | `` constraint: fix possible uaf on double destruction ``                                                  |
| [`265c7924`](https://github.com/hyprwm/Hyprland/commit/265c7924d85e2ad5f2ff0e9f59c03403028eaef4) | `` flake.nix: add hyprcursor follows  (#5435) ``                                                          |
| [`3d64b0e9`](https://github.com/hyprwm/Hyprland/commit/3d64b0e9f08151786d354c0ca45c5c6016a16836) | `` flake.lock: update ``                                                                                  |
| [`04d067d7`](https://github.com/hyprwm/Hyprland/commit/04d067d78b0074ff0000b4ce2d8741881b1ace25) | `` IME: fix race condition on closing window (#5455) ``                                                   |
| [`1596e2d1`](https://github.com/hyprwm/Hyprland/commit/1596e2d1f7db76c4a367a6beb814d79db019d8d2) | `` workspacerules: add back on-created-empty functionality (#5452) ``                                     |
| [`6cea710a`](https://github.com/hyprwm/Hyprland/commit/6cea710ac8e966366763b9609895dcef7fdb5bcb) | `` scripts: switch to branch --show-current for branch in generateVersion ``                              |
| [`f081a430`](https://github.com/hyprwm/Hyprland/commit/f081a4300fc99b0bcd821a1b391364443db424cf) | `` input: fixup background layer checking on maximized ``                                                 |
| [`159444c4`](https://github.com/hyprwm/Hyprland/commit/159444c45b6fa87d250cf694233ce0213a4585bd) | `` compositor: fix ghost fadingOut windows remaining after cleanup ``                                     |
| [`f8c22916`](https://github.com/hyprwm/Hyprland/commit/f8c22916ab369e13f027b717fa1e505337ec8fd4) | `` compositor: remove windows from fadingOut properly ``                                                  |