### PR TITLE
chore(flake/devshell): `2d45b54c` -> `2c8e04e5`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -120,11 +120,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1711099426,
-        "narHash": "sha256-HzpgM/wc3aqpnHJJ2oDqPBkNsqWbW0WfWUO8lKu8nGk=",
+        "lastModified": 1713195852,
+        "narHash": "sha256-MEb4Hx/Aw7pcsmcHXBuldFsrVTfl9Q9dz1JSlxUanmE=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "2d45b54ca4a183f2fdcf4b19c895b64fbf620ee8",
+        "rev": "2c8e04e5c29299bec53c2e5a73da0f9afa8dabb5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                               |
| ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`2c8e04e5`](https://github.com/numtide/devshell/commit/2c8e04e5c29299bec53c2e5a73da0f9afa8dabb5) | `` init compatibility with: nix bundle, nix run, lib.getExe (#306) `` |