### PR TITLE
chore(flake/emacs-overlay): `9f440671` -> `ea70f9df`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1712941527,
-        "narHash": "sha256-wD9XQFGW0qzRW1YHj6oklCHzgKNxjwS0tZ/hFGgiHX4=",
+        "lastModified": 1713027173,
+        "narHash": "sha256-DY+Xldj7rvQIjuCthMIzWI+P0Vv5g5d5B46lBp1vwUo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "9f4406718ada7af83892e17355ef7fd202c20897",
+        "rev": "ea70f9df1ff67d1b37abd0893959ff315a599517",
         "type": "github"
       },
       "original": {
@@ -1255,11 +1255,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1712741485,
-        "narHash": "sha256-bCs0+MSTra80oXAsnM6Oq62WsirOIaijQ/BbUY59tR4=",
+        "lastModified": 1712867921,
+        "narHash": "sha256-edTFV4KldkCMdViC/rmpJa7oLIU8SE/S35lh/ukC7bg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b2cf36f43f9ef2ded5711b30b1f393ac423d8f72",
+        "rev": "51651a540816273b67bc4dedea2d37d116c5f7fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`ea70f9df`](https://github.com/nix-community/emacs-overlay/commit/ea70f9df1ff67d1b37abd0893959ff315a599517) | `` Updated melpa ``        |
| [`86e121f2`](https://github.com/nix-community/emacs-overlay/commit/86e121f22763f18336d18980dd5d9a1d554a6874) | `` Updated elpa ``         |
| [`4163cf55`](https://github.com/nix-community/emacs-overlay/commit/4163cf558682e33b06b3ceaada03161d687edaf7) | `` Updated nongnu ``       |
| [`cedcee8e`](https://github.com/nix-community/emacs-overlay/commit/cedcee8ed57f4f715e487c1a35b06745f7f54cf8) | `` Updated flake inputs `` |
| [`f3745199`](https://github.com/nix-community/emacs-overlay/commit/f3745199a37f2a6196d1d98a7912cd70e318aa7d) | `` Updated emacs ``        |
| [`6c6d6be1`](https://github.com/nix-community/emacs-overlay/commit/6c6d6be17dbbe0204d9c3b32f458b2658be64d57) | `` Updated melpa ``        |
| [`6436aa6e`](https://github.com/nix-community/emacs-overlay/commit/6436aa6e70126e1cc401eec83a5ab9c909cf1708) | `` Updated emacs ``        |
| [`3b76a907`](https://github.com/nix-community/emacs-overlay/commit/3b76a907042b19ec237fe870f65a3e3595e47383) | `` Updated melpa ``        |
| [`a27b0ec3`](https://github.com/nix-community/emacs-overlay/commit/a27b0ec305e09e9de940b37a2eec44eb764adeac) | `` Updated elpa ``         |