### PR TITLE
chore(flake/emacs-overlay): `d97f4109` -> `9f440671`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712886378,
-        "narHash": "sha256-UrRX+PbrU8nBZRhK5SUnoCEGgS0+Hn0Lq+lLVJKAU3g=",
+        "lastModified": 1712941527,
+        "narHash": "sha256-wD9XQFGW0qzRW1YHj6oklCHzgKNxjwS0tZ/hFGgiHX4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "d97f41093894dd5e2d2548fe1e67e0b556a4f250",
+        "rev": "9f4406718ada7af83892e17355ef7fd202c20897",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`9f440671`](https://github.com/nix-community/emacs-overlay/commit/9f4406718ada7af83892e17355ef7fd202c20897) | `` Updated emacs ``        |
| [`e84bd87d`](https://github.com/nix-community/emacs-overlay/commit/e84bd87de2cf761c359dc6931c76326cde33e8d2) | `` Updated melpa ``        |
| [`aa451ac0`](https://github.com/nix-community/emacs-overlay/commit/aa451ac08eb3330749f75c4aa33c26e90d0362b2) | `` Updated elpa ``         |
| [`2c7ff266`](https://github.com/nix-community/emacs-overlay/commit/2c7ff266de758a5fd1a29685ff2d6f299ec632d4) | `` Updated nongnu ``       |
| [`9414446d`](https://github.com/nix-community/emacs-overlay/commit/9414446dfdc600c060284afc74d8dd5aa78208d1) | `` Updated emacs ``        |
| [`8de63fb7`](https://github.com/nix-community/emacs-overlay/commit/8de63fb7fbddaec406db99adc302174ec6b4016d) | `` Updated melpa ``        |
| [`9a6b212e`](https://github.com/nix-community/emacs-overlay/commit/9a6b212ead9f4b57809493369c412f79e833ea17) | `` Updated flake inputs `` |