### PR TITLE
chore(flake/emacs-overlay): `705fbd14` -> `d97f4109`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712855032,
-        "narHash": "sha256-FrlJ7F6568TIj4uTmP2vXhF5cOEsY+w3voxMNMwvchI=",
+        "lastModified": 1712886378,
+        "narHash": "sha256-UrRX+PbrU8nBZRhK5SUnoCEGgS0+Hn0Lq+lLVJKAU3g=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "705fbd143cc7ee5899525003feda2267e23b4bd6",
+        "rev": "d97f41093894dd5e2d2548fe1e67e0b556a4f250",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message              |
| ------------------------------------------------------------------------------------------------------------ | -------------------- |
| [`d97f4109`](https://github.com/nix-community/emacs-overlay/commit/d97f41093894dd5e2d2548fe1e67e0b556a4f250) | `` Updated emacs ``  |
| [`39dc9983`](https://github.com/nix-community/emacs-overlay/commit/39dc9983ae9a65f12b4cbb7a80f4586aa6c78b51) | `` Updated melpa ``  |
| [`86055b72`](https://github.com/nix-community/emacs-overlay/commit/86055b7247d4b9192ae3bb4c087de5786c9789ba) | `` Updated elpa ``   |
| [`c0172f74`](https://github.com/nix-community/emacs-overlay/commit/c0172f7428f7b594721351c394471b4c45dbee8e) | `` Updated nongnu `` |