### PR TITLE
chore(flake/sops-nix): `226062b4` -> `cc535d07`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1534,11 +1534,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713066950,
-        "narHash": "sha256-ZaefFyvt5369XdjzSw43NhfbPM9MN5b9YXhzx4lFIRc=",
+        "lastModified": 1713174909,
+        "narHash": "sha256-APoDs2GtzVrsE+Z9w72qpHzEtEDfuinWcNTN7zhwLxg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "226062b47fe0e2130ba3ee9f4f1c880dc815cf87",
+        "rev": "cc535d07cbcdd562bcca418e475c7b1959cefa4b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                   |
| ----------------------------------------------------------------------------------------------- | ----------------------------------------- |
| [`cc535d07`](https://github.com/Mic92/sops-nix/commit/cc535d07cbcdd562bcca418e475c7b1959cefa4b) | `` remove all uses of lib.mdDoc (#532) `` |