### PR TITLE
chore(flake/nixpkgs-master): `48f9f5da` -> `d9110b97`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1224,11 +1224,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1712758442,
-        "narHash": "sha256-s2hdNIZvvv46FtUMX9cPHEgD4eWUR3eJ9P94zzBzgFQ=",
+        "lastModified": 1712880699,
+        "narHash": "sha256-zT6iwuO7WBN95q2VWNTyQVU5kEi6Po5SEPM3NUb6p7o=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "48f9f5dabaced3f54a832729b058e0b857626e82",
+        "rev": "d9110b97053f3fd502ea0af486aaa508cd567df1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                          |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
| [`d5514f48`](https://github.com/NixOS/nixpkgs/commit/d5514f487793d06143aaf345fab01304f427e052) | `` python312Packages.httpsig: propagate setuptools ``                            |
| [`26222216`](https://github.com/NixOS/nixpkgs/commit/262222169f97ad43ed7a2c5bc58f1db034b3dcf4) | `` nixos/kubeswitch: init ``                                                     |
| [`e44c60eb`](https://github.com/NixOS/nixpkgs/commit/e44c60ebad02e3217ca7e7db08f0ea90b4829889) | `` kubeswitch: fix package ``                                                    |
| [`b64d76aa`](https://github.com/NixOS/nixpkgs/commit/b64d76aa6cc182aeb7fb90fdfc1d2d875a5d9483) | `` vscode-extensions.asvetliakov.vscode-neovim: 1.7.1 -> 1.8.1 ``                |
| [`3a8eaa54`](https://github.com/NixOS/nixpkgs/commit/3a8eaa5405374eca242c44efa62617046536a0b8) | `` bitbake-language-server: 0.0.8 -> 0.0.14 ``                                   |
| [`d0b73a35`](https://github.com/NixOS/nixpkgs/commit/d0b73a3518fc301f2774b9bc6cb7a054b6720bad) | `` uuu: 1.5.141 -> 1.5.179 ``                                                    |
| [`4b3c66aa`](https://github.com/NixOS/nixpkgs/commit/4b3c66aa1e4d604e362c7013777d213aa27e1deb) | `` python311Packages.snakemake-interface-common: 1.17.1 -> 1.17.2 ``             |
| [`1a963976`](https://github.com/NixOS/nixpkgs/commit/1a96397699e9a523736e0e603adcfb62cb6d2e1d) | `` python312Packages.fyta-cli: 0.3.5 -> 0.4.0 ``                                 |
| [`fc019034`](https://github.com/NixOS/nixpkgs/commit/fc019034528c5150e919a6c72799b805575b0618) | `` prusa-slicer: 2.7.3 -> 2.7.4 ``                                               |
| [`8d935aae`](https://github.com/NixOS/nixpkgs/commit/8d935aae937375cbb2e882550a71317f83214982) | `` lighttpd: enable debug info ``                                                |
| [`d6a67aa6`](https://github.com/NixOS/nixpkgs/commit/d6a67aa67827b624bc858e0b3b4bab8311a612c5) | `` avrdude: add libserialport dependency ``                                      |
| [`22865a32`](https://github.com/NixOS/nixpkgs/commit/22865a32c655520718d11614aaf7019783d8a3a1) | `` asahi-wifisync: init at 0.2.0 ``                                              |
| [`5838eddf`](https://github.com/NixOS/nixpkgs/commit/5838eddf77e2121717db4292f0620d76667f8660) | `` asahi-btsync: init at 0.2.0 ``                                                |
| [`5d5d9bb3`](https://github.com/NixOS/nixpkgs/commit/5d5d9bb3db5483a5649d53084726768f6d4fff49) | `` asahi-bless: init at 0.3.0 ``                                                 |
| [`9db50798`](https://github.com/NixOS/nixpkgs/commit/9db507982c26f50152d073cc818149de3cb42994) | `` asahi-nvram: init at 0.2.1 ``                                                 |
| [`45ce960b`](https://github.com/NixOS/nixpkgs/commit/45ce960bf8332536fa02dd32afc23fb1f14f1aec) | `` cgit,cgit-pink: enable debug info ``                                          |
| [`383472d1`](https://github.com/NixOS/nixpkgs/commit/383472d1f4866021a4a57e99930ffda7c20c7a9f) | `` python311Packages.ping3: 4.0.7 -> 4.0.8 ``                                    |
| [`3eff0586`](https://github.com/NixOS/nixpkgs/commit/3eff05864b29a6b559d3fedbc4c6b906218f7354) | `` python311Packages.azure-eventhub: 5.11.6 -> 5.11.7 ``                         |
| [`398e3c2c`](https://github.com/NixOS/nixpkgs/commit/398e3c2cc0a6536beeb5ead64a2fb83c5305956c) | `` git-repo: 2.39 -> 2.45 ``                                                     |
| [`410b95ef`](https://github.com/NixOS/nixpkgs/commit/410b95ef0ef0e7021173bff950fe7ba17695a193) | `` electron-source.electron_29: 29.2.0 -> 29.3.0 ``                              |
| [`b8d3915d`](https://github.com/NixOS/nixpkgs/commit/b8d3915d9fed3ecc39cee8490a78b730773ec6b9) | `` electron-source.electron_28: 28.2.10 -> 28.3.0 ``                             |
| [`3e042060`](https://github.com/NixOS/nixpkgs/commit/3e0420605d3f173851fe2710f7b8df62b7d3b099) | `` electron-source.electron_27: 27.3.9 -> 27.3.10 ``                             |
| [`0b361dd8`](https://github.com/NixOS/nixpkgs/commit/0b361dd84dfcd9026eaad5092826ba8afd9eca6d) | `` oelint-adv: 4.4.5 -> 5.1.2 ``                                                 |
| [`ca45605a`](https://github.com/NixOS/nixpkgs/commit/ca45605a5719d763f3129d6f411b4eb10fe57e34) | `` Revert "yaru-theme: 23.10.0 -> 24.04.0" ``                                    |
| [`0ba23300`](https://github.com/NixOS/nixpkgs/commit/0ba23300dec970d3226841a0002e1dd0a4320430) | `` nixos/movim: precompress static files ``                                      |
| [`64b11058`](https://github.com/NixOS/nixpkgs/commit/64b110589cf76e4eaa6ff1c79b162418cccae3a4) | `` movim: minifyStaticFiles prop ``                                              |
| [`fcc7c53e`](https://github.com/NixOS/nixpkgs/commit/fcc7c53e9c833a9ee40b790c62bcbc0543170d50) | `` nixos/movim: add service module ``                                            |
| [`ee952c11`](https://github.com/NixOS/nixpkgs/commit/ee952c112c0fe0b32a6341be3eb77b8bda0fe012) | `` python312Packages.yolink-api: 0.4.2 -> 0.4.3 ``                               |
| [`c03ba17b`](https://github.com/NixOS/nixpkgs/commit/c03ba17b3bcabaabaa4e2dcfb5c299a2641ff563) | `` python311Packages.graphene-django: 3.2.0 -> 3.2.1 ``                          |
| [`dcb8f305`](https://github.com/NixOS/nixpkgs/commit/dcb8f305ff29a371a8a8c86a4991453727623452) | `` vscode-extensions.coder.coder-remote: 0.1.18 -> 0.1.36 ``                     |
| [`19fb422a`](https://github.com/NixOS/nixpkgs/commit/19fb422a607850a3782fa4b55a8b46e294d8ffc5) | `` xfce.xfce4-i3-workspaces-plugin: 1.4.1 -> 1.4.2 ``                            |
| [`130b5db6`](https://github.com/NixOS/nixpkgs/commit/130b5db625c248c91d8b8f22b838fad1cbd26b45) | `` xfce.xfce4-i3-workspaces-plugin: Clean up ``                                  |
| [`5010a92f`](https://github.com/NixOS/nixpkgs/commit/5010a92fa992792f4afc9d7a47d5d0e669ffecd1) | `` eigenmath: unstable-2024-03-20 -> unstable-2024-04-08 ``                      |
| [`e67c7383`](https://github.com/NixOS/nixpkgs/commit/e67c738314a99339990b9efbc9a2df4409a1f83e) | `` doc: update fetchzip docs, add examples and follow conventions ``             |
| [`0dd8c95d`](https://github.com/NixOS/nixpkgs/commit/0dd8c95dcd706a05d1269744a9554bc53f2e4530) | `` ffmpeg: qr code support ``                                                    |
| [`08d90fa6`](https://github.com/NixOS/nixpkgs/commit/08d90fa65effbc09446b1d26ef4b7d4570582bb1) | `` ffmpeg: add MPEG-5 EVC en/decoding ``                                         |
| [`3189bf16`](https://github.com/NixOS/nixpkgs/commit/3189bf160b6db3b9ceafe47f73df516d73a44153) | `` xeve: init at 0.4.3 ``                                                        |
| [`1307c7f2`](https://github.com/NixOS/nixpkgs/commit/1307c7f27eb88095323c3f246b51a3fdbd9dfcde) | `` xevd: init at 0.4.1 ``                                                        |
| [`9072edec`](https://github.com/NixOS/nixpkgs/commit/9072edec01ee65b67bf0cdc4a52f055ef1acf1e4) | `` ungoogled-chromium: 123.0.6312.105-1 -> 123.0.6312.122-1 ``                   |
| [`b24e22d0`](https://github.com/NixOS/nixpkgs/commit/b24e22d061a801afc7ef466bb202927cc6b080c6) | `` chromium: 123.0.6312.105 -> 123.0.6312.122 ``                                 |
| [`3c4f4f2a`](https://github.com/NixOS/nixpkgs/commit/3c4f4f2afd4b51957cb506dc502f564efe2b5fff) | `` chromedriver: 123.0.6312.86 -> 123.0.6312.122 ``                              |
| [`0361b39a`](https://github.com/NixOS/nixpkgs/commit/0361b39aaab2b98465f8fb9f5657cf213fd2b692) | `` ansible_2_14: drop ``                                                         |
| [`7ab6f241`](https://github.com/NixOS/nixpkgs/commit/7ab6f241e96e0a251063627464de15e501322e6b) | `` python312Packages.dirigera: 1.1.0 -> 1.1.1 ``                                 |
| [`c7bfada2`](https://github.com/NixOS/nixpkgs/commit/c7bfada2c41a2da119d5184d0dab584e0ceac395) | `` jrnl: format with nixfmt ``                                                   |
| [`fc41b1ab`](https://github.com/NixOS/nixpkgs/commit/fc41b1abe251ec00151bb6301b5390e8e6b62f77) | `` jrnl: patch for to support pytest_bdd 7.1.2 and later ``                      |
| [`533c6e18`](https://github.com/NixOS/nixpkgs/commit/533c6e184c8266c8c452e5be71c0c54deec2f228) | `` jrnl: refactor ``                                                             |
| [`dcd42c58`](https://github.com/NixOS/nixpkgs/commit/dcd42c58966511214a43ccc9d0d64d91f6cfef13) | `` elasticsearch-curator: format with nixfmt ``                                  |
| [`1d5c336a`](https://github.com/NixOS/nixpkgs/commit/1d5c336aa68fae0ba63ec006ffc62ba29a0f2a4c) | `` elasticsearch-curator: 8.0.12 -> 8.0.15 ``                                    |
| [`4f519945`](https://github.com/NixOS/nixpkgs/commit/4f51994509b626f68914c63d6b401267894ef245) | `` python312Packages.es-client: refactor ``                                      |
| [`f65eeb51`](https://github.com/NixOS/nixpkgs/commit/f65eeb51bee9eba6c019d3649deeacb2613061a7) | `` python312Packages.es-client: 8.12.8 -> 8.13.1 ``                              |
| [`b99c9b71`](https://github.com/NixOS/nixpkgs/commit/b99c9b718844fec4d6fe47648c87deb1845e23ea) | `` python312Packages.elastic-apm: format with nixfmt ``                          |
| [`e57658dc`](https://github.com/NixOS/nixpkgs/commit/e57658dced028946a8275fcd0f00034faeebcc5d) | `` python312Packages.elastic-apm: 6.21.3 -> 6.22.0 ``                            |
| [`7db70a7b`](https://github.com/NixOS/nixpkgs/commit/7db70a7b687d12a160a22912b5c8cade8256d63b) | `` python312Packages.pytest-bdd: format with nixfmt ``                           |
| [`6cde10ba`](https://github.com/NixOS/nixpkgs/commit/6cde10ba6bf8fcd9fc8a0e1e929bce73a6f9aec4) | `` python312Packages.pytest-bdd: 6.1.1 -> 7.1.2 ``                               |
| [`15ed0d21`](https://github.com/NixOS/nixpkgs/commit/15ed0d212574c950e94e56f7ad7ec3c33ee8f772) | `` Revert "fzf: remove fzf-share helper" ``                                      |
| [`104f24e0`](https://github.com/NixOS/nixpkgs/commit/104f24e0b99b6d340c313e8f7c963cb8e9f8ae3a) | `` Revert "doc: replace fzf-share mention with sk-share from Skim package" ``    |
| [`1fb10f50`](https://github.com/NixOS/nixpkgs/commit/1fb10f5017cfe9ee0c97e5087310c893cfa98103) | `` nixos/fzf: bring back keybindings and completion option removed in #298692 `` |
| [`d40167f9`](https://github.com/NixOS/nixpkgs/commit/d40167f9a52192e4e698bd9ee04d6c5bd335e2df) | `` team-list: join jitsi team ``                                                 |
| [`9bcfb99d`](https://github.com/NixOS/nixpkgs/commit/9bcfb99d6b86f5373d313d7b726a3c782d198e70) | `` git-mit: 5.12.191 -> 5.12.194 ``                                              |
| [`03a1d58c`](https://github.com/NixOS/nixpkgs/commit/03a1d58cbf567f4481f6c32091797a5236e6bc51) | `` faas-cli: 0.16.23 -> 0.16.25 ``                                               |
| [`ba169b48`](https://github.com/NixOS/nixpkgs/commit/ba169b48936ebc26f02cde04a00619edc829dba0) | `` python311Packages.sphinxcontrib-confluencebuilder: 2.5.0 -> 2.5.1 ``          |
| [`084ce1ee`](https://github.com/NixOS/nixpkgs/commit/084ce1ee888100b00f6a884dc88c8e960154673e) | `` Revert "nixos/getty: add option to autologin once per boot" ``                |
| [`3853200e`](https://github.com/NixOS/nixpkgs/commit/3853200ec36267b97eb2f6d98bf46d7d791bd2ff) | `` python311Packages.pytorch-pfn-extras: fix build ``                            |
| [`3b26d563`](https://github.com/NixOS/nixpkgs/commit/3b26d563c53acd716d5c15a0c7b0ff126a2a1625) | `` Build Nixpkgs manual when nixdoc changes ``                                   |
| [`3669ad7a`](https://github.com/NixOS/nixpkgs/commit/3669ad7a7bce7ca56bfdcaff9d39e11684d66f9e) | `` Revert "nixdoc: 3.0.2 -> 3.0.3" ``                                            |
| [`0e6aff21`](https://github.com/NixOS/nixpkgs/commit/0e6aff21fedf5ec2f59774565218f3c1b70a33f1) | `` terragrunt: 0.56.2 -> 0.56.5 ``                                               |
| [`ee187195`](https://github.com/NixOS/nixpkgs/commit/ee187195cc5d674fa8fd7f05e38c5a9232d8cdd8) | `` tor: 0.4.8.10 -> 0.4.8.11 ``                                                  |
| [`8847bb91`](https://github.com/NixOS/nixpkgs/commit/8847bb9115f050d88a0616f6ee890b2e46815e8e) | `` texpresso: 0-unstable-2024-03-26 -> 0-unstable-2024-04-08 (#301517) ``        |
| [`a5bc2b61`](https://github.com/NixOS/nixpkgs/commit/a5bc2b616c955e20467ef6dde9bb523b47201584) | `` python312Packages.mypy-boto3-rekognition: 1.34.20 -> 1.34.82 ``               |
| [`d3e3934d`](https://github.com/NixOS/nixpkgs/commit/d3e3934dc8e28a1b9e81bdc34294528d23ad029c) | `` python312Packages.mypy-boto3-connect: 1.34.67 -> 1.34.82 ``                   |
| [`d2c45fd7`](https://github.com/NixOS/nixpkgs/commit/d2c45fd78d7d5a1cf73c9a567aaf23bfa799853a) | `` python312Packages.mypy-boto3-cleanrooms: 1.34.78 -> 1.34.82 ``                |
| [`a499115d`](https://github.com/NixOS/nixpkgs/commit/a499115d5cf87386a0bfe79206ae7249b21ae9c7) | `` rebar3: 3.22.1 -> 3.23.0 ``                                                   |
| [`dc11297a`](https://github.com/NixOS/nixpkgs/commit/dc11297a61b07bd4442adb3c8eec176b546938de) | `` solana-cli: install shell completions ``                                      |
| [`5150491f`](https://github.com/NixOS/nixpkgs/commit/5150491fd4318c9c2b79c25cd7b92bc2baaec793) | `` solana-cli: migrate to by-name ``                                             |
| [`f3410e6f`](https://github.com/NixOS/nixpkgs/commit/f3410e6f4e47d5887c849084614c9339aa7baede) | `` jetbrains.plugins: update ``                                                  |
| [`991b1cda`](https://github.com/NixOS/nixpkgs/commit/991b1cdaffc0e2c4428fdded7d4e6caba54e1809) | `` jetbrains.{clion,rider}: 2023.3.4 -> 2024.1.1 ``                              |
| [`46f5689c`](https://github.com/NixOS/nixpkgs/commit/46f5689c73b2b00a91ac26aed92a4ec9057ff3d2) | `` cling: add a smoke test ``                                                    |
| [`38d5073d`](https://github.com/NixOS/nixpkgs/commit/38d5073d56dbc3538c80246bb9c2a6e4cce2b9c0) | `` vscode-extensions.mgt19937.typst-preview: 0.11.1 -> 0.11.4 ``                 |
| [`42041589`](https://github.com/NixOS/nixpkgs/commit/42041589e4f414deffa4faff0c045c6b8fb61653) | `` lxd-ui: add nix-update-script and meta.changelog ``                           |
| [`35085ab7`](https://github.com/NixOS/nixpkgs/commit/35085ab73009898b5e9d74f1792883773eb2c4b5) | `` ubootTuringRK1: init ``                                                       |
| [`303fb359`](https://github.com/NixOS/nixpkgs/commit/303fb35953de8f496bc2037b27e739c442c1f0ed) | `` lxd-ui: 0.7 -> 0.8 ``                                                         |
| [`4ec09aff`](https://github.com/NixOS/nixpkgs/commit/4ec09aff58edc116a66ba94909a2423b2425b6dc) | `` python312Packages.clifford: mark as broken ``                                 |
| [`ea97563c`](https://github.com/NixOS/nixpkgs/commit/ea97563cf1ed50ce951a339e244c5b9c3b5e82bf) | `` scrutiny: 0.8.0 -> 0.8.1 ``                                                   |
| [`e78bd028`](https://github.com/NixOS/nixpkgs/commit/e78bd02879db01086453de0877974bcb2ef0c027) | `` libserdes: 7.6.0 -> 7.6.1 ``                                                  |
| [`54ad90b9`](https://github.com/NixOS/nixpkgs/commit/54ad90b9cd55a0543c66c5349956f15993e2c620) | `` python312Packages.clifford: migrate to build-system ``                        |
| [`13ceab75`](https://github.com/NixOS/nixpkgs/commit/13ceab7595325852f91ae22deae0009a80f77df7) | `` python312Packages.clifford: add meta.changelog ``                             |
| [`7ba38acb`](https://github.com/NixOS/nixpkgs/commit/7ba38acb5171819f163cea6916f3df0e35b44861) | `` checkov: split inputs ``                                                      |
| [`789684ad`](https://github.com/NixOS/nixpkgs/commit/789684ad02f78823a485b9ff3d49db0219520ba4) | `` nixos/paperless: Switch to `systemd.tmpfiles.settings` ``                     |
| [`9532793d`](https://github.com/NixOS/nixpkgs/commit/9532793d59f929073f8ed4cf61d1580f5b75fe02) | `` nixos/paperless: refactor to use systemd LoadCredential ``                    |
| [`bb40bf4a`](https://github.com/NixOS/nixpkgs/commit/bb40bf4a04eecea814b1b92dfd0c4987e645002e) | `` checkov: 3.2.55 -> 3.2.60 ``                                                  |
| [`d3fb90b7`](https://github.com/NixOS/nixpkgs/commit/d3fb90b7efcec9a2a3d7c9334373e833fbef273b) | `` weaviate: 1.24.7 -> 1.24.8 ``                                                 |
| [`cf6c4e59`](https://github.com/NixOS/nixpkgs/commit/cf6c4e59fb5715a44735f53da8c8ab806538b6c8) | `` python312Packages.pubnub: format with nixfmt ``                               |
| [`3ef25cb3`](https://github.com/NixOS/nixpkgs/commit/3ef25cb316a3ed9c165f1855a6bc58e72e217ef2) | `` trafficserver: 9.2.3 -> 9.2.4 ``                                              |
| [`ff51a64a`](https://github.com/NixOS/nixpkgs/commit/ff51a64adbb7c75ea05a680aa6a8bda7e3eda4e5) | `` ocamlPackages.charInfo_width: remove at 1.1.0 ``                              |
| [`0770ab6a`](https://github.com/NixOS/nixpkgs/commit/0770ab6a87f419e32a9d9785eb0ea6438dd255cd) | `` ocamlPackages.zed: remove at 3.1.0 for OCaml < 4.08 ``                        |
| [`39447b3f`](https://github.com/NixOS/nixpkgs/commit/39447b3f0701bed3f66b03533d9f1057b50cb759) | `` _0xpropo: init at 1.000 ``                                                    |
| [`15d162ad`](https://github.com/NixOS/nixpkgs/commit/15d162adaee36b32ffbbd8f6d50c4bb0cb0252a8) | `` cnquery: 10.11.0 -> 10.11.1 ``                                                |
| [`68b0265a`](https://github.com/NixOS/nixpkgs/commit/68b0265ab5c2b420f916b4f51880f5bcbf6a51ff) | `` ananicy-rules-cachyos: unstable-2023-10-11 -> unstable-2024-04-10 ``          |
| [`646500b8`](https://github.com/NixOS/nixpkgs/commit/646500b85fd9a0cfd397aaee67c6458a0cc94034) | `` gitu: 0.13.1 -> 0.15.0 ``                                                     |
| [`c1d5363e`](https://github.com/NixOS/nixpkgs/commit/c1d5363ecc0345338802eddabc421a74c3b351a5) | `` nixos/cloudflared: fix docs for tlsTimeout ``                                 |
| [`1c5c38f1`](https://github.com/NixOS/nixpkgs/commit/1c5c38f1ce3c6c27338339ec74d7b3ca5d24a430) | `` python312Packages.openai: 1.16.2 -> 1.17.0 ``                                 |
| [`ec1f6857`](https://github.com/NixOS/nixpkgs/commit/ec1f6857a12475f620e374bb3042d4881abfbc78) | `` python312Packages.pubnub: 7.4.3 -> 7.4.4 ``                                   |
| [`aa5041e9`](https://github.com/NixOS/nixpkgs/commit/aa5041e9c23cde58eff59e34ba1bb1299584b57a) | `` spicedb: 1.30.0 -> 1.30.1 ``                                                  |
| [`ac734d9b`](https://github.com/NixOS/nixpkgs/commit/ac734d9b1edd6e9a73a9a08f1d99d40deeee6ee3) | `` wslu: 4.1.2 -> 4.1.3 ``                                                       |
| [`f5933f51`](https://github.com/NixOS/nixpkgs/commit/f5933f5148ff7a19152248383b8a267c19d27e69) | `` chess-tui: init at 1.2.0 ``                                                   |
| [`d8f6e7df`](https://github.com/NixOS/nixpkgs/commit/d8f6e7df57751b43798510143b9cdd01f018ffef) | `` shanggu-fonts: init at 1.020 ``                                               |
| [`de1025fd`](https://github.com/NixOS/nixpkgs/commit/de1025fdfd914e37108451448c4c4ed91436ca8f) | `` orc: fix build on 32-bit ARM ``                                               |
| [`47918937`](https://github.com/NixOS/nixpkgs/commit/47918937b8b017764161116c0346a9f09f3f83ab) | `` movim: update to latest (includes NixOS patches) ``                           |
| [`97899b5b`](https://github.com/NixOS/nixpkgs/commit/97899b5ba66be56998c7520b44b9710b1686706f) | `` doc: add information about ryzen-monitor-ng and ryzen-smu modules ``          |
| [`286d741f`](https://github.com/NixOS/nixpkgs/commit/286d741f474ebeabae13574c508bcd214d115a72) | `` nixos/ryzen-monitor-ng: init module ``                                        |
| [`a352dc5e`](https://github.com/NixOS/nixpkgs/commit/a352dc5e0ff3b482e2aad50ca664693eafda20de) | `` ryzen-monitor-ng: init at 2.0.5 ``                                            |
| [`ba056672`](https://github.com/NixOS/nixpkgs/commit/ba0566726ec5c55f4091fb3dd93a9b313215384d) | `` nixos/ryzen-smu: init module ``                                               |
| [`cc0f0564`](https://github.com/NixOS/nixpkgs/commit/cc0f05649269e39170b59716af72ff738ef5b931) | `` ryzen-smu: init at 0.1.5 ``                                                   |
| [`b094c83d`](https://github.com/NixOS/nixpkgs/commit/b094c83dd3519451ce89dfc5ddad63f9e2748473) | `` camunda-modeler: 5.21.0 -> 5.22.0 ``                                          |
| [`c10316a4`](https://github.com/NixOS/nixpkgs/commit/c10316a4f6337a4ef58902784fae1ecc37c8daf4) | `` movim: ImageMagick fix ``                                                     |
| [`94d3c3c6`](https://github.com/NixOS/nixpkgs/commit/94d3c3c65c57d46f7561e5d718537c8b52aad3ef) | `` movim: add bin script helper ``                                               |
| [`e122cdb5`](https://github.com/NixOS/nixpkgs/commit/e122cdb5fe34b2e62ffada323dd7bdfac3fe147a) | `` namespace-cli: 0.0.354 -> 0.0.355 ``                                          |
| [`ee7205fa`](https://github.com/NixOS/nixpkgs/commit/ee7205fa8857e9646ec52b98fc02267dd4262703) | `` micronaut: 4.3.7 -> 4.3.8 ``                                                  |
| [`67ad2fcc`](https://github.com/NixOS/nixpkgs/commit/67ad2fccc1ffe2ac3bb1bf946ffe872193eab09f) | `` kubernetes-helm: 3.14.3 -> 3.14.4 ``                                          |
| [`12aa54eb`](https://github.com/NixOS/nixpkgs/commit/12aa54eb5083ba434c7ad0e22bcd201a41b9ed4d) | `` ibus-engines.typing-booster-unwrapped: 2.25.4 -> 2.25.6 ``                    |
| [`51f1681f`](https://github.com/NixOS/nixpkgs/commit/51f1681f814e821d409de95617540397fb51bc04) | `` ibus-engines.m17n: 1.4.28 -> 1.4.29 ``                                        |