### PR TITLE
chore(flake/emacs-overlay): `fb0a8410` -> `f92b1cf3`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713027991,
-        "narHash": "sha256-xaHTBJTsG85//PpYxD7fYH93NQEGShXeGuT+Ba7ElTg=",
+        "lastModified": 1713133980,
+        "narHash": "sha256-fGpgQoMyuLbS/r3FkZ59ISNI3Oo148tEMlKJpnmCI7w=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "fb0a841062d30d512632144a0b8f429d3d83c9c1",
+        "rev": "f92b1cf3105eb9eab992e585861a762ad8cb0037",
         "type": "github"
       },
       "original": {
@@ -1255,11 +1255,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1712867921,
-        "narHash": "sha256-edTFV4KldkCMdViC/rmpJa7oLIU8SE/S35lh/ukC7bg=",
+        "lastModified": 1713013257,
+        "narHash": "sha256-ZEfGB3YCBVggvk0BQIqVY7J8XF/9jxQ68fCca6nib+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "51651a540816273b67bc4dedea2d37d116c5f7fe",
+        "rev": "90055d5e616bd943795d38808c94dbf0dd35abe8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`f92b1cf3`](https://github.com/nix-community/emacs-overlay/commit/f92b1cf3105eb9eab992e585861a762ad8cb0037) | `` Updated elpa ``         |
| [`5b014959`](https://github.com/nix-community/emacs-overlay/commit/5b014959f1634723bfce7bf137a181031b1c6e7c) | `` Updated flake inputs `` |
| [`8a3f1e57`](https://github.com/nix-community/emacs-overlay/commit/8a3f1e574aa11b3f0aee99bcb453b56c8d6f1ac7) | `` Updated emacs ``        |
| [`6cfac69a`](https://github.com/nix-community/emacs-overlay/commit/6cfac69a49d02b98869683e0776857662ae06a39) | `` Updated melpa ``        |
| [`f4bc6d72`](https://github.com/nix-community/emacs-overlay/commit/f4bc6d7272120520122cfef5867d92a92e81bf62) | `` Updated elpa ``         |
| [`0c36a0d1`](https://github.com/nix-community/emacs-overlay/commit/0c36a0d16b7ca94731eee246d00238885d22490f) | `` Updated emacs ``        |
| [`8b543264`](https://github.com/nix-community/emacs-overlay/commit/8b543264eb28d8953911bcf1bc0d94d7e89c2d7a) | `` Updated melpa ``        |
| [`1ec32758`](https://github.com/nix-community/emacs-overlay/commit/1ec327581332f85fb273487226b102ee1af3d6db) | `` Updated elpa ``         |