### PR TITLE
chore(flake/sops-nix): `538c114c` -> `226062b4`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1534,11 +1534,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1712617241,
-        "narHash": "sha256-a4hbls4vlLRMciv62YrYT/Xs/3Cubce8WFHPUDWwzf8=",
+        "lastModified": 1713066950,
+        "narHash": "sha256-ZaefFyvt5369XdjzSw43NhfbPM9MN5b9YXhzx4lFIRc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "538c114cfdf1f0458f507087b1dcf018ce1c0c4c",
+        "rev": "226062b47fe0e2130ba3ee9f4f1c880dc815cf87",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                  |
| ----------------------------------------------------------------------------------------------- | ------------------------ |
| [`226062b4`](https://github.com/Mic92/sops-nix/commit/226062b47fe0e2130ba3ee9f4f1c880dc815cf87) | `` flake.lock: Update `` |