### PR TITLE
chore(flake/nixpkgs-master): `a2a0f5f6` -> `1f54fa2d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1224,11 +1224,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1713047660,
-        "narHash": "sha256-fgHpJ+38YTfIkHX63P0q2VUBdNNHUQYJ3LYtzu7igzA=",
+        "lastModified": 1713132898,
+        "narHash": "sha256-q+uV0ZsTghNgLZA1IDw1K6wJ1pA2EBDwFee9eC1RCO0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a2a0f5f67dfed05e60e5e8e53830a5ca3ea4937b",
+        "rev": "1f54fa2ddf2623784a2b4431b35a1b5ce91a14bf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`ed817f46`](https://github.com/NixOS/nixpkgs/commit/ed817f469939a238181fa4872e082af4ad8c7499) | `` xcaddy: 0.3.5 -> 0.4.0 ``                                                                      |
| [`d59720a7`](https://github.com/NixOS/nixpkgs/commit/d59720a710244803b2152c370736246a1d3689d6) | `` doc/release-notes: mention Lomiri availability ``                                              |
| [`93e91c15`](https://github.com/NixOS/nixpkgs/commit/93e91c150ec90232f456137ad3bee44d6a9fe4b5) | `` ayatana-indicator-messages: Fix desktop parsing ``                                             |
| [`8d0a5773`](https://github.com/NixOS/nixpkgs/commit/8d0a5773b2fbfba337f403318f1194931175ddcd) | `` lomiri.telephony-service: Fix indicator ``                                                     |
| [`52696f99`](https://github.com/NixOS/nixpkgs/commit/52696f99fa9ef1f1166b4d78945ab75e6d65ba76) | `` lomiri.libusermetrics: Add custom patch for launching systemd service ``                       |
| [`9c5e9db5`](https://github.com/NixOS/nixpkgs/commit/9c5e9db5bf094e1f374541d7bf789884de641192) | `` lomiri.lomiri-system-settings: Patch language plugin's locale lookup path ``                   |
| [`c1af1ec9`](https://github.com/NixOS/nixpkgs/commit/c1af1ec9228406bd9ff28f813a63f08d48299dfa) | `` lomiri.content-hub: Move example peers to examples output ``                                   |
| [`dd3f11b8`](https://github.com/NixOS/nixpkgs/commit/dd3f11b8f674fa0770181ac44d52042cabe53891) | `` lomiri.morph-browser: Patch desktop icon path to be absolute ``                                |
| [`b6fd92ab`](https://github.com/NixOS/nixpkgs/commit/b6fd92ab77158c7d5835a2ce234a97dc323353f9) | `` nixos/tests/lomiri: init ``                                                                    |
| [`9528502e`](https://github.com/NixOS/nixpkgs/commit/9528502e83df873f0a3880875999ffa226f3c83a) | `` nixos/lomiri: init ``                                                                          |
| [`399d6988`](https://github.com/NixOS/nixpkgs/commit/399d6988547f46df4c37fe0c085cff63bb7040bc) | `` nixos/lightdm-greeters/lomiri: init ``                                                         |
| [`67daa502`](https://github.com/NixOS/nixpkgs/commit/67daa5021fcc4683d1f18bc191fa829db2360906) | `` lomiri.lomiri-session: init at 0.2 ``                                                          |
| [`1850a54e`](https://github.com/NixOS/nixpkgs/commit/1850a54e5744c425b07a5ee781dccc52fbce6286) | `` lomiri.lomiri: init at 0.2.1 ``                                                                |
| [`ad27491b`](https://github.com/NixOS/nixpkgs/commit/ad27491b769676e844a099daa9d1d2e445f45a05) | `` ngtcp2: fix build on darwin by providing CoreServices ``                                       |
| [`e6cae7e4`](https://github.com/NixOS/nixpkgs/commit/e6cae7e4f77e2ee0808b913dbe67056e30067b20) | `` nghttp3: fix build on darwin by providing CoreServices ``                                      |
| [`e62c51a0`](https://github.com/NixOS/nixpkgs/commit/e62c51a05c3bd87c5fc6bfdb42a96f8a3a197450) | `` frigate: fix path to onvif wsdl files ``                                                       |
| [`94808651`](https://github.com/NixOS/nixpkgs/commit/94808651040239efdfb05337e9445e7ae54f499e) | `` python312Packages.frozendict: 2.4.1 -> 2.4.2 ``                                                |
| [`d67c7ccd`](https://github.com/NixOS/nixpkgs/commit/d67c7ccde4ded0774d845b97b9faf194c82a0062) | `` python312Packages.pymodbus: 3.6.7 -> 3.6.8 ``                                                  |
| [`9adf0708`](https://github.com/NixOS/nixpkgs/commit/9adf0708a3b60e2a71e40d2fd5e98c8b12d9beeb) | `` yq: 3.2.3 -> 3.3.0 ``                                                                          |
| [`b174ea61`](https://github.com/NixOS/nixpkgs/commit/b174ea619292f82a81d668bcd20aca95ec57108e) | `` llvmPackages_18: drop an orphaned file ``                                                      |
| [`7f0edf51`](https://github.com/NixOS/nixpkgs/commit/7f0edf51e7916064a206b1959d7ef509d4ec9d29) | `` python312Packages.equinox: 0.11.3 -> 0.11.4 ``                                                 |
| [`2a16ac41`](https://github.com/NixOS/nixpkgs/commit/2a16ac4174eabd968dac94f32b1cafb39e12b1e0) | `` fuzzel: 1.9.2 -> 1.10.0 ``                                                                     |
| [`7d1cfb83`](https://github.com/NixOS/nixpkgs/commit/7d1cfb83bbbb94ce5c14df9737dd29ed5cacdba3) | `` local-ai: 2.12.3 -> 2.12.4 ``                                                                  |
| [`8c11ab63`](https://github.com/NixOS/nixpkgs/commit/8c11ab639aa056e9a25c428d6d9786f2c36a662f) | `` raycast: add maintainer donteatoreo ``                                                         |
| [`0951eef3`](https://github.com/NixOS/nixpkgs/commit/0951eef3801b91f7cc408cdae123c38e7b8b4f03) | `` raycast: fix passthru.updateScript ``                                                          |
| [`7dbcdd7b`](https://github.com/NixOS/nixpkgs/commit/7dbcdd7b465f168f31edf098761411d46fef0f32) | `` python312Packages.ansicolor: refactor ``                                                       |
| [`2345d95b`](https://github.com/NixOS/nixpkgs/commit/2345d95ba47fa41cf8e20a0e662bb4ad9a4bea09) | `` colloid-gtk-theme: 2023-10-28 -> 2024-04-14 ``                                                 |
| [`be86ca7e`](https://github.com/NixOS/nixpkgs/commit/be86ca7e0e5320b7a42711b88c1b32cafce7fef1) | `` cargo-temp: 0.2.19 -> 0.2.20 ``                                                                |
| [`57f408c5`](https://github.com/NixOS/nixpkgs/commit/57f408c562d6fc17aaa60a16573d741ba5a3e0e4) | `` pace: init at 0.15.2 ``                                                                        |
| [`bdf1699e`](https://github.com/NixOS/nixpkgs/commit/bdf1699ea1d2a832af30cc45920dd454875435d0) | `` ananicy-rules-cachyos: fix hooks and pname ``                                                  |
| [`d9046002`](https://github.com/NixOS/nixpkgs/commit/d9046002291c03f00fd6abbd1a623283ee7978f0) | `` protolint: 0.49.4 -> 0.49.6 ``                                                                 |
| [`01181b1e`](https://github.com/NixOS/nixpkgs/commit/01181b1ea2f813a2c96fc6d676adfe970f7dc5a9) | `` fq: 0.10.0 -> 0.11.0 ``                                                                        |
| [`6b09031c`](https://github.com/NixOS/nixpkgs/commit/6b09031c2c45c2e25b57bef8e02367cf755136a0) | `` clipcat: 0.16.5 -> 0.16.6 ``                                                                   |
| [`cf8ecfbd`](https://github.com/NixOS/nixpkgs/commit/cf8ecfbd027393f633c27a891408d1b0eedb5bb8) | `` cargo-tally: 1.0.42 -> 1.0.43 ``                                                               |
| [`3aa35ca0`](https://github.com/NixOS/nixpkgs/commit/3aa35ca0238d9cef55f840a45947a88a9d0fbd6a) | `` maintainers: add isabelroses ``                                                                |
| [`8faaed60`](https://github.com/NixOS/nixpkgs/commit/8faaed60249a44ba718ac748f75aefbbee18a8b6) | `` cariddi: 1.3.3 -> 1.3.4 ``                                                                     |
| [`de009cd3`](https://github.com/NixOS/nixpkgs/commit/de009cd3d123667b0c403f8484d6ec5fa15fceea) | `` maintainers: add diniamo ``                                                                    |
| [`b680b6eb`](https://github.com/NixOS/nixpkgs/commit/b680b6eb94076fad8ac57edb2a077f34289585ba) | `` tenv: 1.7.0 -> 1.7.1 ``                                                                        |
| [`10062752`](https://github.com/NixOS/nixpkgs/commit/10062752e1d5e4934e7b71b2e636c07d9274ac9f) | `` livi: init at 0.0.6 ``                                                                         |
| [`671d051a`](https://github.com/NixOS/nixpkgs/commit/671d051a48c744a4f5cb4faef2598ce1315c3379) | `` ckb-next: Fix udev rule ``                                                                     |
| [`6bc0ceae`](https://github.com/NixOS/nixpkgs/commit/6bc0ceaee79bd14d0abfcb7c1f21f0017bd17435) | `` ugrep: 5.1.3 -> 5.1.4 ``                                                                       |
| [`816ec8cf`](https://github.com/NixOS/nixpkgs/commit/816ec8cfe345c6e3942828ec4513f6c97e2a37a9) | `` phrase-cli: 2.23.1 -> 2.23.2 ``                                                                |
| [`56742e96`](https://github.com/NixOS/nixpkgs/commit/56742e961c9801e16ecc2b0e228cddc046b997aa) | `` exploitdb: 2024-04-13 -> 2024-04-14 ``                                                         |
| [`ca453e82`](https://github.com/NixOS/nixpkgs/commit/ca453e82df8daed165e7b0890b3ec91d0065a6ba) | `` androidStudioPackages.canary: 2024.1.1.2 -> 2024.1.1.3 ``                                      |
| [`db585038`](https://github.com/NixOS/nixpkgs/commit/db585038d275944a8e68b575cb71154e20c77973) | `` simulide_1_1_0: 1.1.0-RC1 -> 1.1.0-SR0 ``                                                      |
| [`d0b62f21`](https://github.com/NixOS/nixpkgs/commit/d0b62f21051575fcb4e6a48f5d94ddc1090a8e4e) | `` minijinja: 1.0.17 -> 1.0.20 ``                                                                 |
| [`a8800e7f`](https://github.com/NixOS/nixpkgs/commit/a8800e7f5f6e0442c8dca1fc0982dbd11316294b) | `` Plasma 5: 5.27.10 -> 5.27.11 ``                                                                |
| [`b5132960`](https://github.com/NixOS/nixpkgs/commit/b51329603f2ef41324d130f5d1ba1dd90658db55) | `` atmos: 1.68.0 -> 1.69.0 ``                                                                     |
| [`4ae12930`](https://github.com/NixOS/nixpkgs/commit/4ae12930f24eff5a06aa211063028c80385868ec) | `` nixos/xfce: `bgSupport = !noDesktop` ``                                                        |
| [`f190aa84`](https://github.com/NixOS/nixpkgs/commit/f190aa8442bc65d8fa9e3b77dafcdd24b785717d) | `` terraform-providers: fix vendorHash for go1.22 ``                                              |
| [`b6f237dd`](https://github.com/NixOS/nixpkgs/commit/b6f237dd7a322eff33057dc63b8971886c79d542) | `` threatest: fix vendorHash for go1.22 ``                                                        |
| [`a17f40f2`](https://github.com/NixOS/nixpkgs/commit/a17f40f2d4a632e26a7b954a1e1212d5c5d29cb5) | `` age-plugin-tpm: fix vendorHash for go1.22 ``                                                   |
| [`b9f6824b`](https://github.com/NixOS/nixpkgs/commit/b9f6824b024cbf4fbc9c38fe8bd557a4e73305f0) | `` juicity: fix vendorHash for go1.22 ``                                                          |
| [`9ae2ccf3`](https://github.com/NixOS/nixpkgs/commit/9ae2ccf3a4f10100c00a90f3f2aa5d007ce0b5cc) | `` dae: fix vendorHash for go1.22 ``                                                              |
| [`d9237327`](https://github.com/NixOS/nixpkgs/commit/d92373278332cbe65cd756a46f862bcc9fc8430b) | `` teleport_14: fix vendorHash for go1.22 ``                                                      |
| [`2aa9c8dc`](https://github.com/NixOS/nixpkgs/commit/2aa9c8dc5f9ec0a191c64b000e4ef09befc83d28) | `` teleport_13: fix vendorHash for go1.22 ``                                                      |
| [`4719f71b`](https://github.com/NixOS/nixpkgs/commit/4719f71b5c32488c8e01517467ee6ed844ae6012) | `` teleport_12: fix vendorHash for go1.22 ``                                                      |
| [`69ccea03`](https://github.com/NixOS/nixpkgs/commit/69ccea0338c8bd4dd921cfadd6ead4c38d0ee994) | `` pufferpanel: fix vendorHash for go1.22 ``                                                      |
| [`06b903ed`](https://github.com/NixOS/nixpkgs/commit/06b903ed276641acacb98ea4c37dff6be3795ceb) | `` phlare: fix vendorHash for go1.22 ``                                                           |
| [`6c076c91`](https://github.com/NixOS/nixpkgs/commit/6c076c910684b55c642ee463ccee1ba8d0ff379a) | `` icebreaker: fix vendorHash for go1.22 ``                                                       |
| [`6933748e`](https://github.com/NixOS/nixpkgs/commit/6933748e0944a2825657070f05e5ab629ebe86c4) | `` hydron: fix vendorHash for go1.22 ``                                                           |
| [`6f05e554`](https://github.com/NixOS/nixpkgs/commit/6f05e55422644f49a95e4b702507da22401dc79b) | `` boringssl: fix vendorHash for go1.22 ``                                                        |
| [`7e7a22fa`](https://github.com/NixOS/nixpkgs/commit/7e7a22fa3a3487ac9437ac3189ef633ce43e9391) | `` alps: fix vendorHash for go1.22 ``                                                             |
| [`c8aa4946`](https://github.com/NixOS/nixpkgs/commit/c8aa4946802d3ebfd4ff59f73437fd2f759d354f) | `` wails: fix vendorHash for go1.22 ``                                                            |
| [`66bad658`](https://github.com/NixOS/nixpkgs/commit/66bad658c93be94d84cee2fb31eada82b1e2ddda) | `` kustomize: fix vendorHash for go1.22 ``                                                        |
| [`61b8561d`](https://github.com/NixOS/nixpkgs/commit/61b8561d6d5a519f634ddc0fc7cd3e2e373faf18) | `` go-migrate: fix vendorHash for go1.22 ``                                                       |
| [`44ed815d`](https://github.com/NixOS/nixpkgs/commit/44ed815d0ddaa304eab80659443c2b72cbb652ab) | `` sqlcmd: fix vendorHash for go1.22 ``                                                           |
| [`10a41b7d`](https://github.com/NixOS/nixpkgs/commit/10a41b7dd6805a09e114f2e0b699dc60429ce9e1) | `` dapr-cli: fix vendorHash for go1.22 ``                                                         |
| [`34b358fb`](https://github.com/NixOS/nixpkgs/commit/34b358fb2469849b28ab490bd082b30334abef17) | `` benthos: fix vendorHash for go1.22 ``                                                          |
| [`8b05ded0`](https://github.com/NixOS/nixpkgs/commit/8b05ded0c502a74b580a673f91afad2c90bc0566) | `` zitadel: fix vendorHash for go1.22 ``                                                          |
| [`5615fd00`](https://github.com/NixOS/nixpkgs/commit/5615fd0057a62e236e2ac2a6480e8ed34db9e3c2) | `` butler: fix vendorHash for go1.22 ``                                                           |
| [`e1afd4de`](https://github.com/NixOS/nixpkgs/commit/e1afd4de729127acbcfb57eeb83d45d0e7edf632) | `` bepass: fix vendorHash for go1.22 ``                                                           |
| [`92e5b8d6`](https://github.com/NixOS/nixpkgs/commit/92e5b8d6d90aa0301a2dd607ba93fc66bbdc5e17) | `` aerc: fix vendorHash for go1.22 ``                                                             |
| [`5e682bb1`](https://github.com/NixOS/nixpkgs/commit/5e682bb1bc2f09038be2b101ee502d584e6f78e3) | `` argocd-autopilot: fix vendorHash for go1.22 ``                                                 |
| [`8e649d36`](https://github.com/NixOS/nixpkgs/commit/8e649d36d3a902022ae192d33ec26fb0e3c3e1ed) | `` wtf: fix vendorHash for go1.22 ``                                                              |
| [`c39b2e88`](https://github.com/NixOS/nixpkgs/commit/c39b2e886d123f3e460a65d55c75eb04b8482b5a) | `` skate: fix vendorHash for go1.22 ``                                                            |
| [`ef79e057`](https://github.com/NixOS/nixpkgs/commit/ef79e0578ea7f0f32d8ed48dd6309343276f261e) | `` ratt: fix vendorHash for go1.22 ``                                                             |
| [`049b684d`](https://github.com/NixOS/nixpkgs/commit/049b684d52e1f9abfc5f748c621adaec30548a47) | `` deckmaster: fix vendorHash for go1.22 ``                                                       |
| [`3e28bdc6`](https://github.com/NixOS/nixpkgs/commit/3e28bdc6786cb4192f2a04248cf65c49bc43bcd0) | `` buildGoModule: inherit env from main package to goModule derivation ``                         |
| [`b8d10fa8`](https://github.com/NixOS/nixpkgs/commit/b8d10fa8b4c7737671a29a71182805ad53de6eba) | `` mystmd: 1.1.52 -> 1.1.53 ``                                                                    |
| [`5afa0eef`](https://github.com/NixOS/nixpkgs/commit/5afa0eef21187cc51abcda0f45dfd076775db7ed) | `` rain: 1.8.4 -> 1.8.5 ``                                                                        |
| [`0aeb5d0c`](https://github.com/NixOS/nixpkgs/commit/0aeb5d0cc2617bc8236de311146bdc71218a316d) | `` unar: add meta.mainProgram ``                                                                  |
| [`071d333c`](https://github.com/NixOS/nixpkgs/commit/071d333ca0d8e72ac3617b7cd86682cdc7aa766d) | `` sarasa-gothic: 1.0.9 -> 1.0.10 ``                                                              |
| [`a00e2964`](https://github.com/NixOS/nixpkgs/commit/a00e2964ae12c03f6418b3c2d189b9eaa12e837c) | `` rizin: 0.7.2 -> 0.7.3 ``                                                                       |
| [`ef92c824`](https://github.com/NixOS/nixpkgs/commit/ef92c824207db991798ddb14586b302fc5f7308a) | `` python312Packages.mdformat-mkdocs: 2.0.7 -> 2.0.8 ``                                           |
| [`dc4d5c21`](https://github.com/NixOS/nixpkgs/commit/dc4d5c21937ec81d41e0211d74d6e562955bf5be) | `` llvmPackages_{12,13,14,15,16,17,18,git}: use common clang ``                                   |
| [`5c4218b3`](https://github.com/NixOS/nixpkgs/commit/5c4218b36ccb5d0e220e3bda01c3537c3aa8cc06) | `` dolphin-emu: unpin stdenv on darwin ``                                                         |
| [`3510d0af`](https://github.com/NixOS/nixpkgs/commit/3510d0af43b3da8e9dbf8573c010e3e68c36ea9f) | `` prometheus-zfs-exporter: 2.3.2 -> 2.3.4 ``                                                     |
| [`92b656e0`](https://github.com/NixOS/nixpkgs/commit/92b656e0446a2622d35ebde15962088b925903c7) | `` erlang_27: init at 27-rc2 ``                                                                   |
| [`907ee9b7`](https://github.com/NixOS/nixpkgs/commit/907ee9b75ac2162bb7b6f9ab6a6a15b7643dd52f) | `` maintainers: corrected email address (#303922) ``                                              |
| [`e014052f`](https://github.com/NixOS/nixpkgs/commit/e014052f61e6e4c39b827ac30ec1222e769b592e) | `` aseprite: 1.3.2 -> 1.3.6 ``                                                                    |
| [`0b49eafe`](https://github.com/NixOS/nixpkgs/commit/0b49eafe5fb2b62014c11c3df17dfc1e56d29e05) | `` klipper-estimator: 3.7.1 -> 3.7.2 ``                                                           |
| [`e2442cd3`](https://github.com/NixOS/nixpkgs/commit/e2442cd3c745e8cee7513247ffb60d15c4b4f811) | `` ladybird: restore x86_64-darwin support ``                                                     |
| [`b3079c52`](https://github.com/NixOS/nixpkgs/commit/b3079c52c02fb2a0b21e1c852f65d28218633580) | `` kotatogram-desktop: use llvmPackages_14 on darwin ``                                           |
| [`eee3a882`](https://github.com/NixOS/nixpkgs/commit/eee3a882e21f1a5c9fa5e3c7e5aa12a33558bc80) | `` far2l: 2.6.0 -> 2.6.1 ``                                                                       |
| [`ca482b6b`](https://github.com/NixOS/nixpkgs/commit/ca482b6bdb0c009aeb361217b9f28539f76b2a81) | `` frugal: 3.17.10 -> 3.17.11 ``                                                                  |
| [`e784c7af`](https://github.com/NixOS/nixpkgs/commit/e784c7af31358a09ac4c76f7401b8344243b077f) | `` listenbrainz-mpd: 2.3.3 -> 2.3.4 ``                                                            |
| [`86f8ba30`](https://github.com/NixOS/nixpkgs/commit/86f8ba301f43e554112b5574427c2bb7d8e134ab) | `` python311Packages.pyprecice: 3.0.0.0 -> 3.1.0 ``                                               |
| [`4508b599`](https://github.com/NixOS/nixpkgs/commit/4508b5990092ce3d4760b6908667137c88adad5f) | `` nixos/ollama: update documentation ``                                                          |
| [`3769ffed`](https://github.com/NixOS/nixpkgs/commit/3769ffed5960fe7b9bf43383db9b295b9db902d1) | `` ollama: 0.1.30 -> 0.1.31 ``                                                                    |
| [`5a7fd60a`](https://github.com/NixOS/nixpkgs/commit/5a7fd60a2dd07b75ae42e3928e0475132975cfee) | `` 4d-minesweeper: Init at 2.0 ``                                                                 |
| [`73492d7f`](https://github.com/NixOS/nixpkgs/commit/73492d7fa13f3ade085d258a6b8d834189ad2445) | `` awscli2: 2.15.34 -> 2.15.38 ``                                                                 |
| [`de5b46c4`](https://github.com/NixOS/nixpkgs/commit/de5b46c471daf40953841fa36597d2f09d8f3d04) | `` nixos/prometheus: use ports type ``                                                            |
| [`7a80e67c`](https://github.com/NixOS/nixpkgs/commit/7a80e67cb302fc4c7d39c38e18f7b992eb674006) | `` turso-cli: 0.90.3 -> 0.90.7 ``                                                                 |
| [`2e1cafda`](https://github.com/NixOS/nixpkgs/commit/2e1cafdad3fbb14ad1120f20871b9eeb1705e795) | `` templ: move to `pkgs/by-name` ``                                                               |
| [`788a2a43`](https://github.com/NixOS/nixpkgs/commit/788a2a4399e92f31031e6a82a1cde605b48ebdb0) | `` amdgpu_top: 0.7.0 -> 0.8.2 ``                                                                  |
| [`0e9632b5`](https://github.com/NixOS/nixpkgs/commit/0e9632b597df1e7736d2ea191fe9fe3bd62fef0e) | `` fteqw: unstable-2023-08-03 -> 0-unstable-2024-04-13 ``                                         |
| [`6d8db49e`](https://github.com/NixOS/nixpkgs/commit/6d8db49ed0f617a966e244ded324ef804b998764) | `` f2c: 20240130 -> 20240312 ``                                                                   |
| [`b579dac4`](https://github.com/NixOS/nixpkgs/commit/b579dac4ed3d3d059d2a701df1728bf31a05ee70) | `` nixos/paperless: override enabled tesseract languages with the in paperless configured ones `` |
| [`4ed0ebac`](https://github.com/NixOS/nixpkgs/commit/4ed0ebac06b3c59d7416b4ddc64b7ac6956e6eb3) | `` maintainers: add bonsairobo ``                                                                 |
| [`c27e1bcb`](https://github.com/NixOS/nixpkgs/commit/c27e1bcb98fc8ec2db629ce2ea3d2fa3d310214d) | `` ktx-tools: init at 4.2.1 ``                                                                    |
| [`ec7438fd`](https://github.com/NixOS/nixpkgs/commit/ec7438fdc338d0c2da275f4e99caa4ebef4136ca) | `` cargo-dist: 0.11.1 -> 0.13.1 ``                                                                |
| [`dd939b34`](https://github.com/NixOS/nixpkgs/commit/dd939b341f9e366c45c88471c3000459d16ad31a) | `` sketchybar-app-font: 2.0.16 -> 2.0.17 ``                                                       |
| [`490494e8`](https://github.com/NixOS/nixpkgs/commit/490494e82deeb8e84d7f18bea0761fb7a9b99566) | `` python312Packages.simplekv: format with nixfmt ``                                              |
| [`5981eaa4`](https://github.com/NixOS/nixpkgs/commit/5981eaa4aff36bf38fa1b41dacd8c76cb09d0d7b) | `` python312Packages.simplekv: refactor ``                                                        |
| [`7f6b573d`](https://github.com/NixOS/nixpkgs/commit/7f6b573df9d2f4ddb5c296e39d8a75668d199222) | `` python312Packages.attrdict: format with nixfmt ``                                              |
| [`89317108`](https://github.com/NixOS/nixpkgs/commit/8931710805cf7ce65b41153123ff931b123bcdcd) | `` python311Packages.azure-appconfiguration: format with nixfmt ``                                |
| [`0e6226eb`](https://github.com/NixOS/nixpkgs/commit/0e6226eb02763c8dfab58076d8e7fd4fd28c2c6f) | `` python311Packages.azure-appconfiguration: refactor ``                                          |
| [`e9f4c8d4`](https://github.com/NixOS/nixpkgs/commit/e9f4c8d41e1e2e7fdf70cd9aae193ce026e4cc58) | `` trufflehog: 3.72.0 -> 3.73.0 ``                                                                |
| [`b730874a`](https://github.com/NixOS/nixpkgs/commit/b730874aa5a7e59fce8b6c8ebda4c42a480e5a9c) | `` prismlauncher: add vulkan-loader ``                                                            |
| [`fe77b884`](https://github.com/NixOS/nixpkgs/commit/fe77b88406ac0b7950fc55c25c113821eab72a95) | `` unciv: 4.11.2 -> 4.11.4 ``                                                                     |