### PR TITLE
chore(flake/nixpkgs-master): `1dd996e5` -> `a2a0f5f6`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1224,11 +1224,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1713027899,
-        "narHash": "sha256-YG3U+PuZDycqId/irugEVkxoeW++CZl/Vv4wPmQV5e0=",
+        "lastModified": 1713047660,
+        "narHash": "sha256-fgHpJ+38YTfIkHX63P0q2VUBdNNHUQYJ3LYtzu7igzA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1dd996e59a5e67694b7a252aacba71a88d51b41e",
+        "rev": "a2a0f5f67dfed05e60e5e8e53830a5ca3ea4937b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                    |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
| [`e2cd8a7a`](https://github.com/NixOS/nixpkgs/commit/e2cd8a7a2b1f508fedbfebfacd03a3036f32ac88) | `` editorconfig-core-c: 0.12.5 -> 0.12.7 ``                                                |
| [`d5793186`](https://github.com/NixOS/nixpkgs/commit/d5793186e8b239fe551839c3162c26873709e799) | `` python3Packages.sev-snp-measure: init at 0.0.9 (#303158) ``                             |
| [`841e60c6`](https://github.com/NixOS/nixpkgs/commit/841e60c6c58fdbff6bbd4a4bb6ee7f6f14b0d5c5) | `` coder: add updateScript ``                                                              |
| [`26013573`](https://github.com/NixOS/nixpkgs/commit/26013573a799a46bb7e2de53b5e11335ed9fbdbc) | `` gimpPlugins.gap: patch ffmpeg to avoid asm error ``                                     |
| [`ba2a15e0`](https://github.com/NixOS/nixpkgs/commit/ba2a15e0c469f71eae8071e26f4130099b0df88b) | `` home-assistant-custom-components.indego: init at 5.5.0 ``                               |
| [`41df6e2e`](https://github.com/NixOS/nixpkgs/commit/41df6e2e2bbecb21398f67745d25db597110e80b) | `` python312Packages.pyindego: init at 3.1.1 ``                                            |
| [`c0c2f290`](https://github.com/NixOS/nixpkgs/commit/c0c2f2903f310dd5efb86f02b4b5f824183f5173) | `` lib.mdDoc: remove and replace with warning ``                                           |
| [`46456a92`](https://github.com/NixOS/nixpkgs/commit/46456a929b654ed2ac9c56f8a0c1fa1823a4a2a9) | `` lib: remove all uses of lib.mdDoc ``                                                    |
| [`170e005a`](https://github.com/NixOS/nixpkgs/commit/170e005a9252cbf60641462d332a1023d66bdf5d) | `` pkgs/config: remove uses of lib.mdDoc ``                                                |
| [`6afb255d`](https://github.com/NixOS/nixpkgs/commit/6afb255d976f85f3359e4929abd6f5149c323a02) | `` nixos: remove all uses of lib.mdDoc ``                                                  |
| [`96659af1`](https://github.com/NixOS/nixpkgs/commit/96659af197072c921c6063021788ad5d32fb6b3f) | `` nixos/crabfit: init ``                                                                  |
| [`933dd4ce`](https://github.com/NixOS/nixpkgs/commit/933dd4ce289d68505018f79baa09052344850138) | `` libdwarf: 0.9.0 -> 0.9.2 ``                                                             |
| [`600fcb20`](https://github.com/NixOS/nixpkgs/commit/600fcb2070fc30ff978dcf6fb57d81c6212b4aac) | `` crabfit-frontend: init at unstable-2023-08-02 ``                                        |
| [`9239dfa0`](https://github.com/NixOS/nixpkgs/commit/9239dfa065af4f87672ee08137199d45b2a94e5a) | `` linkerd_edge: 24.3.5 -> 24.4.2 ``                                                       |
| [`84f74ee1`](https://github.com/NixOS/nixpkgs/commit/84f74ee14b7370234d58e99d7fcc37156b5bcc1c) | `` bird: add herbetom as maintainer ``                                                     |
| [`9039bcbe`](https://github.com/NixOS/nixpkgs/commit/9039bcbe79f72e581ce84bdf07a59e0064aaa144) | `` crabfit-api: init at unstable-2023-08-02 ``                                             |
| [`21c9e665`](https://github.com/NixOS/nixpkgs/commit/21c9e6650e60f796c7bf3595503dc70cbf8008b8) | `` discover-overlay: init at 0.7.0 ``                                                      |
| [`b18d7cc4`](https://github.com/NixOS/nixpkgs/commit/b18d7cc426c2ab2015826d95047b2c51395081f0) | `` python312Packages.adlfs: foramt with nixfmt ``                                          |
| [`ac1f7bc8`](https://github.com/NixOS/nixpkgs/commit/ac1f7bc86d7215872cb7a21d7e8c3a4ffb012a37) | `` python312Packages.adlfs: refactor ``                                                    |
| [`33346ab5`](https://github.com/NixOS/nixpkgs/commit/33346ab5ac64671735fc3727ceb773dd44d73b95) | `` mini-calc: 2.12.2 -> 2.12.3 ``                                                          |
| [`1ba97bc3`](https://github.com/NixOS/nixpkgs/commit/1ba97bc32cdd44efa350ab4854deeab3f3794299) | `` python312Packages.adlfs: 2024.2.0 -> 2024.4.0 ``                                        |
| [`9e7b5b28`](https://github.com/NixOS/nixpkgs/commit/9e7b5b28014eb1c2cef4c2880f81623843ab374f) | `` xdg-terminal-exec: 0.9.0 -> 0.9.3 ``                                                    |
| [`21ac8f8c`](https://github.com/NixOS/nixpkgs/commit/21ac8f8cd880c3c6e4f4055ad3148b70b0fcc476) | `` hyprshade: fix systemd user service ``                                                  |
| [`6de29df1`](https://github.com/NixOS/nixpkgs/commit/6de29df165236e618f7cff90cfef4d1a4024e653) | `` python311Packages.types-redis: format with nixfmt ``                                    |
| [`4673cc1e`](https://github.com/NixOS/nixpkgs/commit/4673cc1e0003e5e8dc5b34e7fb43b1e0d3a9890a) | `` python311Packages.types-redis: refactor ``                                              |
| [`640586d9`](https://github.com/NixOS/nixpkgs/commit/640586d9d8b5f95d838bb1aae697e93fc2deb802) | `` libmicrohttpd: remove unused old versions ``                                            |
| [`ecf60ecf`](https://github.com/NixOS/nixpkgs/commit/ecf60ecf68bcc2f2fc48109e8384f8a09538a2af) | `` python311Packages.types-redis: 4.6.0.20240311 -> 4.6.0.20240409 ``                      |
| [`8a3c26b0`](https://github.com/NixOS/nixpkgs/commit/8a3c26b0342e0d18b6743fff466bb92f632d5d57) | `` tcsh: Add suominen to maintainers ``                                                    |
| [`4ade905f`](https://github.com/NixOS/nixpkgs/commit/4ade905f62b36010d6977da9a4e06755dd5d3ed9) | `` powershell: 7.4.1 -> 7.4.2 ``                                                           |
| [`aa2c07f7`](https://github.com/NixOS/nixpkgs/commit/aa2c07f76789fda718574ffe37f3e8a49d71feeb) | `` pixel-code: 2.1 -> 2.2 ``                                                               |
| [`7601af5b`](https://github.com/NixOS/nixpkgs/commit/7601af5b1846193c2644c890dbf834c1e07c1855) | `` ciscoPacketTracer8: small refactor, qol ``                                              |
| [`b4d4dc82`](https://github.com/NixOS/nixpkgs/commit/b4d4dc825e9ac360e137c6cf03eef6c6fb3dfb9e) | `` librum: 0.12.1 -> 0.12.2 ``                                                             |
| [`9a4b6ea4`](https://github.com/NixOS/nixpkgs/commit/9a4b6ea478d527b21b4ca7afe21324f8a1690a41) | `` flet-client-flutter: 0.21.1 -> 0.22.0 ``                                                |
| [`43291a15`](https://github.com/NixOS/nixpkgs/commit/43291a15b34f7fcd9a2b416623e54ee35deba2f5) | `` openloco: 24.01.1 -> 24.04 ``                                                           |
| [`8e2fd368`](https://github.com/NixOS/nixpkgs/commit/8e2fd36871b41fe202314957f1803a43b473afad) | `` aws-sam-cli: 1.113.0 -> 1.115.0 ``                                                      |
| [`b2f100e4`](https://github.com/NixOS/nixpkgs/commit/b2f100e4550942a186f6d5d3a332a98eb78ab4d4) | `` promptfoo: 0.49.3 -> 0.51.0 ``                                                          |
| [`5e37f12c`](https://github.com/NixOS/nixpkgs/commit/5e37f12c64f748d1bdd8ffa80f1f5b78857dc5d0) | `` maintainers: add dragonginger ``                                                        |
| [`05f88d63`](https://github.com/NixOS/nixpkgs/commit/05f88d633296efd33455c5d8a8fb0e8ec592c213) | `` ex_doc: 0.31.2 -> 0.32.0 ``                                                             |
| [`1198dc84`](https://github.com/NixOS/nixpkgs/commit/1198dc84f8584a37e4146919d24016ceaf3f4dd8) | `` nixos/hyprland: systemd.setPath - fix user profile bin directory ``                     |
| [`a3d3cdf5`](https://github.com/NixOS/nixpkgs/commit/a3d3cdf5d9fcfc086f7f83c4e9a4833f0e24e111) | `` nixos/matrix-synapse: don't use `services.postgresql.initialScript` in setup example `` |
| [`d8102af4`](https://github.com/NixOS/nixpkgs/commit/d8102af47387d2923b145ef2222a571f5be1ed6f) | `` taler: 0.9.3 -> 0.10.1 ``                                                               |
| [`5c9e0805`](https://github.com/NixOS/nixpkgs/commit/5c9e0805f9ebb1042a6bb35f96eabe97d5d49c6d) | `` texturepacker: 7.1.0 -> 7.2.0 ``                                                        |
| [`ff7266a2`](https://github.com/NixOS/nixpkgs/commit/ff7266a2b93acb4c8fec3378e42b523140d93e06) | `` prometheus-smokeping-prober: 0.8.0 -> 0.8.1 ``                                          |
| [`69f10827`](https://github.com/NixOS/nixpkgs/commit/69f108271fa8ec7a268aa76fe9743ad8ef61dcdc) | `` gigalixir: 1.11.1 -> 1.12.0 ``                                                          |
| [`d5749032`](https://github.com/NixOS/nixpkgs/commit/d5749032b489c05423ec39a664f4a0581cb48a07) | `` crawley: 1.7.4 -> 1.7.5 ``                                                              |
| [`d9f56c35`](https://github.com/NixOS/nixpkgs/commit/d9f56c353ed2b755d79fb219a64d2d84e03b609f) | `` stgit: 2.4.5 -> 2.4.6 ``                                                                |
| [`55bc6865`](https://github.com/NixOS/nixpkgs/commit/55bc6865350811ad48532d8ea909f05eaf4f1e08) | `` konstraint: 0.35.0 -> 0.36.0 ``                                                         |
| [`429b414f`](https://github.com/NixOS/nixpkgs/commit/429b414ffc6988130e4438633d427fc30ae3a275) | `` edid-decode: unstable-2024-01-29 -> unstable-2024-04-02 ``                              |
| [`1eee0a15`](https://github.com/NixOS/nixpkgs/commit/1eee0a157c680c4305974b6ec19b829ae8434a9a) | `` bosh-cli: 7.5.5 -> 7.5.6 ``                                                             |
| [`eede8946`](https://github.com/NixOS/nixpkgs/commit/eede894699d33de216d75187929ecb1ebb7f4794) | `` libtommath: 1.2.1 -> 1.3.0 ``                                                           |
| [`4e71d4b8`](https://github.com/NixOS/nixpkgs/commit/4e71d4b8ed88214296b4835bd8e46bde16bc888b) | `` rar2fs: use fuse2 ``                                                                    |
| [`c3428248`](https://github.com/NixOS/nixpkgs/commit/c3428248d986b1b6a7cb929103c7020330a604b5) | `` fuse2: add to top-level ``                                                              |
| [`8922d75e`](https://github.com/NixOS/nixpkgs/commit/8922d75e9314b1b9586e4241bf4cead018046dae) | `` gnunet-gtk: 0.20.0 -> 0.21.0 ``                                                         |
| [`39035bd2`](https://github.com/NixOS/nixpkgs/commit/39035bd2630b15e2f18ed3eb7d399d85d53db5af) | `` gnunet: 0.20.0 -> 0.21.1 ``                                                             |
| [`c4304c2a`](https://github.com/NixOS/nixpkgs/commit/c4304c2afae4abf0e40672f72ac6729a226bf6b3) | `` iroh: 0.11.0 -> 0.13.0 ``                                                               |
| [`750d2575`](https://github.com/NixOS/nixpkgs/commit/750d257532550cb0564c31a15b7ff19fcafb8246) | `` libcdio-paranoia: 10.2+0.94+2 -> 10.2+2.0.1 ``                                          |
| [`a805ae9f`](https://github.com/NixOS/nixpkgs/commit/a805ae9f3a91702ddb542e6c8b4f260701749ae5) | `` ksnip: fix build with latest kcolorpicker ``                                            |
| [`4e936216`](https://github.com/NixOS/nixpkgs/commit/4e93621647790cc20d286b7b00d9303770548a42) | `` libsForQt5.kimageannotator: 0.7.0 -> 0.7.1 ``                                           |
| [`a8728bf0`](https://github.com/NixOS/nixpkgs/commit/a8728bf01b17ff5250ab25ccf2770de086f23ddd) | `` kdePackages.kcolorpicker: 0.3.0 -> 0.3.1 ``                                             |
| [`9c3d536f`](https://github.com/NixOS/nixpkgs/commit/9c3d536f0061ecf604cfeb2bf7b86e642bdb7fc2) | `` discount: 2.2.7b -> 3.0.0d ``                                                           |
| [`08d28f1f`](https://github.com/NixOS/nixpkgs/commit/08d28f1f1d93fc453e14d600036d982a1fb4fbf4) | `` vscode-utils: add relativeLocation in toExtensionJson ``                                |
| [`b5654da7`](https://github.com/NixOS/nixpkgs/commit/b5654da7e66fb79326df7efe86ace441ad8503e8) | `` pulumi: 3.93.0 -> 3.99.0 ``                                                             |