### PR TITLE
chore(flake/home-manager): `31357486` -> `8fdf3295`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712759992,
-        "narHash": "sha256-2APpO3ZW4idlgtlb8hB04u/rmIcKA8O7pYqxF66xbNY=",
+        "lastModified": 1713019815,
+        "narHash": "sha256-jzTo97VeKMNfnKw3xU+uiU5C7wtnLudsbwl/nwPLC7s=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "31357486b0ef6f4e161e002b6893eeb4fafc3ca9",
+        "rev": "8fdf329526f06886b53b94ddf433848a0d142984",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                      |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
| [`8fdf3295`](https://github.com/nix-community/home-manager/commit/8fdf329526f06886b53b94ddf433848a0d142984) | `` neovim: enable use of external package manager (#5225) `` |
| [`40ab43ae`](https://github.com/nix-community/home-manager/commit/40ab43ae98cb3e6f07eaeaa3f3ed56d589da21b0) | `` foot: set PATH in server's systemd unit file ``           |