### PR TITLE
chore(flake/hyprland): `0c513ba9` -> `9e4b2efe`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -687,11 +687,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712951181,
-        "narHash": "sha256-Am+Jl/pDkVuZxyiBEAw1Ia5/dDRi5HOIYBT/kTT6uKA=",
+        "lastModified": 1713015628,
+        "narHash": "sha256-bB/dALMilF7vC4sE4nNhyUl8pIGSZAfQOqPLQ5kg40I=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "0c513ba91bd73106be99e35b1a020d24e5ae874a",
+        "rev": "9e4b2efe7e24f7b21faefbd50a88f25b5185bc35",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                   |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
| [`9e4b2efe`](https://github.com/hyprwm/Hyprland/commit/9e4b2efe7e24f7b21faefbd50a88f25b5185bc35) | `` cmake: Some small cmake cleanups (#5572) ``                            |
| [`d9650144`](https://github.com/hyprwm/Hyprland/commit/d96501442fb3bbec129e74e26f379898f15881e2) | `` core: Fix double special workspace (#5574) ``                          |
| [`582d6233`](https://github.com/hyprwm/Hyprland/commit/582d6233c802327fea45a14d146e7cbab5fe4b1e) | `` workspace: fix workspace name selector returning true early (#5571) `` |
| [`34396f55`](https://github.com/hyprwm/Hyprland/commit/34396f55a283e5fe332ed7e1b8fd814840808ae5) | `` master: change the mfact dispatcher to use splitratio (#4766) ``       |