### PR TITLE
chore(flake/nixpkgs-unstable): `681d4a87` -> `037735eb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1303,11 +1303,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1712837137,
-        "narHash": "sha256-9joaU/GD35J9Utb0ipelQbOcvsw5eoYTmSarLV3MbNk=",
+        "lastModified": 1712927102,
+        "narHash": "sha256-GGDFfu4B7FQ2TqJ17XQiP6oxdb+mY6qTsKOOPAJDo1Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "681d4a87b26b1dcaae7ffe6cf88c9912c575415f",
+        "rev": "037735eb33b9f9cdf2b9d2e3442f52022d913abc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                    |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
| [`19afc01e`](https://github.com/NixOS/nixpkgs/commit/19afc01e857c02a13ded2d88796afe99f0d493f0) | `` cargo-deny: 0.14.20 -> 0.14.21 ``                                       |
| [`8d3a38e8`](https://github.com/NixOS/nixpkgs/commit/8d3a38e8b19bdd6bf2a2274c91697cd315de0403) | `` NixOS Integration tests: Re-enable for macOS ``                         |
| [`c6a0404e`](https://github.com/NixOS/nixpkgs/commit/c6a0404e3e1ec5fe3705d5f3cf16562763d6f513) | `` nixos/display-managers: add renamed option missed in #291913 ``         |
| [`58ce6dcd`](https://github.com/NixOS/nixpkgs/commit/58ce6dcd53857c36ac08071663ec91fe2865c613) | `` workout-tracker: 0.11.2 -> 0.12.0 ``                                    |
| [`f3d71408`](https://github.com/NixOS/nixpkgs/commit/f3d714082edf4874d63530a46013ced97c3808bf) | `` qtile: remove kamilchm from maintainers ``                              |
| [`7c363e8f`](https://github.com/NixOS/nixpkgs/commit/7c363e8faca3eaf130000ecdd94b7fd2c382d4ed) | `` python312Packages.homeassistant-stubs: 2024.4.1 -> 2024.4.2 ``          |
| [`84372303`](https://github.com/NixOS/nixpkgs/commit/8437230323be3e0e69d5b536322a01fbbf5f3e10) | `` home-assistant: 2024.4.1 -> 2024.4.2 ``                                 |
| [`c057f8f2`](https://github.com/NixOS/nixpkgs/commit/c057f8f2badd68e72142450120da7f6af386d816) | `` python312Packages.junos-eznc: format with nixfmt ``                     |
| [`553c9184`](https://github.com/NixOS/nixpkgs/commit/553c9184da1fa57aa6b46a61797067937ca75c8c) | `` python312Packages.junos-eznc: refactor ``                               |
| [`84a50dcf`](https://github.com/NixOS/nixpkgs/commit/84a50dcf5260ead5cb65bbf5f66cfd69095155ff) | `` python312Packages.gekko: format with nixfmt ``                          |
| [`a726656b`](https://github.com/NixOS/nixpkgs/commit/a726656b84a4cdd3f8ed986bb92742f013596805) | `` python312Packages.gekko: refactor ``                                    |
| [`dfb067ed`](https://github.com/NixOS/nixpkgs/commit/dfb067ede6955539fb91b3c523ea0c557e5bc8de) | `` python312Packages.python-roborock: update --replace ``                  |
| [`12e189c1`](https://github.com/NixOS/nixpkgs/commit/12e189c1ace40ad7aa14826e6a59e3126ef14422) | `` python312Packages.python-roborock: 1.0.0 -> 2.0.0 ``                    |
| [`a0493a14`](https://github.com/NixOS/nixpkgs/commit/a0493a1408208751dc5b2c927816710da8395473) | `` python312Packages.htmldate: update license ``                           |
| [`ab34cd46`](https://github.com/NixOS/nixpkgs/commit/ab34cd46e86f45f091b58c5d8f5eaefac1afdcb7) | `` python312Packages.pylitterbot: 2023.4.9 -> 2023.4.11 ``                 |
| [`fd7880be`](https://github.com/NixOS/nixpkgs/commit/fd7880beecc92cb77f23ed161c93c58c7a7d1ee0) | `` python312Packages.htmldate: format with nixfmt ``                       |
| [`4ac754bd`](https://github.com/NixOS/nixpkgs/commit/4ac754bd55654efcfc56fe9bf095f9ab9e4753cf) | `` python312Packages.htmldate: refactor ``                                 |
| [`16317c40`](https://github.com/NixOS/nixpkgs/commit/16317c40ead5c0f0f14741ffff108c72e9a6c742) | `` python312Packages.htmldate: 1.8.0 -> 1.8.1 ``                           |
| [`b1bcfd89`](https://github.com/NixOS/nixpkgs/commit/b1bcfd8959f8fae67326100832609894cc2d2871) | `` python312Packages.langchain: 0.1.15 -> 0.1.16 ``                        |
| [`994ac6c6`](https://github.com/NixOS/nixpkgs/commit/994ac6c6a620bb9f5b0d760caa981b0d3129638d) | `` python312Packages.langchain-core: 0.1.41 -> 0.1.42 ``                   |
| [`d76ef7a0`](https://github.com/NixOS/nixpkgs/commit/d76ef7a057d3480ce3e3029411a7686ee0b05819) | `` python312Packages.flask-paginate: format with nixfmt ``                 |
| [`5b950810`](https://github.com/NixOS/nixpkgs/commit/5b950810d762686eba9898f109793e360da1d46c) | `` python312Packages.flask-paginate: refactor ``                           |
| [`6f111441`](https://github.com/NixOS/nixpkgs/commit/6f111441020979315b9ba2bb4d531026ad5cab49) | `` tenki: 1.5.0 -> 1.6.0 ``                                                |
| [`573b674c`](https://github.com/NixOS/nixpkgs/commit/573b674cbab5d844aad989ac3f35171fc93b1a5b) | `` pacu: format with nixfmt ``                                             |
| [`8d24f246`](https://github.com/NixOS/nixpkgs/commit/8d24f24690c3b3107d6c1c5db2e29d062f5bbf86) | `` pacu: disable failing tests ``                                          |
| [`ef4e2f85`](https://github.com/NixOS/nixpkgs/commit/ef4e2f85f1dee5c4ac59f5b92dd3dc6301efa699) | `` pacu: refactor ``                                                       |
| [`49b04c69`](https://github.com/NixOS/nixpkgs/commit/49b04c692749b198dc55f6a2866677b2e6a0e293) | `` pacu: relax pycognito ``                                                |
| [`b97489f0`](https://github.com/NixOS/nixpkgs/commit/b97489f0d249aef35c332efcef2e14763cf35acc) | `` python312Packages.dsnap: format with nixfmt ``                          |
| [`fc19d1f5`](https://github.com/NixOS/nixpkgs/commit/fc19d1f5ed7b5d66607c53a0cedf092e065732bc) | `` python312Packages.dsnap: disable tests ``                               |
| [`63cc6594`](https://github.com/NixOS/nixpkgs/commit/63cc6594d13fca2973d6f31a816eb02210715689) | `` python312Packages.dsnap: refactor ``                                    |
| [`bcfb0c19`](https://github.com/NixOS/nixpkgs/commit/bcfb0c192aa13367ca938bf3843a089805c5434f) | `` python312Packages.mypy-boto3-s3control: 1.34.18 -> 1.34.83 ``           |
| [`abd6a507`](https://github.com/NixOS/nixpkgs/commit/abd6a507e8585362edd6b354f8eea1a6ec562686) | `` python312Packages.mypy-boto3-rds: 1.34.81 -> 1.34.83 ``                 |
| [`3bba05a9`](https://github.com/NixOS/nixpkgs/commit/3bba05a94d7bd94f6d0436b7228353390aa3ec36) | `` python312Packages.mypy-boto3-pipes: 1.34.0 -> 1.34.83 ``                |
| [`c31e63e5`](https://github.com/NixOS/nixpkgs/commit/c31e63e52ac527dbb1d260a6b8cdd82ea7f352bb) | `` python312Packages.mypy-boto3-omics: 1.34.7 -> 1.34.83 ``                |
| [`b989d28c`](https://github.com/NixOS/nixpkgs/commit/b989d28c0bd753d23af8a95dca6aee893cc478b3) | `` python312Packages.mypy-boto3-medialive: 1.34.77 -> 1.34.83 ``           |
| [`ee8ecb12`](https://github.com/NixOS/nixpkgs/commit/ee8ecb1204e7fdaf8f70a44b90a612e639bb2fde) | `` python312Packages.mypy-boto3-iam: 1.34.8 -> 1.34.83 ``                  |
| [`68fac439`](https://github.com/NixOS/nixpkgs/commit/68fac43975ca975be9768b89cc293066a80a94cd) | `` python312Packages.mypy-boto3-codebuild: 1.34.81 -> 1.34.83 ``           |
| [`40f84d06`](https://github.com/NixOS/nixpkgs/commit/40f84d06820c656320e0c573b398cceac443412c) | `` python312Packages.mypy-boto3-cloudwatch: 1.34.75 -> 1.34.83 ``          |
| [`7fb0bdfe`](https://github.com/NixOS/nixpkgs/commit/7fb0bdfe3481f8276542f8f1f075d548c69cc1a7) | `` python312Packages.mypy-boto3-cloudfront: 1.34.0 -> 1.34.83 ``           |
| [`0cc36711`](https://github.com/NixOS/nixpkgs/commit/0cc367117fa4e774e2d810520919cd515ccaf71a) | `` python312Packages.mypy-boto3-batch: 1.34.72 -> 1.34.83 ``               |
| [`1277f7d1`](https://github.com/NixOS/nixpkgs/commit/1277f7d1e109ce84e03b220432cb117d3877df2e) | `` qownnotes: add shell completion ``                                      |
| [`827ce2d1`](https://github.com/NixOS/nixpkgs/commit/827ce2d1f7dd3b54819ade3ef2a99d1923cd036e) | `` python312Packages.gekko: 1.1.0 -> 1.1.1 ``                              |
| [`048cd042`](https://github.com/NixOS/nixpkgs/commit/048cd0429129c6d1df28f15a426edfc9c8099938) | `` python312Packages.junos-eznc: 2.7.0 -> 2.7.1 ``                         |
| [`3674a336`](https://github.com/NixOS/nixpkgs/commit/3674a336f628338a9c92ae27c846240d352223da) | `` audiness: format with nixfmt ``                                         |
| [`851c6dbe`](https://github.com/NixOS/nixpkgs/commit/851c6dbee0352f4524d2c06ca6ca3725ec806c0d) | `` audiness: 0.3.1 -> 0.3.2 ``                                             |
| [`3170cbae`](https://github.com/NixOS/nixpkgs/commit/3170cbaec42edf6c4bf16ba042a52fbb602fa3f3) | `` audiness: refactor ``                                                   |
| [`8f0e4dbb`](https://github.com/NixOS/nixpkgs/commit/8f0e4dbb0b2955d2be6dc298e4fd7fe8e7cbf29d) | `` python312Packages.aiortm: format with nixfmt ``                         |
| [`7c5abad9`](https://github.com/NixOS/nixpkgs/commit/7c5abad9c2191cbc763cf1e9ab3a6f24c2aa4db4) | `` python312Packages.aiortm: refactor ``                                   |
| [`ef2d8247`](https://github.com/NixOS/nixpkgs/commit/ef2d824716da66cb0508879807945595bd3cae4d) | `` python312Packages.flask-paginate: 2024.3.28 -> 2024.4.12 ``             |
| [`7a599203`](https://github.com/NixOS/nixpkgs/commit/7a599203ed822034f292a4c131c9b473b1fe2545) | `` python312Packages.cwl-utils: format with nixfmt ``                      |
| [`c2181bed`](https://github.com/NixOS/nixpkgs/commit/c2181bedc43e49694b04a154707ed2e4ca467126) | `` python312Packages.cwl-utils: 0.32 -> 0.33 ``                            |
| [`d833e87e`](https://github.com/NixOS/nixpkgs/commit/d833e87ebe6d902ff3fd0c809601f548995fa6cf) | `` python312Packages.aioopenexchangerates: 0.4.9 -> 0.4.10 ``              |
| [`9352c673`](https://github.com/NixOS/nixpkgs/commit/9352c673cc419a7b3d5a9f148c231d6ab045dff5) | `` python312Packages.aiortm: 0.8.10 -> 0.8.11 ``                           |
| [`9de6ca85`](https://github.com/NixOS/nixpkgs/commit/9de6ca85c9e3b322653c0df19cb818fcc117c291) | `` python311Packages.clarifai-grpc: format with nixfmt ``                  |
| [`a6090bcf`](https://github.com/NixOS/nixpkgs/commit/a6090bcf94a689e341266117c264a4b2827634c5) | `` foot: 1.17.0 -> 1.17.1 ``                                               |
| [`bce1960d`](https://github.com/NixOS/nixpkgs/commit/bce1960d378b1b6e125b07b6698bc2ecbed3d3e3) | `` gallia: format with nixfmt ``                                           |
| [`26fc75a2`](https://github.com/NixOS/nixpkgs/commit/26fc75a28ec39848eed78532e0799e3ed03bd4e3) | `` gallia: refactor ``                                                     |
| [`f475ccc0`](https://github.com/NixOS/nixpkgs/commit/f475ccc012d7650eb2716fc408d35d5623dea2d9) | `` python312Packages.asf-search: relax tenacity ``                         |
| [`d810505e`](https://github.com/NixOS/nixpkgs/commit/d810505e257f015e2faf7ec6cdcb13460555d543) | `` nuclei-templates: format with nixfmt ``                                 |
| [`8a1afb61`](https://github.com/NixOS/nixpkgs/commit/8a1afb61b8e77b670820d57db3146e55c95ff160) | `` enum4linux-ng: format with nixfmt ``                                    |
| [`4267a48a`](https://github.com/NixOS/nixpkgs/commit/4267a48a590a4e6cc7e643d87ed88400ecd1f53e) | `` josm: 19017 -> 19039 ``                                                 |
| [`12a172cd`](https://github.com/NixOS/nixpkgs/commit/12a172cd2ab2a5d623f9cbb52de1eb0be4c8549e) | `` vscode-extensions.supermaven.supermaven: init at 0.1.42 ``              |
| [`d00e7644`](https://github.com/NixOS/nixpkgs/commit/d00e7644c3e45c04b9e5261a56e783b4c5b2af03) | `` nix-inspect: init at 0.1.0 ``                                           |
| [`484878a0`](https://github.com/NixOS/nixpkgs/commit/484878a0149f1bcbed73581ab78dc1c635c1849c) | `` python312Packages.litellm: 1.34.29 -> 1.35.1 ``                         |
| [`09ec298f`](https://github.com/NixOS/nixpkgs/commit/09ec298fa2387a14a6bd8000ad33499c5c96ae07) | `` check-jsonschema: 0.28.1 -> 0.28.2 ``                                   |
| [`e5ff4069`](https://github.com/NixOS/nixpkgs/commit/e5ff406990d8528ca7dd5531835d0df22618bc70) | `` treesheets: unstable-2024-03-30 -> unstable-2024-04-11 ``               |
| [`7baa0bd9`](https://github.com/NixOS/nixpkgs/commit/7baa0bd9f6e4dbeac5fa5f47ca043dcef75b55e6) | `` optimism: 1.7.2 -> 1.7.3 ``                                             |
| [`d227092b`](https://github.com/NixOS/nixpkgs/commit/d227092b9eb90ba5a67b157393f2eea59d34cbbf) | `` nats-server: 2.10.12 -> 2.10.14 ``                                      |
| [`a4b7371c`](https://github.com/NixOS/nixpkgs/commit/a4b7371c708aeb17e39948c3b635e7e262d7e33c) | `` fishPlugins.done: 1.19.2 -> 1.19.3 ``                                   |
| [`7af1be6d`](https://github.com/NixOS/nixpkgs/commit/7af1be6d39d34e498518a0b4c08b835a0bf68994) | `` boogie: 3.1.3 -> 3.1.4 ``                                               |
| [`a66754f4`](https://github.com/NixOS/nixpkgs/commit/a66754f41a63847de61c1ec12934ac1375498eb3) | `` whisper-ctranslate2: 0.4.1 -> 0.4.2 ``                                  |
| [`5fe89bc9`](https://github.com/NixOS/nixpkgs/commit/5fe89bc95dc792594446c435036815c3ffecb466) | `` afio: darwin build ``                                                   |
| [`c4e53810`](https://github.com/NixOS/nixpkgs/commit/c4e5381072c3b41e759eb5ce7bc985391f9180d6) | `` unifi: remove unifiLTS, unifi5, unifi6 ``                               |
| [`d5514f48`](https://github.com/NixOS/nixpkgs/commit/d5514f487793d06143aaf345fab01304f427e052) | `` python312Packages.httpsig: propagate setuptools ``                      |
| [`078dca4b`](https://github.com/NixOS/nixpkgs/commit/078dca4b1e60f1fcd6f6f0c5017e76d532032c62) | `` aewan: fix darwin build ``                                              |
| [`85af3e0c`](https://github.com/NixOS/nixpkgs/commit/85af3e0c8975317c8c86b8210bdd46d47aa3ce95) | `` home-assistant-custom-components.homematicip_local: 1.58.0 -> 1.59.0 `` |
| [`e0e03c7b`](https://github.com/NixOS/nixpkgs/commit/e0e03c7b5004f0ecc2c812ae96ff830b6076d05e) | `` python312Packages.hahomematic: 2024.3.1 -> 2024.4.6 ``                  |
| [`c0dcad2a`](https://github.com/NixOS/nixpkgs/commit/c0dcad2a9215516af09bc98e2a3cf9aa59ff4577) | `` enum4linux-ng: 1.3.2 -> 1.3.3 ``                                        |
| [`fb904290`](https://github.com/NixOS/nixpkgs/commit/fb9042903e20e3b77b94dfd7cc225fc083562988) | `` crossplane-cli: 1.15.1 -> 1.15.2 ``                                     |
| [`26222216`](https://github.com/NixOS/nixpkgs/commit/262222169f97ad43ed7a2c5bc58f1db034b3dcf4) | `` nixos/kubeswitch: init ``                                               |
| [`e44c60eb`](https://github.com/NixOS/nixpkgs/commit/e44c60ebad02e3217ca7e7db08f0ea90b4829889) | `` kubeswitch: fix package ``                                              |
| [`50e1ce4c`](https://github.com/NixOS/nixpkgs/commit/50e1ce4c3b39e7933c7b6d698bc6a8c6356f4251) | `` webkitgtk: 2.44.0 → 2.44.1 ``                                           |
| [`9857fcde`](https://github.com/NixOS/nixpkgs/commit/9857fcdec98ab3823c214d38315378611b010b70) | `` auth0-cli: disable failing tests ``                                     |
| [`b64d76aa`](https://github.com/NixOS/nixpkgs/commit/b64d76aa6cc182aeb7fb90fdfc1d2d875a5d9483) | `` vscode-extensions.asvetliakov.vscode-neovim: 1.7.1 -> 1.8.1 ``          |
| [`292380fc`](https://github.com/NixOS/nixpkgs/commit/292380fc3404beb4474bd60e86393150eaa4e974) | `` nuclei-templates: 9.8.0 -> 9.8.1 ``                                     |
| [`d10683ac`](https://github.com/NixOS/nixpkgs/commit/d10683ac2429047fdcebfb079860bef6dfca157b) | `` python312Packages.pyftdi: format with nixfmt ``                         |
| [`71c63c8c`](https://github.com/NixOS/nixpkgs/commit/71c63c8ca82a04b1b1c0847aa471fb9d7bf1ae6f) | `` python312Packages.pyftdi: refactor ``                                   |
| [`4051fb8e`](https://github.com/NixOS/nixpkgs/commit/4051fb8e761872855e6247965aad6632bca1355d) | `` python312Packages.pyftdi: 0.55.0 -> 0.55.4 ``                           |
| [`54758179`](https://github.com/NixOS/nixpkgs/commit/5475817996d3d3487557284d76ca719db54d1a72) | `` corrscope: Switch to regular ffmpeg ``                                  |
| [`200c034c`](https://github.com/NixOS/nixpkgs/commit/200c034c85d1558b35cbe8ea62154a1fb7ed7ca1) | `` python312Packages.std-uritemplate: format with nixfmt ``                |
| [`50b7b857`](https://github.com/NixOS/nixpkgs/commit/50b7b8575496aea55cb8da449ae583a7cbbb3ca4) | `` python312Packages.std-uritemplate: refactor ``                          |
| [`156e1d69`](https://github.com/NixOS/nixpkgs/commit/156e1d697bee46ec4907cc165c8f06b8f0578edd) | `` python312Packages.std-uritemplate: 0.0.55 -> 0.0.56 ``                  |
| [`7b601d9c`](https://github.com/NixOS/nixpkgs/commit/7b601d9ca4205dd5571cdb1e2cd245ecd63d6f14) | `` python312Packages.boto3-stubs: 1.34.81 -> 1.34.83 ``                    |
| [`b5e88b7a`](https://github.com/NixOS/nixpkgs/commit/b5e88b7ad02cf6de20ea11dd426a5b411a80c536) | `` python312Packages.sievelib: format with nixfmt ``                       |
| [`a85a635d`](https://github.com/NixOS/nixpkgs/commit/a85a635d2d57a77b70dd122e5939abc53df2c609) | `` python312Packages.sievelib: refactor ``                                 |
| [`ad5b7186`](https://github.com/NixOS/nixpkgs/commit/ad5b7186b0664712373a34134199eabffa4defbd) | `` python312Packages.asf-search: format with nixfmt ``                     |
| [`8db206c6`](https://github.com/NixOS/nixpkgs/commit/8db206c6ebebcf3c615e1042ca5b31089c7d44a8) | `` python312Packages.asf-search: refactor ``                               |
| [`53f191b8`](https://github.com/NixOS/nixpkgs/commit/53f191b808a2493a54077baac77f926aab50c1bf) | `` python312Packages.exchangelib: format with nixfmt ``                    |
| [`53b52b8a`](https://github.com/NixOS/nixpkgs/commit/53b52b8ac59f1e48a3c0bd339f34c7f0cdeaa3ed) | `` android-studio: fix emulator ``                                         |
| [`3a8eaa54`](https://github.com/NixOS/nixpkgs/commit/3a8eaa5405374eca242c44efa62617046536a0b8) | `` bitbake-language-server: 0.0.8 -> 0.0.14 ``                             |
| [`d0b73a35`](https://github.com/NixOS/nixpkgs/commit/d0b73a3518fc301f2774b9bc6cb7a054b6720bad) | `` uuu: 1.5.141 -> 1.5.179 ``                                              |
| [`3f563e3b`](https://github.com/NixOS/nixpkgs/commit/3f563e3b755177f0bb35d712674c9d4252b55e76) | `` corrscope: Migrate to by-name ``                                        |
| [`94bc20ad`](https://github.com/NixOS/nixpkgs/commit/94bc20ad0f8f8f09dc115d10739f15f5f0bf11ed) | `` corrscope: 0.8.1 -> 0.9.0 ``                                            |
| [`315c0106`](https://github.com/NixOS/nixpkgs/commit/315c01069b0d95f9368195b3772305862d56ac8b) | `` qownnotes: 24.4.0 -> 24.4.1 ``                                          |
| [`4b3c66aa`](https://github.com/NixOS/nixpkgs/commit/4b3c66aa1e4d604e362c7013777d213aa27e1deb) | `` python311Packages.snakemake-interface-common: 1.17.1 -> 1.17.2 ``       |
| [`59a85588`](https://github.com/NixOS/nixpkgs/commit/59a8558857d1035a98988fd23ab190e82ba332c3) | `` python312Packages.sievelib: 1.3.0 -> 1.4.0 ``                           |
| [`1a963976`](https://github.com/NixOS/nixpkgs/commit/1a96397699e9a523736e0e603adcfb62cb6d2e1d) | `` python312Packages.fyta-cli: 0.3.5 -> 0.4.0 ``                           |
| [`98d520fb`](https://github.com/NixOS/nixpkgs/commit/98d520fb5e9f0a513d0efcd1f9d460f4495d1775) | `` python312Packages.exchangelib: 5.2.0 -> 5.2.1 ``                        |
| [`f9a4ebe0`](https://github.com/NixOS/nixpkgs/commit/f9a4ebe0580f63c5d616382044722a16790322f0) | `` commitizen: 3.21.3 -> 3.22.0 ``                                         |
| [`ce4dcefd`](https://github.com/NixOS/nixpkgs/commit/ce4dcefd17f0cd0d373d95dcdb313a87ea01a2dd) | `` blackfire: 2.26.1 -> 2.26.3 ``                                          |
| [`fc019034`](https://github.com/NixOS/nixpkgs/commit/fc019034528c5150e919a6c72799b805575b0618) | `` prusa-slicer: 2.7.3 -> 2.7.4 ``                                         |
| [`8d935aae`](https://github.com/NixOS/nixpkgs/commit/8d935aae937375cbb2e882550a71317f83214982) | `` lighttpd: enable debug info ``                                          |
| [`d6a67aa6`](https://github.com/NixOS/nixpkgs/commit/d6a67aa67827b624bc858e0b3b4bab8311a612c5) | `` avrdude: add libserialport dependency ``                                |
| [`c904aafd`](https://github.com/NixOS/nixpkgs/commit/c904aafde9dcac79a8848ebec9f0d451c91f6e33) | `` readarr: 0.3.21.2475 -> 0.3.22.2499 ``                                  |
| [`a399db43`](https://github.com/NixOS/nixpkgs/commit/a399db43527b481d2af275ba058a4dc1d36ed373) | `` php81Extensions.opentelemetry: 1.0.1 -> 1.0.2 ``                        |
| [`3167f1de`](https://github.com/NixOS/nixpkgs/commit/3167f1dea348d1b9749964af978e41d268a8108c) | `` kde/gear: 24.02.1 -> 24.02.2 ``                                         |
| [`22865a32`](https://github.com/NixOS/nixpkgs/commit/22865a32c655520718d11614aaf7019783d8a3a1) | `` asahi-wifisync: init at 0.2.0 ``                                        |
| [`5838eddf`](https://github.com/NixOS/nixpkgs/commit/5838eddf77e2121717db4292f0620d76667f8660) | `` asahi-btsync: init at 0.2.0 ``                                          |
| [`5d5d9bb3`](https://github.com/NixOS/nixpkgs/commit/5d5d9bb3db5483a5649d53084726768f6d4fff49) | `` asahi-bless: init at 0.3.0 ``                                           |
| [`9db50798`](https://github.com/NixOS/nixpkgs/commit/9db507982c26f50152d073cc818149de3cb42994) | `` asahi-nvram: init at 0.2.1 ``                                           |
| [`229a9745`](https://github.com/NixOS/nixpkgs/commit/229a97457054f259ddf2c48a80f297bf403cd2cc) | `` mountpoint-s3: 1.5.0 -> 1.6.0 ``                                        |