### PR TITLE
chore(flake/home-manager): `9f32c66a` -> `1c43dcfa`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713131281,
-        "narHash": "sha256-/Jm1X9MPfLXAxZSCdWmQAFNUQggEfNWHol5jSyyzFzw=",
+        "lastModified": 1713166971,
+        "narHash": "sha256-t0P/rKlsE5l1O3O2LYtAelLzp7PeoPCSzsIietQ1hSM=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "9f32c66a51d05e6d4ec0dea555bbff9135749ec7",
+        "rev": "1c43dcfac48a2d622797f7ab741670fdbcf8f609",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                               |
| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`1c43dcfa`](https://github.com/nix-community/home-manager/commit/1c43dcfac48a2d622797f7ab741670fdbcf8f609) | `` ci: bump peaceiris/actions-gh-pages from 3 to 4 `` |
| [`59d50bc5`](https://github.com/nix-community/home-manager/commit/59d50bc582bdf439df096a9ae1781e6c9c8a7523) | `` espanso: enable module on darwin ``                |