### PR TITLE
chore(flake/nixpkgs-master): `1f54fa2d` -> `7d7fedce`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1224,11 +1224,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1713132898,
-        "narHash": "sha256-q+uV0ZsTghNgLZA1IDw1K6wJ1pA2EBDwFee9eC1RCO0=",
+        "lastModified": 1713200622,
+        "narHash": "sha256-4724aM7OC3N7mtY42TGA+aUGhBjw1f2tF+UJ1eGDM3g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1f54fa2ddf2623784a2b4431b35a1b5ce91a14bf",
+        "rev": "7d7fedcedea7b082f566e75bfed7aed7950f07e3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`7801483a`](https://github.com/NixOS/nixpkgs/commit/7801483ab9e2587bdeef6cc5d7da7e7e499851e1) | `` fluxcd: convert hashes to SRI ``                                                   |
| [`e1728ff7`](https://github.com/NixOS/nixpkgs/commit/e1728ff7f53cc75f4ae228faae9088452d7063b3) | `` fluxcd: use SRI hash in update script ``                                           |
| [`94069e2d`](https://github.com/NixOS/nixpkgs/commit/94069e2d50bee6f7841fd57feb993305b3600fc4) | `` coder: use sri hash in updateScript ``                                             |
| [`47908a11`](https://github.com/NixOS/nixpkgs/commit/47908a114b3866efce8a9d9533c5c23510f5f7ae) | `` maintainers: add matrix for anthonyroussel ``                                      |
| [`8706b488`](https://github.com/NixOS/nixpkgs/commit/8706b488716e310f02e5ddc94204dc3fa81d511e) | `` python312Packages.snakemake-interface-storage-plugins: 3.1.1 -> 3.2.0 (#304299) `` |
| [`e9489ba9`](https://github.com/NixOS/nixpkgs/commit/e9489ba998eede2b42e31c21e2672f5c29cb3648) | `` ols: 0-unstable-2024-02-09 -> 0-unstable-2024-04-15 ``                             |
| [`093452c8`](https://github.com/NixOS/nixpkgs/commit/093452c8275ea957a927700b5cf5e1553ea99642) | `` php82Extensions.xdebug: 3.3.1 -> 3.3.2 ``                                          |
| [`1d84c76f`](https://github.com/NixOS/nixpkgs/commit/1d84c76f5c4f1cb710a250faca3ecc80a1edb9d1) | `` nixos/nh: init ``                                                                  |
| [`51af928d`](https://github.com/NixOS/nixpkgs/commit/51af928dececa60ead6a811e1899e4974b90e8b7) | `` ft2-clone: 1.80 -> 1.82 ``                                                         |
| [`14066b78`](https://github.com/NixOS/nixpkgs/commit/14066b7892bce539b6dce43dad5f320d4d81ab54) | `` gqlgenc: 0.19.3 -> 0.20.0 ``                                                       |
| [`e72f5dc4`](https://github.com/NixOS/nixpkgs/commit/e72f5dc40e319b150098b6dc29017790c6f32ab0) | `` kitty: 0.33.1 -> 0.34.0 ``                                                         |
| [`674f2a0d`](https://github.com/NixOS/nixpkgs/commit/674f2a0dd66e63c99b3ec50244d01d23990e7775) | `` cargo-expand: 1.0.82 -> 1.0.84 ``                                                  |
| [`5dccc921`](https://github.com/NixOS/nixpkgs/commit/5dccc92115d4d7e3ef69a83f5aa96dd404580b99) | `` smassh: init at 3.1.3 ``                                                           |
| [`d05c932a`](https://github.com/NixOS/nixpkgs/commit/d05c932ab21541c2bbe91a04e1d70ce8d439f18a) | `` maintainers: add aimpizza ``                                                       |
| [`6a8ead5e`](https://github.com/NixOS/nixpkgs/commit/6a8ead5e3e3d8d60edc6160eb7d74c30f9a2edbd) | `` kdepim-runtime: use XOAUTH2 SASL plugin from libkgapi ``                           |
| [`e2ae18a7`](https://github.com/NixOS/nixpkgs/commit/e2ae18a7f34910631c5465337862801ea35d53de) | `` walker: 0.0.68 -> 0.0.70 ``                                                        |
| [`cde53c12`](https://github.com/NixOS/nixpkgs/commit/cde53c12dcdc559b8f918957cb6c975e22575f17) | `` gnomeExtensions: remove GNOME 46 extensions from the default set ``                |
| [`fde3861f`](https://github.com/NixOS/nixpkgs/commit/fde3861f2109c4cd80c5fe6ba3aec827762cdb63) | `` wrapCC: check darwin-ness for -mcpu/-march based on targetPlatform ``              |
| [`a227e07e`](https://github.com/NixOS/nixpkgs/commit/a227e07e6d4681a2bddcc65a55dc89bc9e3d4162) | `` poethepoet: 0.25.0 -> 0.25.1 ``                                                    |
| [`57695af4`](https://github.com/NixOS/nixpkgs/commit/57695af495e85a1ac6ef8d4f4d1f7c6aeb9802a0) | `` deck: 1.36.2 -> 1.37.0 ``                                                          |
| [`908d0fba`](https://github.com/NixOS/nixpkgs/commit/908d0fba851762ffb41750f0df7fd82d55db3d05) | `` uplosi: 0.1.3 -> 0.2.0 ``                                                          |
| [`67c8efa6`](https://github.com/NixOS/nixpkgs/commit/67c8efa67e783492a349e7ccae5fc90e1312002e) | `` retroarch-joypad-autoconfig: 1.18.0 -> 1.18.1 ``                                   |
| [`b3c00684`](https://github.com/NixOS/nixpkgs/commit/b3c0068460df9529b2b7cb305d7002c8c828f0fb) | `` libretro.flycast: unstable-2024-04-05 -> unstable-2024-04-12 ``                    |
| [`96f0b95b`](https://github.com/NixOS/nixpkgs/commit/96f0b95bfec4cc6198cdf5e6c58f3b260f31c663) | `` libretro.mame: unstable-2024-04-05 -> unstable-2024-04-10 ``                       |
| [`1b411ccb`](https://github.com/NixOS/nixpkgs/commit/1b411ccbf39a1971cdb5bf809806c4c395d1bb24) | `` coqPackages.stdpp: 1.9.0 → 1.10.0 ``                                               |
| [`78945a82`](https://github.com/NixOS/nixpkgs/commit/78945a827cc5f2e5b97b7ca9807f7ac111086a1e) | `` stdenv: make inputDerivation never fixed-output ``                                 |
| [`301408fa`](https://github.com/NixOS/nixpkgs/commit/301408fab263d90d0e1b88f6cea00cb6d45aa531) | `` libretro.fbneo: unstable-2024-04-08 -> unstable-2024-04-15 ``                      |
| [`7a2ab79b`](https://github.com/NixOS/nixpkgs/commit/7a2ab79b5b1316139465f07d9d7bcaa469f155b4) | `` libretro.puae: unstable-2024-02-22 -> unstable-2024-04-12 ``                       |
| [`d4121f21`](https://github.com/NixOS/nixpkgs/commit/d4121f21d3ce8e31f7260ab738e2a71c0e6f3530) | `` libretro.ppsspp: unstable-2024-04-09 -> unstable-2024-04-14 ``                     |
| [`61312c18`](https://github.com/NixOS/nixpkgs/commit/61312c1890f8cca78a84d4ca26644bb3146e973c) | `` libretro.mame2003-plus: unstable-2024-04-09 -> unstable-2024-04-13 ``              |
| [`3559b8b0`](https://github.com/NixOS/nixpkgs/commit/3559b8b023d01db2d9abde1f3c552ffebdd7b024) | `` libretro.pcsx-rearmed: unstable-2024-04-06 -> unstable-2024-04-14 ``               |
| [`415a7526`](https://github.com/NixOS/nixpkgs/commit/415a7526a7507b0bf26a4ac77c0cd427a437ea01) | `` libretro.beetle-psx-hw: unstable-2024-03-22 -> unstable-2024-04-12 ``              |
| [`153de634`](https://github.com/NixOS/nixpkgs/commit/153de63415d8ca5a0b9fe0272c49e4c0d6c28016) | `` libretro.snes9x: unstable-2024-02-14 -> unstable-2024-04-13 ``                     |
| [`e5f757e7`](https://github.com/NixOS/nixpkgs/commit/e5f757e73a11d16a1df10e080bf69c1a245a0b56) | `` pkg-pferd: 3.5.1 -> 3.5.2 ``                                                       |
| [`97b7295e`](https://github.com/NixOS/nixpkgs/commit/97b7295ed419640c925a3fe0fbaa0aeacc3072d4) | `` libretro.play: unstable-2024-04-09 -> unstable-2024-04-10 ``                       |
| [`ab04c487`](https://github.com/NixOS/nixpkgs/commit/ab04c48766c67b36a10512b1e08514ec59f6ac41) | `` python312Packages.tencentcloud-sdk-python: 3.0.1128 -> 3.0.1129 ``                 |
| [`4a4d98d9`](https://github.com/NixOS/nixpkgs/commit/4a4d98d961953fbb9b7d6313833e1cc69fb3b612) | `` python312Packages.soco: format with nixfmt ``                                      |
| [`a589919c`](https://github.com/NixOS/nixpkgs/commit/a589919cb3949c24a0fc2c3c84d251a4d9098971) | `` python312Packages.soco: 0.30.2 -> 0.30.3 ``                                        |
| [`6c627445`](https://github.com/NixOS/nixpkgs/commit/6c627445817f092f4ebc1611b619c231510d7c0e) | `` python312Packages.soco: refactor ``                                                |
| [`e6afeada`](https://github.com/NixOS/nixpkgs/commit/e6afeada62ae43494168ffda167edd14648404e0) | `` fluent-bit: 3.0.1 -> 3.0.2 ``                                                      |
| [`88b93829`](https://github.com/NixOS/nixpkgs/commit/88b93829d9549c6fc83a8db777985f13456c1191) | `` netbird-ui: 0.27.2 -> 0.27.3 ``                                                    |
| [`b941d525`](https://github.com/NixOS/nixpkgs/commit/b941d525061a6e4f43882318225799c901f1ad40) | `` jasmin-compiler: 2023.06.2 → 2023.06.3 ``                                          |
| [`4b6f17a8`](https://github.com/NixOS/nixpkgs/commit/4b6f17a8a68cea10a618681a8163fbc02d30e1cc) | `` dune_3: 3.14.2 -> 3.15.0 ``                                                        |
| [`a46df739`](https://github.com/NixOS/nixpkgs/commit/a46df739b622b48333de8e1cb9fb07f3a41d99da) | `` subxt: 0.35.2 -> 0.35.3 ``                                                         |
| [`8f4266af`](https://github.com/NixOS/nixpkgs/commit/8f4266af56e3b1f361c71a1367904c4c8049f283) | `` luau: 0.620 -> 0.621 ``                                                            |
| [`f8b08359`](https://github.com/NixOS/nixpkgs/commit/f8b0835980b540fc6c765252ee80cfbef31ae4da) | `` nodejs_18: 18.20.1 -> 18.20.2 ``                                                   |
| [`638ea467`](https://github.com/NixOS/nixpkgs/commit/638ea4677efcd23fdc7896f71c21860fd9fcecfe) | `` python312Packages.goodwe: 0.3.2 -> 0.3.3 ``                                        |
| [`e91467c3`](https://github.com/NixOS/nixpkgs/commit/e91467c3ac90158d56bed52c43ac6c0cdc7a88bc) | `` ocamlPackages.owee: 0.6 → 0.7 ``                                                   |
| [`5e384f2b`](https://github.com/NixOS/nixpkgs/commit/5e384f2b24a309d4c2ca7a4c87b52a2ccb05eaa4) | `` ocamlPackages.spacetime_lib: remove at 0.3.0 (broken) ``                           |
| [`b9a62920`](https://github.com/NixOS/nixpkgs/commit/b9a629203cfb7a602695664e0efc56afd94dd356) | `` postgresql13Packages.lantern: 0.2.3 -> 0.2.4 ``                                    |
| [`0ae16ce4`](https://github.com/NixOS/nixpkgs/commit/0ae16ce46df6bf4a678cc6e84af8ab992812a253) | `` prometheus-pve-exporter: 3.2.2 -> 3.2.4 ``                                         |
| [`c0200c0d`](https://github.com/NixOS/nixpkgs/commit/c0200c0d4efd2213416f92ff058a19cbeca636cc) | `` oksh: link to ncurses ``                                                           |
| [`4d6c4ada`](https://github.com/NixOS/nixpkgs/commit/4d6c4ada966c92d0a0f54b2392d31e5021aa73fb) | `` zlint: 3.6.1 -> 3.6.2 ``                                                           |
| [`e29225d8`](https://github.com/NixOS/nixpkgs/commit/e29225d89b099a61bd961b292bc62947c14642c6) | `` stag: fix compiling with clang ``                                                  |
| [`1805354a`](https://github.com/NixOS/nixpkgs/commit/1805354a5c593c0ac3c8e6d071d870deff87b7be) | `` tfupdate: 0.8.1 -> 0.8.2 ``                                                        |
| [`5cf920b2`](https://github.com/NixOS/nixpkgs/commit/5cf920b2d920e7d31b52b0085ee4b6cf568ad5a4) | `` shopware-cli: 0.4.34 -> 0.4.35 ``                                                  |
| [`1c9cf55f`](https://github.com/NixOS/nixpkgs/commit/1c9cf55f0cdac971233528b028864ff1b97d1517) | `` python312Packages.vallox-websocket-api: 5.1.1 -> 5.2.0 ``                          |
| [`8ac83357`](https://github.com/NixOS/nixpkgs/commit/8ac83357e35ef73dde81d25b1a8d8167019fbd3e) | `` python312Packages.diff-cover: 8.0.3 -> 9.0.0 ``                                    |
| [`f99d6768`](https://github.com/NixOS/nixpkgs/commit/f99d67687e348197617085e89e91fe00b5cc0dc1) | `` python311Packages.llama-index-core: 0.10.28.post1 -> 0.10.29 ``                    |
| [`20c7020f`](https://github.com/NixOS/nixpkgs/commit/20c7020faa93262a90ab6888fd4f58834256dc79) | `` v2ray-domain-list-community: 20240402003241 -> 20240410101316 ``                   |
| [`f98ec8fa`](https://github.com/NixOS/nixpkgs/commit/f98ec8fa391d0b026c8c98f903c95ebb8dc8ff53) | `` balena-cli: 18.1.8 -> 18.1.9 ``                                                    |
| [`e8c2fa5e`](https://github.com/NixOS/nixpkgs/commit/e8c2fa5ebca8f6eacc777f7cccaddb3f16ba9ea1) | `` hishtory: 0.288 -> 0.290 ``                                                        |
| [`a46ee656`](https://github.com/NixOS/nixpkgs/commit/a46ee656dceab956f09551cd7c52f8cc00c7890b) | `` hcledit: 0.2.10 -> 0.2.11 ``                                                       |
| [`c3cba41a`](https://github.com/NixOS/nixpkgs/commit/c3cba41a067b0c78ec559ebf8c1fa0753304b026) | `` ghdl: 4.0.0 -> 4.1.0 ``                                                            |
| [`b2262771`](https://github.com/NixOS/nixpkgs/commit/b2262771fdafb63b3b7e11c6c3b87ae1496d3d25) | `` fzf: 0.49.0 -> 0.50.0 ``                                                           |
| [`c7669c5e`](https://github.com/NixOS/nixpkgs/commit/c7669c5efaa897abe27d87cc306906d70fa23090) | `` sssnake: fix darwin build ``                                                       |
| [`a6ae4b94`](https://github.com/NixOS/nixpkgs/commit/a6ae4b94ceaeb0a5066d3de8abb0e066d3425bfc) | `` rtl88xxau-aircrack: unstable-02-05-2023 -> unstable-2024-04-09 ``                  |
| [`0fe85511`](https://github.com/NixOS/nixpkgs/commit/0fe855112c83c2b047f33c04cf694ed21a735ec0) | `` rtl88xxau-aircrack: add ja1den as maintainer ``                                    |
| [`f35d326c`](https://github.com/NixOS/nixpkgs/commit/f35d326c66e6e4d49aebe46a9212fb006412c6fc) | `` rtl88xxau-aircrack: format with nixfmt ``                                          |
| [`9fbef499`](https://github.com/NixOS/nixpkgs/commit/9fbef499c86c42b1c837da3f6a047544deec0344) | `` maintainers: add ja1den ``                                                         |
| [`bacc51ef`](https://github.com/NixOS/nixpkgs/commit/bacc51efb457ddc3aedad0f08f9aee045aa172a6) | `` eigenpy: 3.4.0 -> 3.5.0 ``                                                         |
| [`48e5f774`](https://github.com/NixOS/nixpkgs/commit/48e5f7743f9bcbb3e95cacaf68b2bc5cf2319a8f) | `` jrl-cmakemodules: init at 0-unstable-2024-04-12 ``                                 |
| [`5c9e92f6`](https://github.com/NixOS/nixpkgs/commit/5c9e92f60d9881ec139139ff84d33ef2d3f8bca1) | `` athens: 0.13.2 -> 0.13.3 ``                                                        |
| [`d6b6cc93`](https://github.com/NixOS/nixpkgs/commit/d6b6cc93c4292833767999f8ce818288de555408) | `` xanmod-kernels: change to full preemption ``                                       |
| [`5ebb9b55`](https://github.com/NixOS/nixpkgs/commit/5ebb9b551e889302b691f00291aef28f18e0586d) | `` linux_xanmod_latest: 6.8.5 -> 6.8.6 ``                                             |
| [`cf5e8b86`](https://github.com/NixOS/nixpkgs/commit/cf5e8b86a3b4f1317557c2529946da1fcb5a5391) | `` linux_xanmod: 6.6.26 -> 6.6.27 ``                                                  |
| [`2f63a7e9`](https://github.com/NixOS/nixpkgs/commit/2f63a7e9fe14316f6aeec1380a2ecb00935769d1) | `` python311Packages.oracledb: 2.1.1 -> 2.1.2 ``                                      |
| [`3cbd4a0d`](https://github.com/NixOS/nixpkgs/commit/3cbd4a0de02cca1ed3cced7f36f433f082e717dc) | `` spotify-qt: 3.9 -> 3.11 ``                                                         |
| [`050c43b4`](https://github.com/NixOS/nixpkgs/commit/050c43b4fcb3556a754275edbe8b5638d1fdacdc) | `` pantheon.elementary-photos: Build without webkit2gtk-4.0 ``                        |
| [`1897af2d`](https://github.com/NixOS/nixpkgs/commit/1897af2d3797d4b00a2df115d3c37efa1e975939) | `` llama-cpp: 2636 -> 2674 ``                                                         |
| [`28e38b11`](https://github.com/NixOS/nixpkgs/commit/28e38b1156a1ccc72107015fc84cc415c8705158) | `` updated spotify-qt hash ``                                                         |
| [`6ba3b753`](https://github.com/NixOS/nixpkgs/commit/6ba3b753af7818b1b20fc2b03d9d56d6f8497f45) | `` updated spotify-qt version ``                                                      |
| [`91ca091f`](https://github.com/NixOS/nixpkgs/commit/91ca091fb8de7fcc5a482a21283ae9c7f61748e1) | `` python311Packages.xkbcommon: 0.8 -> 1.0 ``                                         |
| [`2246d3ff`](https://github.com/NixOS/nixpkgs/commit/2246d3ff90aa087b1ad7b225bc570acb73f02f06) | `` python312Packages.aiooss2: refactor ``                                             |
| [`ed854ed0`](https://github.com/NixOS/nixpkgs/commit/ed854ed0e3d7da87e513672c40d2001bdf815521) | `` nixos/networkd: add [Bridge] section to netdev conf ``                             |
| [`4dd2f42d`](https://github.com/NixOS/nixpkgs/commit/4dd2f42dc90bfd121aab8c7eff00868d863cffb3) | `` hifile: 0.9.9.10 -> 0.9.9.11 ``                                                    |
| [`e08a8231`](https://github.com/NixOS/nixpkgs/commit/e08a8231e2c827f586e64727c1063c5e61dbc00d) | `` spotube: update meta.homepage, format with nixfmt ``                               |
| [`ce1515f7`](https://github.com/NixOS/nixpkgs/commit/ce1515f702558d87f9dbba96d077a6551a16da87) | `` hyprlang: 0.5.0 -> 0.5.1 ``                                                        |
| [`32d95f4e`](https://github.com/NixOS/nixpkgs/commit/32d95f4ef119e1e646398a127df041a20ed26840) | `` python3Packages.json5: Disable hypothesis ``                                       |
| [`c4415d22`](https://github.com/NixOS/nixpkgs/commit/c4415d2272ec2be13549086c3b87abc797073d2a) | `` validator-nu: fix version output and modernize package ``                          |
| [`82514311`](https://github.com/NixOS/nixpkgs/commit/82514311e7c34391afbcc20dbeddac3b68d2ea1f) | `` firebase-tools: 13.7.1 -> 13.7.2 ``                                                |
| [`4d17d842`](https://github.com/NixOS/nixpkgs/commit/4d17d84209da8c9f0021aab228a015c8a2f12bfd) | `` devilutionx: 1.4.1 -> 1.5.2 ``                                                     |
| [`16b33190`](https://github.com/NixOS/nixpkgs/commit/16b331903d928568426e3315dd7612cd9bf0fba5) | `` cyberchef: 10.15.1 -> 10.17.0 ``                                                   |
| [`8cc90d43`](https://github.com/NixOS/nixpkgs/commit/8cc90d43b4ba6290a6cc11a00697b751adaefe5f) | `` php81: add missing patch ``                                                        |
| [`30d09cf3`](https://github.com/NixOS/nixpkgs/commit/30d09cf3707d2b28f8570e091902e2399bdb90fb) | `` colloid-gtk-theme: new tweak: everforest ``                                        |
| [`600bdcfa`](https://github.com/NixOS/nixpkgs/commit/600bdcfab6e6d21ab4dd912f7404dba8a316dab2) | `` sdrangel: 7.19.1 -> 7.20.0 ``                                                      |
| [`fa0c748c`](https://github.com/NixOS/nixpkgs/commit/fa0c748ce321e827410137e64aab603bc6b79a5d) | `` geos: fix check on x86_64-darwin ``                                                |
| [`24de5c7b`](https://github.com/NixOS/nixpkgs/commit/24de5c7b087c11bdec485d4885bd415c6db0200b) | `` mold: unpin stdenv on darwin ``                                                    |
| [`db0727e8`](https://github.com/NixOS/nixpkgs/commit/db0727e8c004eb1dd247d66499e8bd6962ef8ae6) | `` onnxruntime: limit nvcc threads ``                                                 |
| [`852af4a5`](https://github.com/NixOS/nixpkgs/commit/852af4a5dc40a885080edf9361c659b5eefc749e) | `` onnxruntime: do not build unnecessary tests ``                                     |
| [`f82cd4f4`](https://github.com/NixOS/nixpkgs/commit/f82cd4f491da960f9c49893b451e6c3482c17e60) | `` python312Packages.pygccxml: 2.4.0 -> 2.5.0 ``                                      |
| [`a5cedfaf`](https://github.com/NixOS/nixpkgs/commit/a5cedfaffa62205ffeeb7d11a3d6d9ca483c2c65) | `` nixos/slock: add .package option (for those wishing to override) ``                |
| [`05ee9325`](https://github.com/NixOS/nixpkgs/commit/05ee93256b10e886c03327946776527c467838d7) | `` kittysay: init at 0.5.0 ``                                                         |
| [`61cb74ed`](https://github.com/NixOS/nixpkgs/commit/61cb74ed88f6f910fa70a9c4c6b2e6ced658240a) | `` python312Packages.crc: 6.1.1 -> 6.1.2 ``                                           |
| [`0201352d`](https://github.com/NixOS/nixpkgs/commit/0201352d0f6e29940c6253faaef13ea7add2440a) | `` python312Packages.aiooss2: 0.2.10 -> 0.2.11 ``                                     |
| [`87d52cea`](https://github.com/NixOS/nixpkgs/commit/87d52ceade5a733c151a463075f319f44e5ba735) | `` nixos/doc: add loki breaking change ``                                             |
| [`af2004e1`](https://github.com/NixOS/nixpkgs/commit/af2004e1d4cd76c0c059362db78f804417900af7) | `` ruapu: init at 0.1.0 ``                                                            |
| [`34261948`](https://github.com/NixOS/nixpkgs/commit/3426194874a9c82b4dd84ee3a2e434317d6ed169) | `` garage_1_x: expose at top-level ``                                                 |
| [`7b167c79`](https://github.com/NixOS/nixpkgs/commit/7b167c79c48e919e86da998e507913e91e766c66) | `` glooctl: 1.16.9 -> 1.16.10 ``                                                      |
| [`c8eabd7a`](https://github.com/NixOS/nixpkgs/commit/c8eabd7a15388f525f3ea15bb3bd8d0ac9008cd3) | `` pynmeagps: init at 1.0.35 ``                                                       |
| [`eb9e29c0`](https://github.com/NixOS/nixpkgs/commit/eb9e29c088967651c3d9f4896cfb5e117a70924d) | `` openvscode-server: 1.87.1 -> 1.88.0 ``                                             |
| [`3cce8278`](https://github.com/NixOS/nixpkgs/commit/3cce82782f90593e7cffbac1e1205bac2aaac23d) | `` emulsion: 10.4 -> 10.5 ``                                                          |
| [`1bd82603`](https://github.com/NixOS/nixpkgs/commit/1bd82603ae101edc9355b021ba827a4fb1f531ea) | `` troubadix: init at 24.4.0 ``                                                       |
| [`ff33aae7`](https://github.com/NixOS/nixpkgs/commit/ff33aae7db5467c25e00df67d17badc677bdc3e5) | `` cloud-custodian: 0.8.45.1 -> 0.9.35.0 ``                                           |
| [`53b9f7d7`](https://github.com/NixOS/nixpkgs/commit/53b9f7d70c742596132af88ae14e62c388025959) | `` openvas-scanner: init at 23.0.1 ``                                                 |
| [`bc3ce9fb`](https://github.com/NixOS/nixpkgs/commit/bc3ce9fb25676790513786704ee8d6b2474b8810) | `` gvm-libs: format with nixfmt ``                                                    |
| [`1fced86a`](https://github.com/NixOS/nixpkgs/commit/1fced86a4c063111c97f999941d7c02644a83dae) | `` dnsrecon: 1.1.5 -> 1.2.0 ``                                                        |
| [`954f5cad`](https://github.com/NixOS/nixpkgs/commit/954f5cad0ffe5a3607e9a704d8b674ecc69f6078) | `` python311Packages.llama-index-readers-file: 0.1.16 -> 0.1.17 ``                    |
| [`0d008ec5`](https://github.com/NixOS/nixpkgs/commit/0d008ec57d777b91f28c05e61a92d48def4cd317) | `` reaper: 7.13 -> 7.14 ``                                                            |
| [`62ace1bb`](https://github.com/NixOS/nixpkgs/commit/62ace1bb030743ab3c7583ea1823e7d5396371f8) | `` openssh: add nixosTests.openssh to passthru.tests ``                               |
| [`7533dac2`](https://github.com/NixOS/nixpkgs/commit/7533dac2b173c2fb6d3dd9257b8869087209f690) | `` tailscale-nginx-auth: 1.62.1 -> 1.64.0 ``                                          |
| [`ad83596e`](https://github.com/NixOS/nixpkgs/commit/ad83596e07ed8c0aedd15872f4a772a5d66f974c) | `` srm-cuarzo: 0.5.5-1 -> 0.5.6-1 ``                                                  |
| [`d5116840`](https://github.com/NixOS/nixpkgs/commit/d5116840710ee9c483453e9a766797c56594bcb0) | `` geos, proj: unpin stdenv on darwin ``                                              |
| [`ba8a9ff1`](https://github.com/NixOS/nixpkgs/commit/ba8a9ff1dd25755ffcf40beb0c233a385e68b056) | `` python311Packages.apprise: 1.7.5 -> 1.7.6 ``                                       |
| [`6543ef14`](https://github.com/NixOS/nixpkgs/commit/6543ef14b864913fc547e091baba2e0f0c0f900f) | `` obs-studio-plugins.obs-vkcapture: 1.4.7 -> 1.5.0 ``                                |
| [`8f588920`](https://github.com/NixOS/nixpkgs/commit/8f588920fc337f989d01e8014da934c58e8fff63) | `` iosevka: 29.1.0 -> 29.2.0 ``                                                       |
| [`8d1292cd`](https://github.com/NixOS/nixpkgs/commit/8d1292cd49b1462acd9d3b2224740192bb6b266f) | `` nodejs-slim_21: 21.7.2 -> 21.7.3 ``                                                |
| [`22bd2ab6`](https://github.com/NixOS/nixpkgs/commit/22bd2ab6247c42c3dbf9221d6f3a509c8291cd94) | `` less: apply patch for security issue when opening files with \n in paths ``        |
| [`21516e68`](https://github.com/NixOS/nixpkgs/commit/21516e68ae97f304ea78e9530600ae938aaede85) | `` chezmoi: 2.47.3 -> 2.47.4 ``                                                       |
| [`bfbf91b4`](https://github.com/NixOS/nixpkgs/commit/bfbf91b458b18e490dcc5f0dc7bd445865093a3d) | `` python312Packages.myst-nb: 1.0.0 -> 1.1.0 ``                                       |
| [`d9f3cf13`](https://github.com/NixOS/nixpkgs/commit/d9f3cf135358e0a3afae8c8af783b32195d3a8c6) | `` sssd: add meta.pkgConfigModules, passthru.tests.pkg-config ``                      |
| [`bd17c30c`](https://github.com/NixOS/nixpkgs/commit/bd17c30c7578ee99b9c0db699d0018b9ce92c709) | `` python311Packages.tpm2-pytss: fix cross-compilation ``                             |