### PR TITLE
chore(flake/hyprland): `b1a94302` -> `0c513ba9`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -687,11 +687,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712877538,
-        "narHash": "sha256-FK4Rhq9mEf8wpS3/K/ueB5Sql2XOeCQX/SzCe/QySNk=",
+        "lastModified": 1712951181,
+        "narHash": "sha256-Am+Jl/pDkVuZxyiBEAw1Ia5/dDRi5HOIYBT/kTT6uKA=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "b1a94302897ae559c877471f7d365651bcd24ad4",
+        "rev": "0c513ba91bd73106be99e35b1a020d24e5ae874a",
         "type": "github"
       },
       "original": {
@@ -1807,20 +1807,18 @@
     "wlroots": {
       "flake": false,
       "locked": {
-        "host": "gitlab.freedesktop.org",
-        "lastModified": 1709983277,
-        "narHash": "sha256-wXWIJLd4F2JZeMaihWVDW/yYXCLEC8OpeNJZg9a9ly8=",
-        "owner": "wlroots",
-        "repo": "wlroots",
-        "rev": "50eae512d9cecbf0b3b1898bb1f0b40fa05fe19b",
-        "type": "gitlab"
+        "lastModified": 1712935342,
+        "narHash": "sha256-zzIbTFNFd/as42jyGx23fil2uBDYYv+8GA5JmRq5y9c=",
+        "owner": "hyprwm",
+        "repo": "wlroots-hyprland",
+        "rev": "62eeffbe233d199f520a5755c344e85f8eab7940",
+        "type": "github"
       },
       "original": {
-        "host": "gitlab.freedesktop.org",
-        "owner": "wlroots",
-        "repo": "wlroots",
-        "rev": "50eae512d9cecbf0b3b1898bb1f0b40fa05fe19b",
-        "type": "gitlab"
+        "owner": "hyprwm",
+        "repo": "wlroots-hyprland",
+        "rev": "62eeffbe233d199f520a5755c344e85f8eab7940",
+        "type": "github"
       }
     },
     "wrapper-manager": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                           |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------- |
| [`0c513ba9`](https://github.com/hyprwm/Hyprland/commit/0c513ba91bd73106be99e35b1a020d24e5ae874a) | `` CI: fix packaging ``                           |
| [`dd6fdf49`](https://github.com/hyprwm/Hyprland/commit/dd6fdf49d9deebfe792ab5cd0332432249922fa9) | `` window: always unref workspace on unmap ``     |
| [`ddcdb56f`](https://github.com/hyprwm/Hyprland/commit/ddcdb56f2c7dab026a047379aaff4e30acff7414) | `` CI: fix arch ``                                |
| [`32147f5e`](https://github.com/hyprwm/Hyprland/commit/32147f5e91d5423fd6c509b3c4619f382b66b628) | `` hyprpm: fix wlroots path (#5567) ``            |
| [`d8d0d3b2`](https://github.com/hyprwm/Hyprland/commit/d8d0d3b20bdb4e4320989349dacd6deb17cfb619) | `` Nix & Meson: switch to wlroots-hyprland ``     |
| [`382b6d3f`](https://github.com/hyprwm/Hyprland/commit/382b6d3f6b26284388cfe3181c447f11a8dc9bee) | `` makefile: move wlr headers dir ``              |
| [`0a70ccd0`](https://github.com/hyprwm/Hyprland/commit/0a70ccd099d5620fcb65be90212fd09bad82fc30) | `` Makefile: remove refs to libwlroots ``         |
| [`e1e11f5a`](https://github.com/hyprwm/Hyprland/commit/e1e11f5a878aee4fe58310a1f42cb80de11d6c3d) | `` [gha] Nix: update wlroots ``                   |
| [`45945a3e`](https://github.com/hyprwm/Hyprland/commit/45945a3e7d4485cc2d8889ee3cca4cc595e4270d) | `` deps: move from wlroots to wlroots-hyprland `` |