### PR TITLE
chore(flake/nixpkgs-unstable): `e546289e` -> `5f81b281`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1303,11 +1303,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1713021534,
-        "narHash": "sha256-Aqz8cY3NRUEFWqtLA6xxJBHD1B+CopZkMaVEFZxjX3I=",
+        "lastModified": 1713107505,
+        "narHash": "sha256-JZIwPyHhX7XzUTIyHNQSPmLdwVtQZ3zMGoXvtvaoZZQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e546289ea912083149781d395778043053825db0",
+        "rev": "5f81b2812ea76d998cb25a3491cce03093326cb2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`be86ca7e`](https://github.com/NixOS/nixpkgs/commit/be86ca7e0e5320b7a42711b88c1b32cafce7fef1) | `` cargo-temp: 0.2.19 -> 0.2.20 ``                                                                |
| [`57f408c5`](https://github.com/NixOS/nixpkgs/commit/57f408c562d6fc17aaa60a16573d741ba5a3e0e4) | `` pace: init at 0.15.2 ``                                                                        |
| [`d9046002`](https://github.com/NixOS/nixpkgs/commit/d9046002291c03f00fd6abbd1a623283ee7978f0) | `` protolint: 0.49.4 -> 0.49.6 ``                                                                 |
| [`6b09031c`](https://github.com/NixOS/nixpkgs/commit/6b09031c2c45c2e25b57bef8e02367cf755136a0) | `` clipcat: 0.16.5 -> 0.16.6 ``                                                                   |
| [`cf8ecfbd`](https://github.com/NixOS/nixpkgs/commit/cf8ecfbd027393f633c27a891408d1b0eedb5bb8) | `` cargo-tally: 1.0.42 -> 1.0.43 ``                                                               |
| [`3aa35ca0`](https://github.com/NixOS/nixpkgs/commit/3aa35ca0238d9cef55f840a45947a88a9d0fbd6a) | `` maintainers: add isabelroses ``                                                                |
| [`8faaed60`](https://github.com/NixOS/nixpkgs/commit/8faaed60249a44ba718ac748f75aefbbee18a8b6) | `` cariddi: 1.3.3 -> 1.3.4 ``                                                                     |
| [`b680b6eb`](https://github.com/NixOS/nixpkgs/commit/b680b6eb94076fad8ac57edb2a077f34289585ba) | `` tenv: 1.7.0 -> 1.7.1 ``                                                                        |
| [`10062752`](https://github.com/NixOS/nixpkgs/commit/10062752e1d5e4934e7b71b2e636c07d9274ac9f) | `` livi: init at 0.0.6 ``                                                                         |
| [`6bc0ceae`](https://github.com/NixOS/nixpkgs/commit/6bc0ceaee79bd14d0abfcb7c1f21f0017bd17435) | `` ugrep: 5.1.3 -> 5.1.4 ``                                                                       |
| [`816ec8cf`](https://github.com/NixOS/nixpkgs/commit/816ec8cfe345c6e3942828ec4513f6c97e2a37a9) | `` phrase-cli: 2.23.1 -> 2.23.2 ``                                                                |
| [`56742e96`](https://github.com/NixOS/nixpkgs/commit/56742e961c9801e16ecc2b0e228cddc046b997aa) | `` exploitdb: 2024-04-13 -> 2024-04-14 ``                                                         |
| [`ca453e82`](https://github.com/NixOS/nixpkgs/commit/ca453e82df8daed165e7b0890b3ec91d0065a6ba) | `` androidStudioPackages.canary: 2024.1.1.2 -> 2024.1.1.3 ``                                      |
| [`db585038`](https://github.com/NixOS/nixpkgs/commit/db585038d275944a8e68b575cb71154e20c77973) | `` simulide_1_1_0: 1.1.0-RC1 -> 1.1.0-SR0 ``                                                      |
| [`d0b62f21`](https://github.com/NixOS/nixpkgs/commit/d0b62f21051575fcb4e6a48f5d94ddc1090a8e4e) | `` minijinja: 1.0.17 -> 1.0.20 ``                                                                 |
| [`a8800e7f`](https://github.com/NixOS/nixpkgs/commit/a8800e7f5f6e0442c8dca1fc0982dbd11316294b) | `` Plasma 5: 5.27.10 -> 5.27.11 ``                                                                |
| [`b5132960`](https://github.com/NixOS/nixpkgs/commit/b51329603f2ef41324d130f5d1ba1dd90658db55) | `` atmos: 1.68.0 -> 1.69.0 ``                                                                     |
| [`4ae12930`](https://github.com/NixOS/nixpkgs/commit/4ae12930f24eff5a06aa211063028c80385868ec) | `` nixos/xfce: `bgSupport = !noDesktop` ``                                                        |
| [`b8d10fa8`](https://github.com/NixOS/nixpkgs/commit/b8d10fa8b4c7737671a29a71182805ad53de6eba) | `` mystmd: 1.1.52 -> 1.1.53 ``                                                                    |
| [`5afa0eef`](https://github.com/NixOS/nixpkgs/commit/5afa0eef21187cc51abcda0f45dfd076775db7ed) | `` rain: 1.8.4 -> 1.8.5 ``                                                                        |
| [`0aeb5d0c`](https://github.com/NixOS/nixpkgs/commit/0aeb5d0cc2617bc8236de311146bdc71218a316d) | `` unar: add meta.mainProgram ``                                                                  |
| [`071d333c`](https://github.com/NixOS/nixpkgs/commit/071d333ca0d8e72ac3617b7cd86682cdc7aa766d) | `` sarasa-gothic: 1.0.9 -> 1.0.10 ``                                                              |
| [`ef92c824`](https://github.com/NixOS/nixpkgs/commit/ef92c824207db991798ddb14586b302fc5f7308a) | `` python312Packages.mdformat-mkdocs: 2.0.7 -> 2.0.8 ``                                           |
| [`dc4d5c21`](https://github.com/NixOS/nixpkgs/commit/dc4d5c21937ec81d41e0211d74d6e562955bf5be) | `` llvmPackages_{12,13,14,15,16,17,18,git}: use common clang ``                                   |
| [`3510d0af`](https://github.com/NixOS/nixpkgs/commit/3510d0af43b3da8e9dbf8573c010e3e68c36ea9f) | `` prometheus-zfs-exporter: 2.3.2 -> 2.3.4 ``                                                     |
| [`92b656e0`](https://github.com/NixOS/nixpkgs/commit/92b656e0446a2622d35ebde15962088b925903c7) | `` erlang_27: init at 27-rc2 ``                                                                   |
| [`907ee9b7`](https://github.com/NixOS/nixpkgs/commit/907ee9b75ac2162bb7b6f9ab6a6a15b7643dd52f) | `` maintainers: corrected email address (#303922) ``                                              |
| [`e014052f`](https://github.com/NixOS/nixpkgs/commit/e014052f61e6e4c39b827ac30ec1222e769b592e) | `` aseprite: 1.3.2 -> 1.3.6 ``                                                                    |
| [`0b49eafe`](https://github.com/NixOS/nixpkgs/commit/0b49eafe5fb2b62014c11c3df17dfc1e56d29e05) | `` klipper-estimator: 3.7.1 -> 3.7.2 ``                                                           |
| [`e2442cd3`](https://github.com/NixOS/nixpkgs/commit/e2442cd3c745e8cee7513247ffb60d15c4b4f811) | `` ladybird: restore x86_64-darwin support ``                                                     |
| [`eee3a882`](https://github.com/NixOS/nixpkgs/commit/eee3a882e21f1a5c9fa5e3c7e5aa12a33558bc80) | `` far2l: 2.6.0 -> 2.6.1 ``                                                                       |
| [`ca482b6b`](https://github.com/NixOS/nixpkgs/commit/ca482b6bdb0c009aeb361217b9f28539f76b2a81) | `` frugal: 3.17.10 -> 3.17.11 ``                                                                  |
| [`e784c7af`](https://github.com/NixOS/nixpkgs/commit/e784c7af31358a09ac4c76f7401b8344243b077f) | `` listenbrainz-mpd: 2.3.3 -> 2.3.4 ``                                                            |
| [`86f8ba30`](https://github.com/NixOS/nixpkgs/commit/86f8ba301f43e554112b5574427c2bb7d8e134ab) | `` python311Packages.pyprecice: 3.0.0.0 -> 3.1.0 ``                                               |
| [`4508b599`](https://github.com/NixOS/nixpkgs/commit/4508b5990092ce3d4760b6908667137c88adad5f) | `` nixos/ollama: update documentation ``                                                          |
| [`3769ffed`](https://github.com/NixOS/nixpkgs/commit/3769ffed5960fe7b9bf43383db9b295b9db902d1) | `` ollama: 0.1.30 -> 0.1.31 ``                                                                    |
| [`5a7fd60a`](https://github.com/NixOS/nixpkgs/commit/5a7fd60a2dd07b75ae42e3928e0475132975cfee) | `` 4d-minesweeper: Init at 2.0 ``                                                                 |
| [`73492d7f`](https://github.com/NixOS/nixpkgs/commit/73492d7fa13f3ade085d258a6b8d834189ad2445) | `` awscli2: 2.15.34 -> 2.15.38 ``                                                                 |
| [`de5b46c4`](https://github.com/NixOS/nixpkgs/commit/de5b46c471daf40953841fa36597d2f09d8f3d04) | `` nixos/prometheus: use ports type ``                                                            |
| [`7a80e67c`](https://github.com/NixOS/nixpkgs/commit/7a80e67cb302fc4c7d39c38e18f7b992eb674006) | `` turso-cli: 0.90.3 -> 0.90.7 ``                                                                 |
| [`2e1cafda`](https://github.com/NixOS/nixpkgs/commit/2e1cafdad3fbb14ad1120f20871b9eeb1705e795) | `` templ: move to `pkgs/by-name` ``                                                               |
| [`e2cd8a7a`](https://github.com/NixOS/nixpkgs/commit/e2cd8a7a2b1f508fedbfebfacd03a3036f32ac88) | `` editorconfig-core-c: 0.12.5 -> 0.12.7 ``                                                       |
| [`788a2a43`](https://github.com/NixOS/nixpkgs/commit/788a2a4399e92f31031e6a82a1cde605b48ebdb0) | `` amdgpu_top: 0.7.0 -> 0.8.2 ``                                                                  |
| [`d5793186`](https://github.com/NixOS/nixpkgs/commit/d5793186e8b239fe551839c3162c26873709e799) | `` python3Packages.sev-snp-measure: init at 0.0.9 (#303158) ``                                    |
| [`0e9632b5`](https://github.com/NixOS/nixpkgs/commit/0e9632b597df1e7736d2ea191fe9fe3bd62fef0e) | `` fteqw: unstable-2023-08-03 -> 0-unstable-2024-04-13 ``                                         |
| [`6d8db49e`](https://github.com/NixOS/nixpkgs/commit/6d8db49ed0f617a966e244ded324ef804b998764) | `` f2c: 20240130 -> 20240312 ``                                                                   |
| [`b579dac4`](https://github.com/NixOS/nixpkgs/commit/b579dac4ed3d3d059d2a701df1728bf31a05ee70) | `` nixos/paperless: override enabled tesseract languages with the in paperless configured ones `` |
| [`4ed0ebac`](https://github.com/NixOS/nixpkgs/commit/4ed0ebac06b3c59d7416b4ddc64b7ac6956e6eb3) | `` maintainers: add bonsairobo ``                                                                 |
| [`c27e1bcb`](https://github.com/NixOS/nixpkgs/commit/c27e1bcb98fc8ec2db629ce2ea3d2fa3d310214d) | `` ktx-tools: init at 4.2.1 ``                                                                    |
| [`ec7438fd`](https://github.com/NixOS/nixpkgs/commit/ec7438fdc338d0c2da275f4e99caa4ebef4136ca) | `` cargo-dist: 0.11.1 -> 0.13.1 ``                                                                |
| [`dd939b34`](https://github.com/NixOS/nixpkgs/commit/dd939b341f9e366c45c88471c3000459d16ad31a) | `` sketchybar-app-font: 2.0.16 -> 2.0.17 ``                                                       |
| [`490494e8`](https://github.com/NixOS/nixpkgs/commit/490494e82deeb8e84d7f18bea0761fb7a9b99566) | `` python312Packages.simplekv: format with nixfmt ``                                              |
| [`5981eaa4`](https://github.com/NixOS/nixpkgs/commit/5981eaa4aff36bf38fa1b41dacd8c76cb09d0d7b) | `` python312Packages.simplekv: refactor ``                                                        |
| [`7f6b573d`](https://github.com/NixOS/nixpkgs/commit/7f6b573df9d2f4ddb5c296e39d8a75668d199222) | `` python312Packages.attrdict: format with nixfmt ``                                              |
| [`841e60c6`](https://github.com/NixOS/nixpkgs/commit/841e60c6c58fdbff6bbd4a4bb6ee7f6f14b0d5c5) | `` coder: add updateScript ``                                                                     |
| [`89317108`](https://github.com/NixOS/nixpkgs/commit/8931710805cf7ce65b41153123ff931b123bcdcd) | `` python311Packages.azure-appconfiguration: format with nixfmt ``                                |
| [`0e6226eb`](https://github.com/NixOS/nixpkgs/commit/0e6226eb02763c8dfab58076d8e7fd4fd28c2c6f) | `` python311Packages.azure-appconfiguration: refactor ``                                          |
| [`e9f4c8d4`](https://github.com/NixOS/nixpkgs/commit/e9f4c8d41e1e2e7fdf70cd9aae193ce026e4cc58) | `` trufflehog: 3.72.0 -> 3.73.0 ``                                                                |
| [`26013573`](https://github.com/NixOS/nixpkgs/commit/26013573a799a46bb7e2de53b5e11335ed9fbdbc) | `` gimpPlugins.gap: patch ffmpeg to avoid asm error ``                                            |
| [`b730874a`](https://github.com/NixOS/nixpkgs/commit/b730874aa5a7e59fce8b6c8ebda4c42a480e5a9c) | `` prismlauncher: add vulkan-loader ``                                                            |
| [`fe77b884`](https://github.com/NixOS/nixpkgs/commit/fe77b88406ac0b7950fc55c25c113821eab72a95) | `` unciv: 4.11.2 -> 4.11.4 ``                                                                     |
| [`3566f9e8`](https://github.com/NixOS/nixpkgs/commit/3566f9e81d32e0a6064c545ff2696132ade8fb9f) | `` exploitdb: 2024-04-09 -> 2024-04-13 ``                                                         |
| [`a47f8954`](https://github.com/NixOS/nixpkgs/commit/a47f8954c7a41bf403cb59eb4d2f6a69bb1622be) | `` python311Packages.django-ipware: 6.0.4 -> 6.0.5 ``                                             |
| [`aece2526`](https://github.com/NixOS/nixpkgs/commit/aece25266ab710641f5b49c217e3cf9de7ceb86c) | `` rpcs3: 0.0.31-16271-4ecf8ecd0 -> 0.0.31-16334-fba1db29b ``                                     |
| [`ba2a15e0`](https://github.com/NixOS/nixpkgs/commit/ba2a15e0c469f71eae8071e26f4130099b0df88b) | `` home-assistant-custom-components.indego: init at 5.5.0 ``                                      |
| [`41df6e2e`](https://github.com/NixOS/nixpkgs/commit/41df6e2e2bbecb21398f67745d25db597110e80b) | `` python312Packages.pyindego: init at 3.1.1 ``                                                   |
| [`c0c2f290`](https://github.com/NixOS/nixpkgs/commit/c0c2f2903f310dd5efb86f02b4b5f824183f5173) | `` lib.mdDoc: remove and replace with warning ``                                                  |
| [`46456a92`](https://github.com/NixOS/nixpkgs/commit/46456a929b654ed2ac9c56f8a0c1fa1823a4a2a9) | `` lib: remove all uses of lib.mdDoc ``                                                           |
| [`170e005a`](https://github.com/NixOS/nixpkgs/commit/170e005a9252cbf60641462d332a1023d66bdf5d) | `` pkgs/config: remove uses of lib.mdDoc ``                                                       |
| [`6afb255d`](https://github.com/NixOS/nixpkgs/commit/6afb255d976f85f3359e4929abd6f5149c323a02) | `` nixos: remove all uses of lib.mdDoc ``                                                         |
| [`1dd996e5`](https://github.com/NixOS/nixpkgs/commit/1dd996e59a5e67694b7a252aacba71a88d51b41e) | `` aichat: 0.15.0 -> 0.16.0 ``                                                                    |
| [`96659af1`](https://github.com/NixOS/nixpkgs/commit/96659af197072c921c6063021788ad5d32fb6b3f) | `` nixos/crabfit: init ``                                                                         |
| [`933dd4ce`](https://github.com/NixOS/nixpkgs/commit/933dd4ce289d68505018f79baa09052344850138) | `` libdwarf: 0.9.0 -> 0.9.2 ``                                                                    |
| [`600fcb20`](https://github.com/NixOS/nixpkgs/commit/600fcb2070fc30ff978dcf6fb57d81c6212b4aac) | `` crabfit-frontend: init at unstable-2023-08-02 ``                                               |
| [`9239dfa0`](https://github.com/NixOS/nixpkgs/commit/9239dfa065af4f87672ee08137199d45b2a94e5a) | `` linkerd_edge: 24.3.5 -> 24.4.2 ``                                                              |
| [`84f74ee1`](https://github.com/NixOS/nixpkgs/commit/84f74ee14b7370234d58e99d7fcc37156b5bcc1c) | `` bird: add herbetom as maintainer ``                                                            |
| [`9039bcbe`](https://github.com/NixOS/nixpkgs/commit/9039bcbe79f72e581ce84bdf07a59e0064aaa144) | `` crabfit-api: init at unstable-2023-08-02 ``                                                    |
| [`8526ce72`](https://github.com/NixOS/nixpkgs/commit/8526ce728d54b2c2afd6e1634e18ea2cb10dabf1) | `` maintainers: add mksafavi ``                                                                   |
| [`21c9e665`](https://github.com/NixOS/nixpkgs/commit/21c9e6650e60f796c7bf3595503dc70cbf8008b8) | `` discover-overlay: init at 0.7.0 ``                                                             |
| [`6bb72e79`](https://github.com/NixOS/nixpkgs/commit/6bb72e79f7dc29fab08fed730b5b7fe7df031a9e) | `` tootik: 0.9.6 -> 0.10.0 ``                                                                     |
| [`5774fe42`](https://github.com/NixOS/nixpkgs/commit/5774fe4232705d1c766cf9095065bea3453d7e33) | `` python311Packages.azure-appconfiguration: 1.5.0 -> 1.6.0 ``                                    |
| [`b18d7cc4`](https://github.com/NixOS/nixpkgs/commit/b18d7cc426c2ab2015826d95047b2c51395081f0) | `` python312Packages.adlfs: foramt with nixfmt ``                                                 |
| [`ac1f7bc8`](https://github.com/NixOS/nixpkgs/commit/ac1f7bc86d7215872cb7a21d7e8c3a4ffb012a37) | `` python312Packages.adlfs: refactor ``                                                           |
| [`33346ab5`](https://github.com/NixOS/nixpkgs/commit/33346ab5ac64671735fc3727ceb773dd44d73b95) | `` mini-calc: 2.12.2 -> 2.12.3 ``                                                                 |
| [`1ba97bc3`](https://github.com/NixOS/nixpkgs/commit/1ba97bc32cdd44efa350ab4854deeab3f3794299) | `` python312Packages.adlfs: 2024.2.0 -> 2024.4.0 ``                                               |
| [`9e7b5b28`](https://github.com/NixOS/nixpkgs/commit/9e7b5b28014eb1c2cef4c2880f81623843ab374f) | `` xdg-terminal-exec: 0.9.0 -> 0.9.3 ``                                                           |
| [`eb086c06`](https://github.com/NixOS/nixpkgs/commit/eb086c0687ee37edf66425bb1fe72b5f25b9637e) | `` metasploit: 6.4.2 -> 6.4.3 ``                                                                  |
| [`21ac8f8c`](https://github.com/NixOS/nixpkgs/commit/21ac8f8cd880c3c6e4f4055ad3148b70b0fcc476) | `` hyprshade: fix systemd user service ``                                                         |
| [`6de29df1`](https://github.com/NixOS/nixpkgs/commit/6de29df165236e618f7cff90cfef4d1a4024e653) | `` python311Packages.types-redis: format with nixfmt ``                                           |
| [`4673cc1e`](https://github.com/NixOS/nixpkgs/commit/4673cc1e0003e5e8dc5b34e7fb43b1e0d3a9890a) | `` python311Packages.types-redis: refactor ``                                                     |
| [`ab05cc3b`](https://github.com/NixOS/nixpkgs/commit/ab05cc3b1f6a0168f3d345d51c23c466d5121075) | `` radcli: init at 1.3.1 ``                                                                       |