### PR TITLE
chore(flake/nixpkgs-master): `d9110b97` -> `1973d842`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1224,11 +1224,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1712880699,
-        "narHash": "sha256-zT6iwuO7WBN95q2VWNTyQVU5kEi6Po5SEPM3NUb6p7o=",
+        "lastModified": 1712896726,
+        "narHash": "sha256-9ViuPLj9LQdeH950HzMCD147rw37G/5U0eCZCGxCPQM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d9110b97053f3fd502ea0af486aaa508cd567df1",
+        "rev": "1973d8420eb5eb50d6b2c13c3d88e1d9bc02f594",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                             |
| ---------------------------------------------------------------------------------------------- | ----------------------------------- |
| [`5fe89bc9`](https://github.com/NixOS/nixpkgs/commit/5fe89bc95dc792594446c435036815c3ffecb466) | `` afio: darwin build ``            |
| [`078dca4b`](https://github.com/NixOS/nixpkgs/commit/078dca4b1e60f1fcd6f6f0c5017e76d532032c62) | `` aewan: fix darwin build ``       |
| [`403c17e4`](https://github.com/NixOS/nixpkgs/commit/403c17e488fd6570964d627fa055ba4186a89f80) | `` flint: remove mpir dependency `` |
| [`c495c40f`](https://github.com/NixOS/nixpkgs/commit/c495c40f15a1466562161783b2f2cd0ac119fdf7) | `` pomodoro-gtk: init at 1.4.1 ``   |