### PR TITLE
chore(flake/hyprland): `67f47fbd` -> `ccbdce7c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -687,11 +687,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713126795,
-        "narHash": "sha256-IX9N+WMMcdBsxjQFLHjBCwXByMt+0S8sL18dQ2QTzvI=",
+        "lastModified": 1713198145,
+        "narHash": "sha256-1JvIYclTpOsjL+VMABTuKSZBZdXlMryog3t8CHELkYA=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "67f47fbdccd639502a76ccb3552a23df37f19ef8",
+        "rev": "ccbdce7c8528781020b39ddf4498277df5e5e78d",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                  |
| ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
| [`ccbdce7c`](https://github.com/hyprwm/Hyprland/commit/ccbdce7c8528781020b39ddf4498277df5e5e78d) | `` input: send an empty relative event after constraint motion events `` |
| [`3dbf8e93`](https://github.com/hyprwm/Hyprland/commit/3dbf8e936e5646d2e935509399f430fec850398a) | `` cursor: add hyprcursor loggers ``                                     |
| [`d1c2d524`](https://github.com/hyprwm/Hyprland/commit/d1c2d524a0f0e92783d707b7e6552ac74075146c) | `` misc: fix autocompletions for meson (hyprctl/hyprpm) ``               |
| [`2ea36783`](https://github.com/hyprwm/Hyprland/commit/2ea367839bf6eb6eef1e954601b1cab63e218b84) | `` build: Unbreak build on FreeBSD by adjusting dependencies (#5595) ``  |
| [`1719905e`](https://github.com/hyprwm/Hyprland/commit/1719905e7fdb42516566fb95c07c6572d5fe6ce5) | `` CI: unshallow on checkout before sourcing the tarball ``              |
| [`ce4c3639`](https://github.com/hyprwm/Hyprland/commit/ce4c36392da5dd23d2893546c6a5d6681b72dcec) | `` hyprpm: minor fixes to hyprpm for shallow and versioned  clones ``    |