### PR TITLE
chore(flake/nixpkgs-master): `cfd6b5fc` -> `1dd996e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1224,11 +1224,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1712963716,
-        "narHash": "sha256-WKm9CvgCldeIVvRz87iOMi8CFVB1apJlkUT4GGvA0iM=",
+        "lastModified": 1713027899,
+        "narHash": "sha256-YG3U+PuZDycqId/irugEVkxoeW++CZl/Vv4wPmQV5e0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cfd6b5fc90b15709b780a5a1619695a88505a176",
+        "rev": "1dd996e59a5e67694b7a252aacba71a88d51b41e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
| [`1dd996e5`](https://github.com/NixOS/nixpkgs/commit/1dd996e59a5e67694b7a252aacba71a88d51b41e) | `` aichat: 0.15.0 -> 0.16.0 ``                                                                                                  |
| [`6bb72e79`](https://github.com/NixOS/nixpkgs/commit/6bb72e79f7dc29fab08fed730b5b7fe7df031a9e) | `` tootik: 0.9.6 -> 0.10.0 ``                                                                                                   |
| [`e9e9bc94`](https://github.com/NixOS/nixpkgs/commit/e9e9bc94505ad57db4e6179127979ad76d065d52) | `` pspg: 5.8.2 -> 5.8.3 ``                                                                                                      |
| [`8945f3e5`](https://github.com/NixOS/nixpkgs/commit/8945f3e5ff3aec60dba4103bd682e89ddf14cc32) | `` clash-geoip: 20240312 -> 20240412 ``                                                                                         |
| [`ee64a5f3`](https://github.com/NixOS/nixpkgs/commit/ee64a5f3ea5ea4c4ef7820a9bda41c16cd1c9ae4) | `` mdadm: fix build on musl (#303565) ``                                                                                        |
| [`d4d3f045`](https://github.com/NixOS/nixpkgs/commit/d4d3f04593f763992e9dd435e739c28d966d0ad2) | `` dablin: 1.15.0 -> 1.16.0 ``                                                                                                  |
| [`c5df2aec`](https://github.com/NixOS/nixpkgs/commit/c5df2aec81103e6952edbfd9dea170de7ae2114a) | `` supabase-cli: 1.155.1 -> 1.156.3 ``                                                                                          |
| [`384eea2f`](https://github.com/NixOS/nixpkgs/commit/384eea2fd8ae07e668562ea07ccf1edcff9fa8bb) | `` eigenlayer: 0.7.0 -> 0.7.2 ``                                                                                                |
| [`5f44f017`](https://github.com/NixOS/nixpkgs/commit/5f44f017908819f7bc73a006a5977fa0b037f6f4) | `` cargo-tarpaulin: 0.27.3 -> 0.28.0 ``                                                                                         |
| [`6fe34562`](https://github.com/NixOS/nixpkgs/commit/6fe3456226e1f499e1c48a2122e4a49a4f8d1c40) | `` linux_4_19: 4.19.311 -> 4.19.312 ``                                                                                          |
| [`f17c4548`](https://github.com/NixOS/nixpkgs/commit/f17c4548922207b3f0c19f35a0a75fdda3abb959) | `` linux_5_4: 5.4.273 -> 5.4.274 ``                                                                                             |
| [`a3417d10`](https://github.com/NixOS/nixpkgs/commit/a3417d10886bf3e89a6fec82f5617848607d305b) | `` linux_5_10: 5.10.214 -> 5.10.215 ``                                                                                          |
| [`5491d76e`](https://github.com/NixOS/nixpkgs/commit/5491d76e0ed0d658a94b8f42d27de4b093a52278) | `` linux_5_15: 5.15.154 -> 5.15.155 ``                                                                                          |
| [`11568449`](https://github.com/NixOS/nixpkgs/commit/11568449f1adb0b9b82427fe41ea9fc01fd87029) | `` linux_6_1: 6.1.85 -> 6.1.86 ``                                                                                               |
| [`d20461f6`](https://github.com/NixOS/nixpkgs/commit/d20461f6b72aebdba324897c4d95fa60e4dfa5db) | `` linux_6_6: 6.6.26 -> 6.6.27 ``                                                                                               |
| [`83084587`](https://github.com/NixOS/nixpkgs/commit/83084587f4e993c87cfc435dff58e208195ea4ba) | `` linux_6_8: 6.8.5 -> 6.8.6 ``                                                                                                 |
| [`1504f79f`](https://github.com/NixOS/nixpkgs/commit/1504f79fdfc46f0070d8ce814f2de4fec97b87ea) | `` linuxManualConfig: Sometimes depend on ubootTools ``                                                                         |
| [`92d4fc3a`](https://github.com/NixOS/nixpkgs/commit/92d4fc3a4ce2a3019300d6727eaac69c07931a63) | `` linux/common-config: enable ZRAM_MULTI_COMP where available ``                                                               |
| [`c531d97b`](https://github.com/NixOS/nixpkgs/commit/c531d97bf84d91868a5e22686cf0994bca0e7b44) | `` samba: work around reproducible-builds issue ``                                                                              |
| [`29ef3d58`](https://github.com/NixOS/nixpkgs/commit/29ef3d58b59eb6edec31999d3acf4b07787d32ca) | `` nixos/coolercontrol: Add support for Nvidia hardware ``                                                                      |
| [`bbc0a5ee`](https://github.com/NixOS/nixpkgs/commit/bbc0a5ee52707169d9ffb9f6eb840c4a9c426e1d) | `` coolercontrol.coolercontrold: Hardcode a shell ``                                                                            |
| [`5bb6726e`](https://github.com/NixOS/nixpkgs/commit/5bb6726e849ca19a2824a4d53e3135a9f991b7a8) | `` coolercontrol.*: 1.1.1 -> 1.2.2 ``                                                                                           |
| [`7988aa59`](https://github.com/NixOS/nixpkgs/commit/7988aa599941dbbaa65c592555df0b9175afab68) | `` ast-grep: 0.20.3 -> 0.20.5 ``                                                                                                |
| [`78dc094c`](https://github.com/NixOS/nixpkgs/commit/78dc094cbae0863e87878a2525f8a5d6294b083f) | `` cargo-about: 0.6.0 -> 0.6.1 ``                                                                                               |
| [`d6733d93`](https://github.com/NixOS/nixpkgs/commit/d6733d933ddce467d1b1d12e9265eb205c23fcdd) | `` rerun: nixfmt ``                                                                                                             |
| [`7c74092a`](https://github.com/NixOS/nixpkgs/commit/7c74092ad1e31bdd1bab14f906852851723f2253) | `` rerun: fix the broken test ``                                                                                                |
| [`f70de388`](https://github.com/NixOS/nixpkgs/commit/f70de388b186e4e9f7a8370dad55e79958721401) | `` ngtcp2: 1.2.0 -> 1.4.0 ``                                                                                                    |
| [`128d8fb7`](https://github.com/NixOS/nixpkgs/commit/128d8fb72d64355cb6d7080d65f1941f4bb14d82) | `` nghttp3: 1.1.0 -> 1.2.0 ``                                                                                                   |
| [`bfc8ad76`](https://github.com/NixOS/nixpkgs/commit/bfc8ad764fa14cb69181b1f4f93b9a4f8e5c584b) | `` devenv: 1.0.3 -> 1.0.4 ``                                                                                                    |
| [`feb75846`](https://github.com/NixOS/nixpkgs/commit/feb75846b5c57626b6b2e97d7c59c4561101dc25) | `` osu-lazer: 2024.312.1 -> 2024.412.1 ``                                                                                       |
| [`7b93ea96`](https://github.com/NixOS/nixpkgs/commit/7b93ea965ef33e48e106501a70b65aec4e66c76f) | `` osu-lazer-bin: 2024.312.1 -> 2024.412.1 ``                                                                                   |
| [`6a70b734`](https://github.com/NixOS/nixpkgs/commit/6a70b734eecd7e74970b360558995c78133772b6) | `` simdutf: 5.2.3 -> 5.2.4 ``                                                                                                   |
| [`f9bd870b`](https://github.com/NixOS/nixpkgs/commit/f9bd870b18735149357e47e1cb80ccb99192ab64) | `` typos: 1.20.4 -> 1.20.8 ``                                                                                                   |
| [`b56fccdf`](https://github.com/NixOS/nixpkgs/commit/b56fccdf5f34af076e61b8e088f215a359cebf46) | `` home-assistant-components.midea-air-appliances-lan: 0.9.2 -> 0.9.4 ``                                                        |
| [`1d9a0f56`](https://github.com/NixOS/nixpkgs/commit/1d9a0f56f488a2ad1c8ad7492075b4255bdb53be) | `` python312Packages.oncalendar: 1.0 -> 1.1 ``                                                                                  |
| [`96eb78b8`](https://github.com/NixOS/nixpkgs/commit/96eb78b80ccb9f6bda7aebee58017638d757218b) | `` anilibria-winmaclinux: 1.2.15 -> 1.2.16.1 ``                                                                                 |
| [`76bf98fc`](https://github.com/NixOS/nixpkgs/commit/76bf98fc84101acca507c7828cb1d139f8ad42da) | `` ansible-lint: 24.2.1 -> 24.2.2 ``                                                                                            |
| [`4773a144`](https://github.com/NixOS/nixpkgs/commit/4773a1441623156fa192e415d5812592f5cd9157) | `` vimPlugins.grapple-nvim: init at 2024-04-09 ``                                                                               |
| [`4c7b61ce`](https://github.com/NixOS/nixpkgs/commit/4c7b61ce7918eb8d0cae28e0f7fff571593327d5) | `` streamlink-twitch-gui-bin: copyDesktopItems ``                                                                               |
| [`bdfd7e0b`](https://github.com/NixOS/nixpkgs/commit/bdfd7e0bce6202e95f323b1bbc9643853562db30) | `` wireproxy: 1.0.7 -> 1.0.8 ``                                                                                                 |
| [`d3ea189a`](https://github.com/NixOS/nixpkgs/commit/d3ea189a5aa8e0959757555a9368535a286eebef) | `` xh: 0.21.0 -> 0.22.0 ``                                                                                                      |
| [`dc646e04`](https://github.com/NixOS/nixpkgs/commit/dc646e04c4329e97e52416a54305c80d2281ca64) | `` maintainers: add nayala ``                                                                                                   |
| [`d3992ec2`](https://github.com/NixOS/nixpkgs/commit/d3992ec28ba6dce0fc0e033e96ec985cb41a79d4) | `` hidviz: Init at 0.2 ``                                                                                                       |
| [`155c0656`](https://github.com/NixOS/nixpkgs/commit/155c06562e4ddf9c105eb3e28869ad2dfa2e1ac7) | `` nerdfonts: 3.2.0 -> 3.2.1 ``                                                                                                 |
| [`b0f90fa4`](https://github.com/NixOS/nixpkgs/commit/b0f90fa4e6fd556821e4d11b5ab0de55fded24d2) | `` flake-checker: 0.1.17 -> 0.1.18 ``                                                                                           |
| [`cda13204`](https://github.com/NixOS/nixpkgs/commit/cda1320493236bc638dc3fea4c484ddd50e943f9) | `` api-linter: 1.64.0 -> 1.65.0 ``                                                                                              |
| [`8403200f`](https://github.com/NixOS/nixpkgs/commit/8403200fc5db423a8394124298fced49f1a8d7d2) | `` python312Packages.whirlpool-sixth-sense: 0.18.7 -> 0.18.8 ``                                                                 |
| [`4801ec1d`](https://github.com/NixOS/nixpkgs/commit/4801ec1d5b358307f77d9b1187c7c5746f5ddc87) | `` python312Packages.pytest-aio: format with nixfmt ``                                                                          |
| [`36ba4c15`](https://github.com/NixOS/nixpkgs/commit/36ba4c15c79b70d624abac78c72ce3852561c519) | `` python312Packages.pytest-aio: 1.5.0 -> 1.8.1 ``                                                                              |
| [`b542a3f1`](https://github.com/NixOS/nixpkgs/commit/b542a3f147c363748af9ad438ac44f0f0be6b7b5) | `` python312Packages.playwrightcapture: format with nixfmt ``                                                                   |
| [`2be4b0ca`](https://github.com/NixOS/nixpkgs/commit/2be4b0cafedd352692719b5da4617db32ca69f04) | `` python312Packages.playwrightcapture: refactor ``                                                                             |
| [`5d0de9ac`](https://github.com/NixOS/nixpkgs/commit/5d0de9ac816e3439deace0ccd572b74c2ce71082) | `` python312Packages.playwrightcapture: 1.24.2 -> 1.24.3 ``                                                                     |
| [`782fc2eb`](https://github.com/NixOS/nixpkgs/commit/782fc2ebac4bb51f6d86f9e998143585edc7d212) | `` llvmPackages_{12,13,14,15,16,17,18,git}: use common libcxx ``                                                                |
| [`f877a574`](https://github.com/NixOS/nixpkgs/commit/f877a5740248a5b6962e8c52beb5f08bd9c99f4d) | `` python312Packages.publicsuffixlist: 0.10.0.20240411 -> 0.10.0.20240412 ``                                                    |
| [`08901bd1`](https://github.com/NixOS/nixpkgs/commit/08901bd1f7623a538b26445a00be97b8b8ef6f71) | `` sqlfluff: format with nixfmt ``                                                                                              |
| [`5ae151de`](https://github.com/NixOS/nixpkgs/commit/5ae151de0e8c37204bcbd2ddc35ae246c4c86ddb) | `` limesuite: disable gui by default and add limesuiteWithGui ``                                                                |
| [`487ebcad`](https://github.com/NixOS/nixpkgs/commit/487ebcad6fac8b6a7328143868acaa44605ad93f) | `` trunk-io: 1.3.0 -> 1.3.1 ``                                                                                                  |
| [`6d56dcdb`](https://github.com/NixOS/nixpkgs/commit/6d56dcdbb040a11c29da751ad0aaa9103e210223) | `` python312Packages.tencentcloud-sdk-python: 3.0.1127 -> 3.0.1128 ``                                                           |
| [`10065462`](https://github.com/NixOS/nixpkgs/commit/100654623a4af365e95c591d171ce4dd2c4cf8d7) | `` python312Packages.llama-index-readers-s3: format with nixfmt ``                                                              |
| [`0aef7076`](https://github.com/NixOS/nixpkgs/commit/0aef707601feae5eaabb767da6888e6b0b63918a) | `` python312Packages.llama-index-readers-s3: 0.1.5 -> 0.1.7 ``                                                                  |
| [`bb9843af`](https://github.com/NixOS/nixpkgs/commit/bb9843af722be48609a79199d5d30ba2e0528a2a) | `` python312Packages.llamaindex-py-client: 0.1.16 -> 0.1.18 ``                                                                  |
| [`ab40cb6e`](https://github.com/NixOS/nixpkgs/commit/ab40cb6eba7ce6402d993214acc42d6b9aa86e5f) | `` python312Packages.boto3-stubs: format with nixfmt ``                                                                         |
| [`e305a837`](https://github.com/NixOS/nixpkgs/commit/e305a83762107fb91a88f49bad0ad43c81cea55e) | `` python312Packages.boto3-stubs: refactor ``                                                                                   |
| [`a0372d53`](https://github.com/NixOS/nixpkgs/commit/a0372d53fdc61b136979deaa47ddc4734c95bd05) | `` python312Packages.boto3-stubs: 1.34.83 -> 1.34.84 ``                                                                         |
| [`c6e4e722`](https://github.com/NixOS/nixpkgs/commit/c6e4e7221879e24ef98ee8adf7b77eabd2251070) | `` php83: 8.3.4 -> 8.3.6, fix CVE-2024-2756, CVE-2024-3096, CVE-2024-2757 ``                                                    |
| [`147dffac`](https://github.com/NixOS/nixpkgs/commit/147dffac94cb987f6b91c74b93ed32b6eb390bcc) | `` php82: 8.2.17 -> 8.2.18, fix CVE-2024-2756, CVE-2024-3096 ``                                                                 |
| [`d12c76c7`](https://github.com/NixOS/nixpkgs/commit/d12c76c716f4494ff3b95b3e0d5977b267285baa) | `` php81: 8.1.27 -> 8.1.28, fix CVE-2024-2756, CVE-2024-3096 ``                                                                 |
| [`31226468`](https://github.com/NixOS/nixpkgs/commit/312264686e6e803fbe5c2b1b6b1dc1815166f13a) | `` llvmPackages_{12,13,14,15,16,17,18,git}: use common compiler-rt ``                                                           |
| [`ac27f7ca`](https://github.com/NixOS/nixpkgs/commit/ac27f7cab1a38101204f68b7bb6488266511e1eb) | `` treewide: remove unused copyDesktopItems from some packages ``                                                               |
| [`40e6d7af`](https://github.com/NixOS/nixpkgs/commit/40e6d7af2e2da507f725beefa087ec2cd57f7ff9) | `` lomiri.u1db-qt: Fix pkg-config file ``                                                                                       |
| [`5cdbc4e2`](https://github.com/NixOS/nixpkgs/commit/5cdbc4e2d07478e2cc3b4d537badf5d340504f53) | `` rPackages.epialleleR: fix build ``                                                                                           |
| [`973c61c6`](https://github.com/NixOS/nixpkgs/commit/973c61c6a7a521193615d3fb6cd65d73705fb8d4) | `` where-is-my-sddm-theme: 1.8.0 -> 1.9.0 ``                                                                                    |
| [`7c2df2d4`](https://github.com/NixOS/nixpkgs/commit/7c2df2d4b048da7f0e8bfd28a7e5f9edea11227b) | `` syft: 1.1.1 -> 1.2.0 ``                                                                                                      |
| [`91787e50`](https://github.com/NixOS/nixpkgs/commit/91787e50c18badc93c55b929f2791480766ecb96) | `` nixops-digitalocean: rename python-digitalocean ``                                                                           |
| [`8fc4a6f1`](https://github.com/NixOS/nixpkgs/commit/8fc4a6f148a9ad49a7f369627e251e71ebafa87c) | `` rustywind: 0.21.1 -> 0.22.0 ``                                                                                               |
| [`425c8101`](https://github.com/NixOS/nixpkgs/commit/425c8101a9e9a484a2b109cf8e3aa34ed94f7cd6) | `` lomiri.trust-store: Fix references variable in pkg-config ``                                                                 |
| [`d744c7d8`](https://github.com/NixOS/nixpkgs/commit/d744c7d85a699e28d7cca4c3f3aba4b91800560c) | `` home-assistant: update component-packages ``                                                                                 |
| [`82dfc5fa`](https://github.com/NixOS/nixpkgs/commit/82dfc5fa5fa72b3e620bb7eb307c6e557cd1fac6) | `` python312Packages.python-digitalocean: rename from digital-ocean ``                                                          |
| [`e7e00f90`](https://github.com/NixOS/nixpkgs/commit/e7e00f901ddc5f1f800358118225e3c879fed583) | `` python312Packages.pex: 2.3.0 -> 2.3.1 ``                                                                                     |
| [`0bc4989d`](https://github.com/NixOS/nixpkgs/commit/0bc4989d4ac407c3c2c46b9b9e9a6691da795f03) | `` qownnotes: 24.4.1 -> 24.4.2 ``                                                                                               |
| [`6364a02b`](https://github.com/NixOS/nixpkgs/commit/6364a02b3cc381ed6a8405926a2573b05bd5f10b) | `` python312Packages.dataprep-ml: 0.0.22 -> 0.0.23 ``                                                                           |
| [`2f318100`](https://github.com/NixOS/nixpkgs/commit/2f318100a667e0e370e15b522c973ad49602b181) | `` wayfarer: init at 1.2.4 ``                                                                                                   |
| [`b416c322`](https://github.com/NixOS/nixpkgs/commit/b416c3227cd05f9a9963b73a6b3f3c2f19926959) | `` python312Packages.digital-ocean: format with nixfmt ``                                                                       |
| [`7fd40460`](https://github.com/NixOS/nixpkgs/commit/7fd404603e3b7d4cdac2f91e3b43c0200e39ef20) | `` python312Packages.digital-ocean: refactor ``                                                                                 |
| [`ac9cc54c`](https://github.com/NixOS/nixpkgs/commit/ac9cc54ca0110354a92687490c92edb482d93a98) | `` tegola: enable viewer ``                                                                                                     |
| [`64483813`](https://github.com/NixOS/nixpkgs/commit/64483813c27b995203b0eee30f25fb0152ebf484) | `` tegola: migrate to by-name ``                                                                                                |
| [`59da012b`](https://github.com/NixOS/nixpkgs/commit/59da012b5b2491d14b4ba064efd0479e55a4ca3c) | `` tegola: add geospatial team to maintainers ``                                                                                |
| [`421bd7e5`](https://github.com/NixOS/nixpkgs/commit/421bd7e5db610a1a301933f12d719b9fbc74c457) | `` tegola: 0.19.0 -> 0.20.0 ``                                                                                                  |
| [`33fc340c`](https://github.com/NixOS/nixpkgs/commit/33fc340c955eecd57442a8f63cefb41df004bbc9) | `` lomiri.deviceinfo: Fix references variable in pkg-config ``                                                                  |
| [`9d0e0a6e`](https://github.com/NixOS/nixpkgs/commit/9d0e0a6ea393490e38d5e224b63b535eff24df38) | `` grafana: 10.4.1 -> 10.4.2 ``                                                                                                 |
| [`54b29dac`](https://github.com/NixOS/nixpkgs/commit/54b29dac32c652338ddea097bc60aea6b3433351) | `` deno: 1.41.3 -> 1.42.3 ``                                                                                                    |
| [`43e1b321`](https://github.com/NixOS/nixpkgs/commit/43e1b321d2fb23d47e3768463ff8cd08146b77f8) | `` sqlfluff: 3.0.3 -> 3.0.4 ``                                                                                                  |
| [`7523091d`](https://github.com/NixOS/nixpkgs/commit/7523091d9775887537a004dfeecc0f10b95980e0) | `` lomiri.lomiri-download-manager: Fix lack of output fixup in pkg-config file, update pkg-config call with new CMake option `` |
| [`0e2e5eba`](https://github.com/NixOS/nixpkgs/commit/0e2e5ebac4c621a80f14c3bb3671697e960f7faf) | `` bun: 1.1.2 -> 1.1.3 ``                                                                                                       |
| [`8cdf8ea4`](https://github.com/NixOS/nixpkgs/commit/8cdf8ea4ba4d3693919f8896f777f1c87cfa22db) | `` python312Packages.pybotvac: format with nixfmt ``                                                                            |
| [`c96bb37f`](https://github.com/NixOS/nixpkgs/commit/c96bb37f8014df1004c12c0f0f8af4ffc1e76e47) | `` python312Packages.pybotvac: 0.0.24 -> 0.0.25 ``                                                                              |
| [`4c958df4`](https://github.com/NixOS/nixpkgs/commit/4c958df482229b4f82e46eb0302987d478be7501) | `` lomiri.biometryd: Fix lack of output fixup in pkg-config file, update pkg-config call with new CMake option ``               |
| [`dfc2c881`](https://github.com/NixOS/nixpkgs/commit/dfc2c8816901ba3804059026747f431c0e66161d) | `` chatterino2: include qtwayland ``                                                                                            |
| [`a38bfa7f`](https://github.com/NixOS/nixpkgs/commit/a38bfa7f826aaa210fe1563ca71f516eec8c4b21) | `` cc1541: init at 4.1 ``                                                                                                       |
| [`ad0527ee`](https://github.com/NixOS/nixpkgs/commit/ad0527eef5d9443498a5c7068aa1d588bfa8c2a1) | `` eza: 0.18.9 -> 0.18.10 ``                                                                                                    |
| [`1c9801b1`](https://github.com/NixOS/nixpkgs/commit/1c9801b1c18c42af0955b8467265ebeb7742cb77) | `` streamlink-twitch-gui-bin: icons ``                                                                                          |
| [`a3c17b5d`](https://github.com/NixOS/nixpkgs/commit/a3c17b5d6b09e994345b2b728f3f297d09058427) | `` nix-health: 0.2.3 -> 0.3.0 ``                                                                                                |
| [`bc4dc452`](https://github.com/NixOS/nixpkgs/commit/bc4dc452fa3ce8895a31273e6d541fbc6abfc2af) | `` envoy: flag as vulnerable to CVE-2024-30255 ``                                                                               |
| [`3acad1b8`](https://github.com/NixOS/nixpkgs/commit/3acad1b873b172ea682919a1b9cd178256fa3a6f) | `` uiua: 0.10.2 -> 0.10.3 ``                                                                                                    |
| [`ec6c5949`](https://github.com/NixOS/nixpkgs/commit/ec6c59494497d5679ed1d1d4086abacd89de8ef4) | `` stdenv/check-meta: Fix error message for disallowed unfree packages ``                                                       |
| [`b993e9c7`](https://github.com/NixOS/nixpkgs/commit/b993e9c7b3d3a4391e9635760b9525c9342075d4) | `` python311Packages.arviz: 0.17.1 -> 0.18.0 ``                                                                                 |
| [`a314f1ec`](https://github.com/NixOS/nixpkgs/commit/a314f1ecf076bdf3996fe21a5e73906601552f6d) | `` cloudfoundry-cli: 8.7.9 -> 8.7.10 ``                                                                                         |
| [`943b7323`](https://github.com/NixOS/nixpkgs/commit/943b7323ece9aabedb9ea1063a75f4598c1e4dad) | `` chatterino2: use `callPackage` directly ``                                                                                   |
| [`bc2e4a53`](https://github.com/NixOS/nixpkgs/commit/bc2e4a537e0160fbf591aefb6c70d363f926147b) | `` apvlv: move to pkgs/by-name ``                                                                                               |
| [`0d86a49d`](https://github.com/NixOS/nixpkgs/commit/0d86a49d54710edaa6f23e913dbe57671d3391f8) | `` apvlv: add anthonyroussel to maintainers ``                                                                                  |
| [`a9b20bb1`](https://github.com/NixOS/nixpkgs/commit/a9b20bb178ddefdc6f1b98c7efb3f0bd64b8e150) | `` apvlv: 0.1.5 -> 0.5.0 ``                                                                                                     |
| [`49b8ddad`](https://github.com/NixOS/nixpkgs/commit/49b8ddad0584c4d2cf87677e3bdbb8e58a135253) | `` rPackages.signatureSearch: disable package ``                                                                                |
| [`da661986`](https://github.com/NixOS/nixpkgs/commit/da6619866409b8af6b55187b02849f6c6ea6a47e) | `` rPackages.ChemmineOB: fix build ``                                                                                           |
| [`ce6a887e`](https://github.com/NixOS/nixpkgs/commit/ce6a887ed222ff051a53632f180622ce539eda09) | `` rPackages.SpatialDecon: fix build ``                                                                                         |
| [`8dcbf0d8`](https://github.com/NixOS/nixpkgs/commit/8dcbf0d8d8f07cb27e0d10b1d511760c84b5cf40) | `` skytemple: 1.6.3 -> 1.6.5 ``                                                                                                 |
| [`bde74bb0`](https://github.com/NixOS/nixpkgs/commit/bde74bb03cf2f557e52df5b63867ad208e3575c3) | `` python3Packages.skytemple-ssb-debugger: 1.6.2 -> 1.6.4 ``                                                                    |
| [`ded01930`](https://github.com/NixOS/nixpkgs/commit/ded0193048db47bc51cd944b336e8cee8621d936) | `` python3Packages.skytemple-ssb-emulator: 1.6.1.post1 -> 1.6.4 ``                                                              |
| [`aeb1209c`](https://github.com/NixOS/nixpkgs/commit/aeb1209cbc35a4bca7c8bd78c66373bec648496d) | `` python3Packages.skytemple-files: 1.6.3 -> 1.6.5 ``                                                                           |
| [`4d5101b1`](https://github.com/NixOS/nixpkgs/commit/4d5101b1b6214348510022b821968244eb208379) | `` python3Packages.skytemple-rust: 1.6.3 -> 1.6.5 ``                                                                            |
| [`9598063d`](https://github.com/NixOS/nixpkgs/commit/9598063d6873884bda8f5568adb6eb2babddc77c) | `` make devenv release blocker ``                                                                                               |
| [`230e5586`](https://github.com/NixOS/nixpkgs/commit/230e558635d80b333f2558b4863f7f6628c5f3a2) | `` electron-*-bin: fix vulkan-loader ``                                                                                         |
| [`bb145640`](https://github.com/NixOS/nixpkgs/commit/bb145640a099594032c5e3a4d96f8f259a357afe) | `` chromium: fix vulkan-loader ``                                                                                               |
| [`7eb7e71e`](https://github.com/NixOS/nixpkgs/commit/7eb7e71eb8bcb439b7425c781ae71d5381598d5c) | `` mueval,diagrams-builder: fix GHC libdir ``                                                                                   |
| [`57f9cc10`](https://github.com/NixOS/nixpkgs/commit/57f9cc103f1e62ee1b27e73051d78f2acf2bce17) | `` ptouch-print: 1.4.3 -> 1.5-unstable-2024-02-11 ``                                                                            |
| [`bd5839cd`](https://github.com/NixOS/nixpkgs/commit/bd5839cd1e194f321fab466db293b8317f533763) | `` packages-config.nix: add `agdaPackages` ``                                                                                   |
| [`756672d1`](https://github.com/NixOS/nixpkgs/commit/756672d106479410e71e8f8db16f34d9d4804f71) | `` chatterino2: add supa as maintainer ``                                                                                       |
| [`279ba486`](https://github.com/NixOS/nixpkgs/commit/279ba486a7f09f55d74e5748d649e4e56793d44c) | `` maintainers: add supa ``                                                                                                     |
| [`a9868929`](https://github.com/NixOS/nixpkgs/commit/a986892985ff9639224acdcaeb3453c9772343fd) | `` chatterino2: build with Qt6 ``                                                                                               |
| [`77f34ccf`](https://github.com/NixOS/nixpkgs/commit/77f34ccf4d7faff8b007e8f581bdf659ebe37629) | `` apko: 0.10.0 -> 0.13.2 ``                                                                                                    |
| [`543d39e0`](https://github.com/NixOS/nixpkgs/commit/543d39e0579075f1fa193b5c0353983b474bb73c) | `` mdadm: update homepage ``                                                                                                    |
| [`4874517e`](https://github.com/NixOS/nixpkgs/commit/4874517e27163fa16d37028bce318287fc70ec6a) | `` python31Packages.nibabel: unbreak by disabling test requiring `distutils` ``                                                 |
| [`5e0eeb36`](https://github.com/NixOS/nixpkgs/commit/5e0eeb362bcfa4017e6e57b091c95a0dcb8ba571) | `` postgresql{12,13}Packages.pg_safeupdate: 1.5 -> 1.4 ``                                                                       |
| [`7a358ffd`](https://github.com/NixOS/nixpkgs/commit/7a358ffd0ec3e867fa118bdeb01bf45f2131082b) | `` postgresqlPackages.postgis: add myself as maintainer ``                                                                      |
| [`156f69bb`](https://github.com/NixOS/nixpkgs/commit/156f69bbcb280c059a6418de7fd0921fab64ea1b) | `` postgresqlPackages.pg_safeupdate: add myself as maintainer ``                                                                |
| [`f528df9f`](https://github.com/NixOS/nixpkgs/commit/f528df9f37632a8b0b833022db4251c1ff97002c) | `` rocmPackages_6.hiprand: init at 6.0.2 ``                                                                                     |
| [`e335ef79`](https://github.com/NixOS/nixpkgs/commit/e335ef799143a9cf15a9cc97b9728b6d30b20d8f) | `` tvbrowser: user stripJavaArchivesHook for determinism ``                                                                     |
| [`8f5bbcc3`](https://github.com/NixOS/nixpkgs/commit/8f5bbcc32721cfa8da85929a7007c2c1755cef0e) | `` bird: 2.15 -> 2.15.1 ``                                                                                                      |
| [`2ab5c8b5`](https://github.com/NixOS/nixpkgs/commit/2ab5c8b5faa93d7f19214026b1b4b5dc713066f5) | `` netevent: 20201018 -> 20230429 ``                                                                                            |
| [`4dd2148c`](https://github.com/NixOS/nixpkgs/commit/4dd2148ca611aac4627e433f5fcdbdfd7596044d) | `` otto-matic: 4.0.1 -> unstable-2023-11-13 ``                                                                                  |
| [`cf0edc33`](https://github.com/NixOS/nixpkgs/commit/cf0edc3321ebbcc3c37f16d915a25381671609b5) | `` commandergenius: 2.3.3 -> 3.5.0 ``                                                                                           |
| [`547fea8f`](https://github.com/NixOS/nixpkgs/commit/547fea8f6f2ba3086f183620c5f092c651fa899f) | `` doomseeker: 2018-03-05 -> 2023-08-09 ``                                                                                      |
| [`125fc579`](https://github.com/NixOS/nixpkgs/commit/125fc5796233cf4e46ba2c43b9eb07bfd36394ef) | `` zandronum-alpha: init at 3.2-230709-1914 ``                                                                                  |