### PR TITLE
chore(flake/home-manager): `18f89ef7` -> `31357486`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712730572,
-        "narHash": "sha256-rAVvdP77rEmgobvSgybqPAcHefv5dCXPH/ge6Ds+JtU=",
+        "lastModified": 1712759992,
+        "narHash": "sha256-2APpO3ZW4idlgtlb8hB04u/rmIcKA8O7pYqxF66xbNY=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "18f89ef74f0d48635488ccd6a5e30dc9d48a3a87",
+        "rev": "31357486b0ef6f4e161e002b6893eeb4fafc3ca9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                             |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`31357486`](https://github.com/nix-community/home-manager/commit/31357486b0ef6f4e161e002b6893eeb4fafc3ca9) | `` fish: use the subcommand style for the status command (#4584) `` |