### PR TITLE
chore(flake/nixpkgs-unstable): `ca74eb22` -> `681d4a87`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1303,11 +1303,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1712733109,
-        "narHash": "sha256-DmBcIbIDgJiDxegzaZJlcZKAXrsUL00G0cKLN+JaK1s=",
+        "lastModified": 1712837137,
+        "narHash": "sha256-9joaU/GD35J9Utb0ipelQbOcvsw5eoYTmSarLV3MbNk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ca74eb22840662bbd4aca7c38a35a02d16f0dd0a",
+        "rev": "681d4a87b26b1dcaae7ffe6cf88c9912c575415f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                               |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
| [`084ce1ee`](https://github.com/NixOS/nixpkgs/commit/084ce1ee888100b00f6a884dc88c8e960154673e) | `` Revert "nixos/getty: add option to autologin once per boot" ``                                     |
| [`3b26d563`](https://github.com/NixOS/nixpkgs/commit/3b26d563c53acd716d5c15a0c7b0ff126a2a1625) | `` Build Nixpkgs manual when nixdoc changes ``                                                        |
| [`3669ad7a`](https://github.com/NixOS/nixpkgs/commit/3669ad7a7bce7ca56bfdcaff9d39e11684d66f9e) | `` Revert "nixdoc: 3.0.2 -> 3.0.3" ``                                                                 |
| [`8847bb91`](https://github.com/NixOS/nixpkgs/commit/8847bb9115f050d88a0616f6ee890b2e46815e8e) | `` texpresso: 0-unstable-2024-03-26 -> 0-unstable-2024-04-08 (#301517) ``                             |
| [`dc11297a`](https://github.com/NixOS/nixpkgs/commit/dc11297a61b07bd4442adb3c8eec176b546938de) | `` solana-cli: install shell completions ``                                                           |
| [`5150491f`](https://github.com/NixOS/nixpkgs/commit/5150491fd4318c9c2b79c25cd7b92bc2baaec793) | `` solana-cli: migrate to by-name ``                                                                  |
| [`46f5689c`](https://github.com/NixOS/nixpkgs/commit/46f5689c73b2b00a91ac26aed92a4ec9057ff3d2) | `` cling: add a smoke test ``                                                                         |
| [`38d5073d`](https://github.com/NixOS/nixpkgs/commit/38d5073d56dbc3538c80246bb9c2a6e4cce2b9c0) | `` vscode-extensions.mgt19937.typst-preview: 0.11.1 -> 0.11.4 ``                                      |
| [`42041589`](https://github.com/NixOS/nixpkgs/commit/42041589e4f414deffa4faff0c045c6b8fb61653) | `` lxd-ui: add nix-update-script and meta.changelog ``                                                |
| [`303fb359`](https://github.com/NixOS/nixpkgs/commit/303fb35953de8f496bc2037b27e739c442c1f0ed) | `` lxd-ui: 0.7 -> 0.8 ``                                                                              |
| [`4ec09aff`](https://github.com/NixOS/nixpkgs/commit/4ec09aff58edc116a66ba94909a2423b2425b6dc) | `` python312Packages.clifford: mark as broken ``                                                      |
| [`ea97563c`](https://github.com/NixOS/nixpkgs/commit/ea97563cf1ed50ce951a339e244c5b9c3b5e82bf) | `` scrutiny: 0.8.0 -> 0.8.1 ``                                                                        |
| [`e78bd028`](https://github.com/NixOS/nixpkgs/commit/e78bd02879db01086453de0877974bcb2ef0c027) | `` libserdes: 7.6.0 -> 7.6.1 ``                                                                       |
| [`54ad90b9`](https://github.com/NixOS/nixpkgs/commit/54ad90b9cd55a0543c66c5349956f15993e2c620) | `` python312Packages.clifford: migrate to build-system ``                                             |
| [`13ceab75`](https://github.com/NixOS/nixpkgs/commit/13ceab7595325852f91ae22deae0009a80f77df7) | `` python312Packages.clifford: add meta.changelog ``                                                  |
| [`7ba38acb`](https://github.com/NixOS/nixpkgs/commit/7ba38acb5171819f163cea6916f3df0e35b44861) | `` checkov: split inputs ``                                                                           |
| [`bb40bf4a`](https://github.com/NixOS/nixpkgs/commit/bb40bf4a04eecea814b1b92dfd0c4987e645002e) | `` checkov: 3.2.55 -> 3.2.60 ``                                                                       |
| [`cf6c4e59`](https://github.com/NixOS/nixpkgs/commit/cf6c4e59fb5715a44735f53da8c8ab806538b6c8) | `` python312Packages.pubnub: format with nixfmt ``                                                    |
| [`3ef25cb3`](https://github.com/NixOS/nixpkgs/commit/3ef25cb316a3ed9c165f1855a6bc58e72e217ef2) | `` trafficserver: 9.2.3 -> 9.2.4 ``                                                                   |
| [`ff51a64a`](https://github.com/NixOS/nixpkgs/commit/ff51a64adbb7c75ea05a680aa6a8bda7e3eda4e5) | `` ocamlPackages.charInfo_width: remove at 1.1.0 ``                                                   |
| [`0770ab6a`](https://github.com/NixOS/nixpkgs/commit/0770ab6a87f419e32a9d9785eb0ea6438dd255cd) | `` ocamlPackages.zed: remove at 3.1.0 for OCaml < 4.08 ``                                             |
| [`39447b3f`](https://github.com/NixOS/nixpkgs/commit/39447b3f0701bed3f66b03533d9f1057b50cb759) | `` _0xpropo: init at 1.000 ``                                                                         |
| [`15d162ad`](https://github.com/NixOS/nixpkgs/commit/15d162adaee36b32ffbbd8f6d50c4bb0cb0252a8) | `` cnquery: 10.11.0 -> 10.11.1 ``                                                                     |
| [`1c5c38f1`](https://github.com/NixOS/nixpkgs/commit/1c5c38f1ce3c6c27338339ec74d7b3ca5d24a430) | `` python312Packages.openai: 1.16.2 -> 1.17.0 ``                                                      |
| [`ec1f6857`](https://github.com/NixOS/nixpkgs/commit/ec1f6857a12475f620e374bb3042d4881abfbc78) | `` python312Packages.pubnub: 7.4.3 -> 7.4.4 ``                                                        |
| [`f5933f51`](https://github.com/NixOS/nixpkgs/commit/f5933f5148ff7a19152248383b8a267c19d27e69) | `` chess-tui: init at 1.2.0 ``                                                                        |
| [`d8f6e7df`](https://github.com/NixOS/nixpkgs/commit/d8f6e7df57751b43798510143b9cdd01f018ffef) | `` shanggu-fonts: init at 1.020 ``                                                                    |
| [`b094c83d`](https://github.com/NixOS/nixpkgs/commit/b094c83dd3519451ce89dfc5ddad63f9e2748473) | `` camunda-modeler: 5.21.0 -> 5.22.0 ``                                                               |
| [`71913aac`](https://github.com/NixOS/nixpkgs/commit/71913aac04f206485305bbec5e010d1e573587db) | `` helm-ls: 0.0.14 -> 0.0.15 ``                                                                       |
| [`1a62250c`](https://github.com/NixOS/nixpkgs/commit/1a62250cc12f9d3045a5425efa56b5535e2b3fcb) | `` python312Packages.langchain: 0.1.14 -> 0.1.15 ``                                                   |
| [`1a55c25e`](https://github.com/NixOS/nixpkgs/commit/1a55c25e86ca702c41500693d01edf7fbb03d22b) | `` duckdb: increase file descriptors for installCheck ``                                              |
| [`871d80c8`](https://github.com/NixOS/nixpkgs/commit/871d80c872f66f18bbb7b6f0307097fa3f3bfbc7) | `` python312Packages.dvc-render: format with nixfmt ``                                                |
| [`60925cab`](https://github.com/NixOS/nixpkgs/commit/60925cabbc0c0100e99ace423b2be0edff6dd049) | `` python312Packages.dvc-render: refactor ``                                                          |
| [`4baf94dc`](https://github.com/NixOS/nixpkgs/commit/4baf94dca8374d11e4f08c02ff6468a081d4e5ef) | `` python312Packages.dvc-render: 1.0.1 -> 1.0.2 ``                                                    |
| [`513bb9b5`](https://github.com/NixOS/nixpkgs/commit/513bb9b52f81a66d46cba0723eb689f348ef212e) | `` python312Packages.sqlmap: format with nixfmt ``                                                    |
| [`13c669b3`](https://github.com/NixOS/nixpkgs/commit/13c669b3d813a004b5f8c90e4fa4f25c25b67810) | `` python312Packages.sqlmap: refactor ``                                                              |
| [`ecde7fd7`](https://github.com/NixOS/nixpkgs/commit/ecde7fd7f4b0ad8f65463cdfae09b2506b478387) | `` python312Packages.sqlmap: 1.8.3 -> 1.8.4 ``                                                        |
| [`fe1bedbd`](https://github.com/NixOS/nixpkgs/commit/fe1bedbd902ca515fedb10a8c0a8e436937a8574) | `` python312Packages.sentry-sdk: format with nixfmt ``                                                |
| [`fa30aeae`](https://github.com/NixOS/nixpkgs/commit/fa30aeaecf7d82d2b9beb0cfb6505cf9d5134ad4) | `` python312Packages.sentry-sdk: refactor ``                                                          |
| [`a7056eb2`](https://github.com/NixOS/nixpkgs/commit/a7056eb22e83dc66b185eb2ac96c7ca06990ea5c) | `` python312Packages.sentry-sdk: 1.43.0 -> 1.45.0 ``                                                  |
| [`24d031bf`](https://github.com/NixOS/nixpkgs/commit/24d031bfa207df12b9fca6ff14838bc25fb5a531) | `` python312Packages.sparse: fix build ``                                                             |
| [`ba66597c`](https://github.com/NixOS/nixpkgs/commit/ba66597c5eb9ad8b9f1679dd45983498b4796f92) | `` python312Packages.langchain-community: 0.0.31 -> 0.0.32 ``                                         |
| [`f973d87b`](https://github.com/NixOS/nixpkgs/commit/f973d87b1bf25e11f1305f0e4d00eda70158b2d6) | `` python312Packages.langsmith: 0.1.42 -> 0.1.45 ``                                                   |
| [`3944e8ad`](https://github.com/NixOS/nixpkgs/commit/3944e8ada4e1038be2399ea8fa0a83bee8de20cd) | `` python312Packages.langchain-core: 0.1.40 -> 0.1.41 ``                                              |
| [`da83c7ae`](https://github.com/NixOS/nixpkgs/commit/da83c7ae68df9561b49598292b38294bca868dc9) | `` ollama: add cudart_static to cuda dependencies ``                                                  |
| [`ef03145c`](https://github.com/NixOS/nixpkgs/commit/ef03145c3b404a9e6226c02861cb273daa68dab5) | `` python312Packages.tencentcloud-sdk-python: 3.0.1126 -> 3.0.1127 ``                                 |
| [`8a36964e`](https://github.com/NixOS/nixpkgs/commit/8a36964ecf416433c78bd5e9e4f7ef7278eb9621) | `` python312Packages.pytenable: format with nixfmt ``                                                 |
| [`8456d31c`](https://github.com/NixOS/nixpkgs/commit/8456d31ce24d6aa2d29e8a6c1bed957f9b9ad8eb) | `` python312Packages.pytenable: refactor ``                                                           |
| [`59fd0e0b`](https://github.com/NixOS/nixpkgs/commit/59fd0e0be784cd126d83bb42b4a17a4e78ce15c0) | `` python312Packages.pytenable: 1.4.21 -> 1.4.22 ``                                                   |
| [`e897ff2f`](https://github.com/NixOS/nixpkgs/commit/e897ff2f219e8172d50ddfaa9e65631872366d64) | `` devbox: 0.10.3 -> 0.10.4 ``                                                                        |
| [`dc4f2184`](https://github.com/NixOS/nixpkgs/commit/dc4f2184327d7b04edda404fa8562ba5e3e17755) | `` check-cherry-picks.sh maintainer script: add clarifying message regarding differences found ``     |
| [`4adc607b`](https://github.com/NixOS/nixpkgs/commit/4adc607b77d623ecd6b545b75435e455ae9382ac) | `` potreeconverter: Don't unnecessarily override patchPhase/fixupPhase. ``                            |
| [`70ed4f3e`](https://github.com/NixOS/nixpkgs/commit/70ed4f3edcfd218fda4c8eae69ea5841ccd68327) | `` python312Packages.mitogen: 0.3.6 -> 0.3.7 ``                                                       |
| [`b612366a`](https://github.com/NixOS/nixpkgs/commit/b612366abc32edc61e86d0fcc0f4a08cabcf5212) | `` check-cherry-picks.sh maintainer script: fix handling of cherry-pick-less branches ``              |
| [`392c8da8`](https://github.com/NixOS/nixpkgs/commit/392c8da8774676f4adaba2d98fcc2823810fa779) | `` qovery-cli: format with nixfmt ``                                                                  |
| [`97466858`](https://github.com/NixOS/nixpkgs/commit/974668588a745682d5818c17aa3f05967c3c449e) | `` base16384: 2.3.0 -> 2.3.1 ``                                                                       |
| [`08a9aec5`](https://github.com/NixOS/nixpkgs/commit/08a9aec581f31cf1e73b2ff440890785351f1c26) | `` python311Packages.llama-index-vector-stores-qdrant: 0.1.6 -> 0.2.0 ``                              |
| [`a5c3a84e`](https://github.com/NixOS/nixpkgs/commit/a5c3a84e42ade89ad415e088553c2e4c5764811d) | `` files-cli: 2.12.54 -> 2.12.56 ``                                                                   |
| [`dbc967d1`](https://github.com/NixOS/nixpkgs/commit/dbc967d14d354154bc556a4348971c59df5dc56c) | `` Revert "NixOS Integration Tests: Enable again for darwin" ``                                       |
| [`ab0b45a3`](https://github.com/NixOS/nixpkgs/commit/ab0b45a3a027644e404dcd01887b3921ad0533de) | `` nixos/sddm: allow disabling the rest of X11 ``                                                     |
| [`2848915e`](https://github.com/NixOS/nixpkgs/commit/2848915e9bc33ed9bdd7905c4b353b45f38ae81b) | `` stow: 2.3.1 -> 2.4.0 ``                                                                            |
| [`74c15474`](https://github.com/NixOS/nixpkgs/commit/74c1547424498edd75cbe3092a624960a2456695) | `` nixos/doc: suggest mounting the ESP on /boot with umask=077 ``                                     |
| [`e17e60b2`](https://github.com/NixOS/nixpkgs/commit/e17e60b2738bcddf4e0661da3d63872ceec2a9cb) | `` nixos-generate-config: preserve vfat filesystem mount permissions ``                               |
| [`0355aaa7`](https://github.com/NixOS/nixpkgs/commit/0355aaa7d29f6e4c990a52c119766a09d3e4371c) | `` quartus-prime-lite: add option to disable Questa simulator ``                                      |
| [`4d46279a`](https://github.com/NixOS/nixpkgs/commit/4d46279ad98b238bcb7c0c08b53a9e1aba1cf6d6) | `` quartus-prime-lite: make usable under emulation ``                                                 |
| [`a4f75867`](https://github.com/NixOS/nixpkgs/commit/a4f75867ee9c13fdb1f4501108eb37790081ced1) | `` quartus-prime-lite: add more qsys requirements ``                                                  |
| [`e4bf075c`](https://github.com/NixOS/nixpkgs/commit/e4bf075cffda38c7ba857234325f3b4c4411ed53) | `` NixOS Integration Tests: Enable again for darwin ``                                                |
| [`a7418181`](https://github.com/NixOS/nixpkgs/commit/a74181815c9b0f5b21fb71f8a6a99db7c1266f83) | `` linux/common-config: remove old NFSD options from 5.15 too ``                                      |
| [`eaf5fc18`](https://github.com/NixOS/nixpkgs/commit/eaf5fc1813adefeea57a3312e7009c6784ddd50e) | `` gmid: migrate to by-name ``                                                                        |
| [`dadbcf93`](https://github.com/NixOS/nixpkgs/commit/dadbcf93673bb8d6004936992eea55e6fbecbb22) | `` nixos/rl-24.05: Add deprecation entry for cudaPackages.autoAdd{DriverRunpath,OpenGLRunpathHook} `` |
| [`52eb8850`](https://github.com/NixOS/nixpkgs/commit/52eb8850b82e0c3eceafc96fe72c56054fbd0451) | `` cudaPackages.autoAdd{Driver,OpengGL}Runpath: deprecate ``                                          |
| [`13481954`](https://github.com/NixOS/nixpkgs/commit/13481954160723e1080b02851ae38a72e04f4fee) | `` tests.importCargoLock: fix self-inclusive src listings in .nix files ``                            |
| [`658206a8`](https://github.com/NixOS/nixpkgs/commit/658206a8f78b2e7e6b949b61bfe39e43cfc015b1) | `` CODEOWNERS: Fix check-by-name path ``                                                              |
| [`2e10f813`](https://github.com/NixOS/nixpkgs/commit/2e10f813fe216bb6e6e62c28dee8bad53a13b661) | `` nixos/prometheus-nats-exporter: new module ``                                                      |
| [`c044ba36`](https://github.com/NixOS/nixpkgs/commit/c044ba368c1504d5be49809659ff31c6e3ce5668) | `` linux-rt_6_6: 6.6.23-rt28 -> 6.6.25-rt29 ``                                                        |
| [`af887c78`](https://github.com/NixOS/nixpkgs/commit/af887c78d2d1a2073d2600a1102f57bf7cbc3324) | `` nixpkgs-check-by-name: 0.1.0 -> 0.1.1 ``                                                           |
| [`550bbd40`](https://github.com/NixOS/nixpkgs/commit/550bbd40902244523f860819a5babc71a17fcc06) | `` linux_5_15: 5.15.153 -> 5.15.154 ``                                                                |
| [`fa12da8a`](https://github.com/NixOS/nixpkgs/commit/fa12da8a56790e4bf93407a55a38baa466e14204) | `` linux_6_1: 6.1.84 -> 6.1.85 ``                                                                     |
| [`7858a70b`](https://github.com/NixOS/nixpkgs/commit/7858a70becf584782bfe094c1c00b565f37afc99) | `` linux_6_6: 6.6.25 -> 6.6.26 ``                                                                     |
| [`8f6d8ef0`](https://github.com/NixOS/nixpkgs/commit/8f6d8ef0c9e418de136785c0fca7fa805bb5a2b8) | `` linux_6_8: 6.8.4 -> 6.8.5 ``                                                                       |
| [`e863d558`](https://github.com/NixOS/nixpkgs/commit/e863d558d0049de5d925ceccb001616e2044b153) | `` linux_testing: 6.9-rc2 -> 6.9-rc3 ``                                                               |
| [`cd70dc73`](https://github.com/NixOS/nixpkgs/commit/cd70dc73d87c7565770630f6152586e3ab59e32a) | `` linux/kernel/update-mainline: don't readd EOL kernels ``                                           |
| [`6347cd23`](https://github.com/NixOS/nixpkgs/commit/6347cd23dcc2b020dd4ea5bfe5871be35e95ae63) | `` dex-oidc: 2.39.0 -> 2.39.1 (#302821) ``                                                            |
| [`37ba6034`](https://github.com/NixOS/nixpkgs/commit/37ba60342b1dbff9b648e9ac2f4fb83f052d16d5) | `` linux-firmware: 20240312 -> 20240410 ``                                                            |
| [`e7d58a40`](https://github.com/NixOS/nixpkgs/commit/e7d58a4040bae44ca6572fd10e975f221d295d12) | `` raycast: 1.70.3 -> 1.71.1 ``                                                                       |
| [`50939388`](https://github.com/NixOS/nixpkgs/commit/50939388bd533ecfe2db3e9a25a5cf4ff04ef342) | `` qovery-cli: 0.86.2 -> 0.87.0 ``                                                                    |
| [`70a4a21e`](https://github.com/NixOS/nixpkgs/commit/70a4a21ed88915f7c4280aa3e3075dc4991497a9) | `` minder: 1.16.3 -> 1.16.4 ``                                                                        |
| [`fa2d0c69`](https://github.com/NixOS/nixpkgs/commit/fa2d0c69d1a9f6d26f72780446842bcfa3969ed3) | `` googleearth-pro: more specific vulnerability description ``                                        |
| [`271fd55b`](https://github.com/NixOS/nixpkgs/commit/271fd55b7ecf4c5a7579a795d3d69519275a6c9f) | `` grafana-loki: add simple version test ``                                                           |
| [`de3d3a0c`](https://github.com/NixOS/nixpkgs/commit/de3d3a0cf1c31fe5e3361bd7181dbbc0c06a6d03) | `` python311Packages.aiolifx-themes: 0.4.16 -> 0.4.17 ``                                              |
| [`93afa6f7`](https://github.com/NixOS/nixpkgs/commit/93afa6f76436b89cd5b73aa378ac7adc0bf87dfe) | `` spire: 1.9.3 -> 1.9.4 ``                                                                           |