### PR TITLE
chore(flake/hyprland): `303b9956` -> `b1a94302`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -687,11 +687,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712739000,
-        "narHash": "sha256-nHx8lUK5hiiDlvFOmqwuh3bw9yCw9w5zR7gI2+pZMvk=",
+        "lastModified": 1712877538,
+        "narHash": "sha256-FK4Rhq9mEf8wpS3/K/ueB5Sql2XOeCQX/SzCe/QySNk=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "303b9956b2ae15508b09dffae602550ca17e6539",
+        "rev": "b1a94302897ae559c877471f7d365651bcd24ad4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                  |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
| [`b1a94302`](https://github.com/hyprwm/Hyprland/commit/b1a94302897ae559c877471f7d365651bcd24ad4) | `` inhibitor: always destroy on window unmap ``                          |
| [`e0a7cf5c`](https://github.com/hyprwm/Hyprland/commit/e0a7cf5c3006e9b7acd26551f14ef7b06d5a11ab) | `` master: fix full height when all windows master (#5549) ``            |
| [`185a3b48`](https://github.com/hyprwm/Hyprland/commit/185a3b48814cc4a1afbf32a69792a6161c4038cd) | `` swipe: nuke numbered ``                                               |
| [`47e5b41f`](https://github.com/hyprwm/Hyprland/commit/47e5b41fead236026ff7630689e677e854531c41) | `` renderer: Add dimaround layer rule (#4643) ``                         |
| [`ac0f3411`](https://github.com/hyprwm/Hyprland/commit/ac0f3411c18497a39498b756b711e092512de9e0) | `` macros: fix no pch warning ``                                         |
| [`abc131ec`](https://github.com/hyprwm/Hyprland/commit/abc131ec7b38b6d10e772fde0f764cd1bd2e9446) | `` configmgr: fix header priority ``                                     |
| [`558d1be7`](https://github.com/hyprwm/Hyprland/commit/558d1be7e3c9242b39fe78efe74ada1298112892) | `` hyprpm: Improve Hyprpm Update Performance (#5530) ``                  |
| [`0b2f7a1b`](https://github.com/hyprwm/Hyprland/commit/0b2f7a1b2fc16a1ea8933324ccfd819e41e3dc18) | `` cursor: Fallback to xcursor if failed to render hyprcursor (#5534) `` |
| [`c35fa9ba`](https://github.com/hyprwm/Hyprland/commit/c35fa9bacc960fb37ebac8541eadc2f4696b287c) | `` workspace: update windows when selector match could change (#5533) `` |
| [`b573c201`](https://github.com/hyprwm/Hyprland/commit/b573c2012587a4a4d84a306a157db77bf4c3566e) | `` monitor: add workspace null check to visible flag ``                  |