### PR TITLE
chore(flake/emacs-overlay): `1bff8265` -> `705fbd14`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712740132,
-        "narHash": "sha256-8N5QS7MS94oJHo4EjlW+cR0Y8tP2/UpVYMAn89XFJf8=",
+        "lastModified": 1712855032,
+        "narHash": "sha256-FrlJ7F6568TIj4uTmP2vXhF5cOEsY+w3voxMNMwvchI=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "1bff826527840aefa0234d7a381a02fd74ad6868",
+        "rev": "705fbd143cc7ee5899525003feda2267e23b4bd6",
         "type": "github"
       },
       "original": {
@@ -1255,11 +1255,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1712588820,
-        "narHash": "sha256-y31s5idk3jMJMAVE4Ud9AdI7HT3CgTAeMTJ0StqKN7Y=",
+        "lastModified": 1712741485,
+        "narHash": "sha256-bCs0+MSTra80oXAsnM6Oq62WsirOIaijQ/BbUY59tR4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d272ca50d1f7424fbfcd1e6f1c9e01d92f6da167",
+        "rev": "b2cf36f43f9ef2ded5711b30b1f393ac423d8f72",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`705fbd14`](https://github.com/nix-community/emacs-overlay/commit/705fbd143cc7ee5899525003feda2267e23b4bd6) | `` Updated emacs ``        |
| [`0d45d704`](https://github.com/nix-community/emacs-overlay/commit/0d45d7041fa75d5312d3cf4abd4be2cd66533796) | `` Updated melpa ``        |
| [`1e87f115`](https://github.com/nix-community/emacs-overlay/commit/1e87f11534fab2ae74551cb394e0916d5ab47fa6) | `` Updated elpa ``         |
| [`50620dc0`](https://github.com/nix-community/emacs-overlay/commit/50620dc0fe98d1b97032e0dae8ffd47329297167) | `` Updated nongnu ``       |
| [`a69a3e1a`](https://github.com/nix-community/emacs-overlay/commit/a69a3e1ab68f4442e52d8b69da86f2df4fff2679) | `` Updated flake inputs `` |
| [`9b79fd13`](https://github.com/nix-community/emacs-overlay/commit/9b79fd139ff55062e46191bd5dd42fcb79696328) | `` Updated emacs ``        |
| [`0a2c51c5`](https://github.com/nix-community/emacs-overlay/commit/0a2c51c571bf98fcb8b219bcd0b26a942c3ae7de) | `` Updated melpa ``        |
| [`2b46008a`](https://github.com/nix-community/emacs-overlay/commit/2b46008a2a346141d38fb57a87cb22f9219f75dd) | `` Updated elpa ``         |
| [`d4d9c62d`](https://github.com/nix-community/emacs-overlay/commit/d4d9c62d5e11ad212aee995ad56b8885067179e7) | `` Updated emacs ``        |
| [`5ed94cc2`](https://github.com/nix-community/emacs-overlay/commit/5ed94cc242bd12c516b2f79e73f10a6ecdd78b7b) | `` Updated melpa ``        |
| [`5fe8b6dd`](https://github.com/nix-community/emacs-overlay/commit/5fe8b6ddd77f1536e41a72a1785e2894a79af5bf) | `` Updated elpa ``         |