### PR TITLE
chore(flake/home-manager): `8fdf3295` -> `9f32c66a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713019815,
-        "narHash": "sha256-jzTo97VeKMNfnKw3xU+uiU5C7wtnLudsbwl/nwPLC7s=",
+        "lastModified": 1713131281,
+        "narHash": "sha256-/Jm1X9MPfLXAxZSCdWmQAFNUQggEfNWHol5jSyyzFzw=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8fdf329526f06886b53b94ddf433848a0d142984",
+        "rev": "9f32c66a51d05e6d4ec0dea555bbff9135749ec7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                              |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
| [`9f32c66a`](https://github.com/nix-community/home-manager/commit/9f32c66a51d05e6d4ec0dea555bbff9135749ec7) | `` k9s: configuration files in Darwin without XDG `` |
| [`76a1650c`](https://github.com/nix-community/home-manager/commit/76a1650c45df8ed130e66eeeb8275a149562c4c5) | `` k9s: fix typos in configuration file names ``     |
| [`630a0992`](https://github.com/nix-community/home-manager/commit/630a0992b3627c64e34f179fab68e3d48c6991c0) | `` nushell: fix nushell config path on darwin ``     |
| [`4cc3c916`](https://github.com/nix-community/home-manager/commit/4cc3c91601b6083c3715516d5d891fa46c679e59) | `` flake.lock: Update ``                             |
| [`f33d5086`](https://github.com/nix-community/home-manager/commit/f33d5086d3f9128aba126135ea2a901c121ebf06) | `` rio: remove redundant `lib.mdDoc` call ``         |