### PR TITLE
chore(flake/ludovico-nixpkgs): `6ce00080` -> `72bd8e69`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -935,11 +935,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712780366,
-        "narHash": "sha256-Qw3OO53+P7K5Fhersat2vxyPH6F2MGrwQn/cD9LrevY=",
+        "lastModified": 1713022072,
+        "narHash": "sha256-QC5S3EN9yYQjvHPX0onOvTcKTvSP9SPmX4HE/EZ8aUc=",
         "owner": "LudovicoPiero",
         "repo": "nixpackages",
-        "rev": "6ce0008094502733f3590ef5c2abc33fc0c0516d",
+        "rev": "72bd8e695fcdc85a7869d432c13ed803decaf4a9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                          |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
| [`72bd8e69`](https://github.com/LudovicoPiero/nixpackages/commit/72bd8e695fcdc85a7869d432c13ed803decaf4a9) | `` iosevka-q: 29.1.0 -> 29.2.0 ``                |
| [`bc2963f1`](https://github.com/LudovicoPiero/nixpackages/commit/bc2963f1e33a7fe8b5fc9ccad9d7def0b2ae314c) | `` chore(flake/nixpkgs): 4cba8b53 -> 1042fd8b `` |