### PR TITLE
chore(flake/emacs-overlay): `f92b1cf3` -> `cf218237`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713133980,
-        "narHash": "sha256-fGpgQoMyuLbS/r3FkZ59ISNI3Oo148tEMlKJpnmCI7w=",
+        "lastModified": 1713200735,
+        "narHash": "sha256-6qPfZsYW3BvyJq+BahgygLdFd5bdqrFue8QGat4lSQo=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "f92b1cf3105eb9eab992e585861a762ad8cb0037",
+        "rev": "cf218237d0d80f1ec8109677ebc82ded2ca84c43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message             |
| ------------------------------------------------------------------------------------------------------------ | ------------------- |
| [`cf218237`](https://github.com/nix-community/emacs-overlay/commit/cf218237d0d80f1ec8109677ebc82ded2ca84c43) | `` Updated emacs `` |
| [`ef7430cd`](https://github.com/nix-community/emacs-overlay/commit/ef7430cdf20c9d82d75ca9331ecc0f8f3115da3c) | `` Updated melpa `` |
| [`5e8cb839`](https://github.com/nix-community/emacs-overlay/commit/5e8cb83995ca355ebed239e66ec4b078f595a1b3) | `` Updated elpa ``  |
| [`61264683`](https://github.com/nix-community/emacs-overlay/commit/612646835968f663fd0e8f1a21ef52b5d0b88c57) | `` Updated melpa `` |
| [`1b01966e`](https://github.com/nix-community/emacs-overlay/commit/1b01966ee01008bcec18702ea5e543b93236ecef) | `` Updated emacs `` |
| [`86488b45`](https://github.com/nix-community/emacs-overlay/commit/86488b451ae54961218f3c85a8554aa7fcdb8731) | `` Updated melpa `` |
| [`1cc0a115`](https://github.com/nix-community/emacs-overlay/commit/1cc0a11542f4feba8430a001b20c2c0151978706) | `` Updated emacs `` |
| [`3b158dc7`](https://github.com/nix-community/emacs-overlay/commit/3b158dc76f3bb67ee9f32bb9bb15571d7ea2074c) | `` Updated melpa `` |