### PR TITLE
chore(flake/nixpkgs-unstable): `5f81b281` -> `b941d525`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1303,11 +1303,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1713107505,
-        "narHash": "sha256-JZIwPyHhX7XzUTIyHNQSPmLdwVtQZ3zMGoXvtvaoZZQ=",
+        "lastModified": 1713156337,
+        "narHash": "sha256-oPG4CUVQGc/8q0k4nS8YK44o2q14cqQSo9OijH1E+Vs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5f81b2812ea76d998cb25a3491cce03093326cb2",
+        "rev": "b941d525061a6e4f43882318225799c901f1ad40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                         |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| [`b941d525`](https://github.com/NixOS/nixpkgs/commit/b941d525061a6e4f43882318225799c901f1ad40) | `` jasmin-compiler: 2023.06.2 → 2023.06.3 ``                                    |
| [`4b6f17a8`](https://github.com/NixOS/nixpkgs/commit/4b6f17a8a68cea10a618681a8163fbc02d30e1cc) | `` dune_3: 3.14.2 -> 3.15.0 ``                                                  |
| [`e91467c3`](https://github.com/NixOS/nixpkgs/commit/e91467c3ac90158d56bed52c43ac6c0cdc7a88bc) | `` ocamlPackages.owee: 0.6 → 0.7 ``                                             |
| [`5e384f2b`](https://github.com/NixOS/nixpkgs/commit/5e384f2b24a309d4c2ca7a4c87b52a2ccb05eaa4) | `` ocamlPackages.spacetime_lib: remove at 0.3.0 (broken) ``                     |
| [`a46ee656`](https://github.com/NixOS/nixpkgs/commit/a46ee656dceab956f09551cd7c52f8cc00c7890b) | `` hcledit: 0.2.10 -> 0.2.11 ``                                                 |
| [`c7669c5e`](https://github.com/NixOS/nixpkgs/commit/c7669c5efaa897abe27d87cc306906d70fa23090) | `` sssnake: fix darwin build ``                                                 |
| [`bacc51ef`](https://github.com/NixOS/nixpkgs/commit/bacc51efb457ddc3aedad0f08f9aee045aa172a6) | `` eigenpy: 3.4.0 -> 3.5.0 ``                                                   |
| [`48e5f774`](https://github.com/NixOS/nixpkgs/commit/48e5f7743f9bcbb3e95cacaf68b2bc5cf2319a8f) | `` jrl-cmakemodules: init at 0-unstable-2024-04-12 ``                           |
| [`3cbd4a0d`](https://github.com/NixOS/nixpkgs/commit/3cbd4a0de02cca1ed3cced7f36f433f082e717dc) | `` spotify-qt: 3.9 -> 3.11 ``                                                   |
| [`28e38b11`](https://github.com/NixOS/nixpkgs/commit/28e38b1156a1ccc72107015fc84cc415c8705158) | `` updated spotify-qt hash ``                                                   |
| [`6ba3b753`](https://github.com/NixOS/nixpkgs/commit/6ba3b753af7818b1b20fc2b03d9d56d6f8497f45) | `` updated spotify-qt version ``                                                |
| [`4dd2f42d`](https://github.com/NixOS/nixpkgs/commit/4dd2f42dc90bfd121aab8c7eff00868d863cffb3) | `` hifile: 0.9.9.10 -> 0.9.9.11 ``                                              |
| [`e08a8231`](https://github.com/NixOS/nixpkgs/commit/e08a8231e2c827f586e64727c1063c5e61dbc00d) | `` spotube: update meta.homepage, format with nixfmt ``                         |
| [`ed817f46`](https://github.com/NixOS/nixpkgs/commit/ed817f469939a238181fa4872e082af4ad8c7499) | `` xcaddy: 0.3.5 -> 0.4.0 ``                                                    |
| [`c4415d22`](https://github.com/NixOS/nixpkgs/commit/c4415d2272ec2be13549086c3b87abc797073d2a) | `` validator-nu: fix version output and modernize package ``                    |
| [`d59720a7`](https://github.com/NixOS/nixpkgs/commit/d59720a710244803b2152c370736246a1d3689d6) | `` doc/release-notes: mention Lomiri availability ``                            |
| [`93e91c15`](https://github.com/NixOS/nixpkgs/commit/93e91c150ec90232f456137ad3bee44d6a9fe4b5) | `` ayatana-indicator-messages: Fix desktop parsing ``                           |
| [`8d0a5773`](https://github.com/NixOS/nixpkgs/commit/8d0a5773b2fbfba337f403318f1194931175ddcd) | `` lomiri.telephony-service: Fix indicator ``                                   |
| [`52696f99`](https://github.com/NixOS/nixpkgs/commit/52696f99fa9ef1f1166b4d78945ab75e6d65ba76) | `` lomiri.libusermetrics: Add custom patch for launching systemd service ``     |
| [`9c5e9db5`](https://github.com/NixOS/nixpkgs/commit/9c5e9db5bf094e1f374541d7bf789884de641192) | `` lomiri.lomiri-system-settings: Patch language plugin's locale lookup path `` |
| [`c1af1ec9`](https://github.com/NixOS/nixpkgs/commit/c1af1ec9228406bd9ff28f813a63f08d48299dfa) | `` lomiri.content-hub: Move example peers to examples output ``                 |
| [`dd3f11b8`](https://github.com/NixOS/nixpkgs/commit/dd3f11b8f674fa0770181ac44d52042cabe53891) | `` lomiri.morph-browser: Patch desktop icon path to be absolute ``              |
| [`b6fd92ab`](https://github.com/NixOS/nixpkgs/commit/b6fd92ab77158c7d5835a2ce234a97dc323353f9) | `` nixos/tests/lomiri: init ``                                                  |
| [`9528502e`](https://github.com/NixOS/nixpkgs/commit/9528502e83df873f0a3880875999ffa226f3c83a) | `` nixos/lomiri: init ``                                                        |
| [`399d6988`](https://github.com/NixOS/nixpkgs/commit/399d6988547f46df4c37fe0c085cff63bb7040bc) | `` nixos/lightdm-greeters/lomiri: init ``                                       |
| [`67daa502`](https://github.com/NixOS/nixpkgs/commit/67daa5021fcc4683d1f18bc191fa829db2360906) | `` lomiri.lomiri-session: init at 0.2 ``                                        |
| [`1850a54e`](https://github.com/NixOS/nixpkgs/commit/1850a54e5744c425b07a5ee781dccc52fbce6286) | `` lomiri.lomiri: init at 0.2.1 ``                                              |
| [`16b33190`](https://github.com/NixOS/nixpkgs/commit/16b331903d928568426e3315dd7612cd9bf0fba5) | `` cyberchef: 10.15.1 -> 10.17.0 ``                                             |
| [`ad27491b`](https://github.com/NixOS/nixpkgs/commit/ad27491b769676e844a099daa9d1d2e445f45a05) | `` ngtcp2: fix build on darwin by providing CoreServices ``                     |
| [`e6cae7e4`](https://github.com/NixOS/nixpkgs/commit/e6cae7e4f77e2ee0808b913dbe67056e30067b20) | `` nghttp3: fix build on darwin by providing CoreServices ``                    |
| [`e62c51a0`](https://github.com/NixOS/nixpkgs/commit/e62c51a05c3bd87c5fc6bfdb42a96f8a3a197450) | `` frigate: fix path to onvif wsdl files ``                                     |
| [`600bdcfa`](https://github.com/NixOS/nixpkgs/commit/600bdcfab6e6d21ab4dd912f7404dba8a316dab2) | `` sdrangel: 7.19.1 -> 7.20.0 ``                                                |
| [`fa0c748c`](https://github.com/NixOS/nixpkgs/commit/fa0c748ce321e827410137e64aab603bc6b79a5d) | `` geos: fix check on x86_64-darwin ``                                          |
| [`94808651`](https://github.com/NixOS/nixpkgs/commit/94808651040239efdfb05337e9445e7ae54f499e) | `` python312Packages.frozendict: 2.4.1 -> 2.4.2 ``                              |
| [`d67c7ccd`](https://github.com/NixOS/nixpkgs/commit/d67c7ccde4ded0774d845b97b9faf194c82a0062) | `` python312Packages.pymodbus: 3.6.7 -> 3.6.8 ``                                |
| [`24de5c7b`](https://github.com/NixOS/nixpkgs/commit/24de5c7b087c11bdec485d4885bd415c6db0200b) | `` mold: unpin stdenv on darwin ``                                              |
| [`9adf0708`](https://github.com/NixOS/nixpkgs/commit/9adf0708a3b60e2a71e40d2fd5e98c8b12d9beeb) | `` yq: 3.2.3 -> 3.3.0 ``                                                        |
| [`b174ea61`](https://github.com/NixOS/nixpkgs/commit/b174ea619292f82a81d668bcd20aca95ec57108e) | `` llvmPackages_18: drop an orphaned file ``                                    |
| [`7f0edf51`](https://github.com/NixOS/nixpkgs/commit/7f0edf51e7916064a206b1959d7ef509d4ec9d29) | `` python312Packages.equinox: 0.11.3 -> 0.11.4 ``                               |
| [`05ee9325`](https://github.com/NixOS/nixpkgs/commit/05ee93256b10e886c03327946776527c467838d7) | `` kittysay: init at 0.5.0 ``                                                   |
| [`2a16ac41`](https://github.com/NixOS/nixpkgs/commit/2a16ac4174eabd968dac94f32b1cafb39e12b1e0) | `` fuzzel: 1.9.2 -> 1.10.0 ``                                                   |
| [`7d1cfb83`](https://github.com/NixOS/nixpkgs/commit/7d1cfb83bbbb94ce5c14df9737dd29ed5cacdba3) | `` local-ai: 2.12.3 -> 2.12.4 ``                                                |
| [`8c11ab63`](https://github.com/NixOS/nixpkgs/commit/8c11ab639aa056e9a25c428d6d9786f2c36a662f) | `` raycast: add maintainer donteatoreo ``                                       |
| [`0951eef3`](https://github.com/NixOS/nixpkgs/commit/0951eef3801b91f7cc408cdae123c38e7b8b4f03) | `` raycast: fix passthru.updateScript ``                                        |
| [`7dbcdd7b`](https://github.com/NixOS/nixpkgs/commit/7dbcdd7b465f168f31edf098761411d46fef0f32) | `` python312Packages.ansicolor: refactor ``                                     |
| [`2345d95b`](https://github.com/NixOS/nixpkgs/commit/2345d95ba47fa41cf8e20a0e662bb4ad9a4bea09) | `` colloid-gtk-theme: 2023-10-28 -> 2024-04-14 ``                               |
| [`bdf1699e`](https://github.com/NixOS/nixpkgs/commit/bdf1699ea1d2a832af30cc45920dd454875435d0) | `` ananicy-rules-cachyos: fix hooks and pname ``                                |
| [`01181b1e`](https://github.com/NixOS/nixpkgs/commit/01181b1ea2f813a2c96fc6d676adfe970f7dc5a9) | `` fq: 0.10.0 -> 0.11.0 ``                                                      |
| [`3cce8278`](https://github.com/NixOS/nixpkgs/commit/3cce82782f90593e7cffbac1e1205bac2aaac23d) | `` emulsion: 10.4 -> 10.5 ``                                                    |
| [`de009cd3`](https://github.com/NixOS/nixpkgs/commit/de009cd3d123667b0c403f8484d6ec5fa15fceea) | `` maintainers: add diniamo ``                                                  |
| [`671d051a`](https://github.com/NixOS/nixpkgs/commit/671d051a48c744a4f5cb4faef2598ce1315c3379) | `` ckb-next: Fix udev rule ``                                                   |
| [`0d008ec5`](https://github.com/NixOS/nixpkgs/commit/0d008ec57d777b91f28c05e61a92d48def4cd317) | `` reaper: 7.13 -> 7.14 ``                                                      |
| [`f190aa84`](https://github.com/NixOS/nixpkgs/commit/f190aa8442bc65d8fa9e3b77dafcdd24b785717d) | `` terraform-providers: fix vendorHash for go1.22 ``                            |
| [`b6f237dd`](https://github.com/NixOS/nixpkgs/commit/b6f237dd7a322eff33057dc63b8971886c79d542) | `` threatest: fix vendorHash for go1.22 ``                                      |
| [`a17f40f2`](https://github.com/NixOS/nixpkgs/commit/a17f40f2d4a632e26a7b954a1e1212d5c5d29cb5) | `` age-plugin-tpm: fix vendorHash for go1.22 ``                                 |
| [`b9f6824b`](https://github.com/NixOS/nixpkgs/commit/b9f6824b024cbf4fbc9c38fe8bd557a4e73305f0) | `` juicity: fix vendorHash for go1.22 ``                                        |
| [`9ae2ccf3`](https://github.com/NixOS/nixpkgs/commit/9ae2ccf3a4f10100c00a90f3f2aa5d007ce0b5cc) | `` dae: fix vendorHash for go1.22 ``                                            |
| [`d9237327`](https://github.com/NixOS/nixpkgs/commit/d92373278332cbe65cd756a46f862bcc9fc8430b) | `` teleport_14: fix vendorHash for go1.22 ``                                    |
| [`2aa9c8dc`](https://github.com/NixOS/nixpkgs/commit/2aa9c8dc5f9ec0a191c64b000e4ef09befc83d28) | `` teleport_13: fix vendorHash for go1.22 ``                                    |
| [`4719f71b`](https://github.com/NixOS/nixpkgs/commit/4719f71b5c32488c8e01517467ee6ed844ae6012) | `` teleport_12: fix vendorHash for go1.22 ``                                    |
| [`69ccea03`](https://github.com/NixOS/nixpkgs/commit/69ccea0338c8bd4dd921cfadd6ead4c38d0ee994) | `` pufferpanel: fix vendorHash for go1.22 ``                                    |
| [`06b903ed`](https://github.com/NixOS/nixpkgs/commit/06b903ed276641acacb98ea4c37dff6be3795ceb) | `` phlare: fix vendorHash for go1.22 ``                                         |
| [`6c076c91`](https://github.com/NixOS/nixpkgs/commit/6c076c910684b55c642ee463ccee1ba8d0ff379a) | `` icebreaker: fix vendorHash for go1.22 ``                                     |
| [`6933748e`](https://github.com/NixOS/nixpkgs/commit/6933748e0944a2825657070f05e5ab629ebe86c4) | `` hydron: fix vendorHash for go1.22 ``                                         |
| [`6f05e554`](https://github.com/NixOS/nixpkgs/commit/6f05e55422644f49a95e4b702507da22401dc79b) | `` boringssl: fix vendorHash for go1.22 ``                                      |
| [`7e7a22fa`](https://github.com/NixOS/nixpkgs/commit/7e7a22fa3a3487ac9437ac3189ef633ce43e9391) | `` alps: fix vendorHash for go1.22 ``                                           |
| [`c8aa4946`](https://github.com/NixOS/nixpkgs/commit/c8aa4946802d3ebfd4ff59f73437fd2f759d354f) | `` wails: fix vendorHash for go1.22 ``                                          |
| [`66bad658`](https://github.com/NixOS/nixpkgs/commit/66bad658c93be94d84cee2fb31eada82b1e2ddda) | `` kustomize: fix vendorHash for go1.22 ``                                      |
| [`61b8561d`](https://github.com/NixOS/nixpkgs/commit/61b8561d6d5a519f634ddc0fc7cd3e2e373faf18) | `` go-migrate: fix vendorHash for go1.22 ``                                     |
| [`44ed815d`](https://github.com/NixOS/nixpkgs/commit/44ed815d0ddaa304eab80659443c2b72cbb652ab) | `` sqlcmd: fix vendorHash for go1.22 ``                                         |
| [`10a41b7d`](https://github.com/NixOS/nixpkgs/commit/10a41b7dd6805a09e114f2e0b699dc60429ce9e1) | `` dapr-cli: fix vendorHash for go1.22 ``                                       |
| [`34b358fb`](https://github.com/NixOS/nixpkgs/commit/34b358fb2469849b28ab490bd082b30334abef17) | `` benthos: fix vendorHash for go1.22 ``                                        |
| [`8b05ded0`](https://github.com/NixOS/nixpkgs/commit/8b05ded0c502a74b580a673f91afad2c90bc0566) | `` zitadel: fix vendorHash for go1.22 ``                                        |
| [`5615fd00`](https://github.com/NixOS/nixpkgs/commit/5615fd0057a62e236e2ac2a6480e8ed34db9e3c2) | `` butler: fix vendorHash for go1.22 ``                                         |
| [`e1afd4de`](https://github.com/NixOS/nixpkgs/commit/e1afd4de729127acbcfb57eeb83d45d0e7edf632) | `` bepass: fix vendorHash for go1.22 ``                                         |
| [`92e5b8d6`](https://github.com/NixOS/nixpkgs/commit/92e5b8d6d90aa0301a2dd607ba93fc66bbdc5e17) | `` aerc: fix vendorHash for go1.22 ``                                           |
| [`5e682bb1`](https://github.com/NixOS/nixpkgs/commit/5e682bb1bc2f09038be2b101ee502d584e6f78e3) | `` argocd-autopilot: fix vendorHash for go1.22 ``                               |
| [`8e649d36`](https://github.com/NixOS/nixpkgs/commit/8e649d36d3a902022ae192d33ec26fb0e3c3e1ed) | `` wtf: fix vendorHash for go1.22 ``                                            |
| [`c39b2e88`](https://github.com/NixOS/nixpkgs/commit/c39b2e886d123f3e460a65d55c75eb04b8482b5a) | `` skate: fix vendorHash for go1.22 ``                                          |
| [`ef79e057`](https://github.com/NixOS/nixpkgs/commit/ef79e0578ea7f0f32d8ed48dd6309343276f261e) | `` ratt: fix vendorHash for go1.22 ``                                           |
| [`049b684d`](https://github.com/NixOS/nixpkgs/commit/049b684d52e1f9abfc5f748c621adaec30548a47) | `` deckmaster: fix vendorHash for go1.22 ``                                     |
| [`3e28bdc6`](https://github.com/NixOS/nixpkgs/commit/3e28bdc6786cb4192f2a04248cf65c49bc43bcd0) | `` buildGoModule: inherit env from main package to goModule derivation ``       |
| [`7533dac2`](https://github.com/NixOS/nixpkgs/commit/7533dac2b173c2fb6d3dd9257b8869087209f690) | `` tailscale-nginx-auth: 1.62.1 -> 1.64.0 ``                                    |
| [`a00e2964`](https://github.com/NixOS/nixpkgs/commit/a00e2964ae12c03f6418b3c2d189b9eaa12e837c) | `` rizin: 0.7.2 -> 0.7.3 ``                                                     |
| [`5c4218b3`](https://github.com/NixOS/nixpkgs/commit/5c4218b36ccb5d0e220e3bda01c3537c3aa8cc06) | `` dolphin-emu: unpin stdenv on darwin ``                                       |
| [`d5116840`](https://github.com/NixOS/nixpkgs/commit/d5116840710ee9c483453e9a766797c56594bcb0) | `` geos, proj: unpin stdenv on darwin ``                                        |
| [`b3079c52`](https://github.com/NixOS/nixpkgs/commit/b3079c52c02fb2a0b21e1c852f65d28218633580) | `` kotatogram-desktop: use llvmPackages_14 on darwin ``                         |
| [`2c51064b`](https://github.com/NixOS/nixpkgs/commit/2c51064b0bb9e8ef60d4dab9bf7d26678114c24b) | `` treewide: remove cudatoolkit.cc references ``                                |
| [`8262bdf7`](https://github.com/NixOS/nixpkgs/commit/8262bdf73850f5ca7f2045a6d82568bb342603a4) | `` cudaPackages.cudatoolkit: replace with symlinkJoin ``                        |
| [`a9688251`](https://github.com/NixOS/nixpkgs/commit/a968825151d4bccec9b696e041e225c08fc344f9) | `` gamescope: 3.14.2 -> 3.14.3 ``                                               |
| [`6abe5d38`](https://github.com/NixOS/nixpkgs/commit/6abe5d3831bd314a4b4d464f963ef4c637b2f619) | `` gitlab-container-registry: 3.91.0 -> 3.92.0 ``                               |
| [`201a8e50`](https://github.com/NixOS/nixpkgs/commit/201a8e5003a713a68ad132ef3c471d8c4996cf59) | `` gitlab: 16.10.1 -> 16.10.2 ``                                                |
| [`3829c3a3`](https://github.com/NixOS/nixpkgs/commit/3829c3a390b61a12968e685e9b74d46830a80821) | `` python311Packages.qdldl: 0.1.7.post0 -> 0.1.7.post1 ``                       |
| [`772dbad3`](https://github.com/NixOS/nixpkgs/commit/772dbad3d41932f08d44aaa63a571d4e26c5d143) | `` rocmPackages.llvm: replace --replace with --replace-fail (cleanup) ``        |
| [`e380b530`](https://github.com/NixOS/nixpkgs/commit/e380b5303715016fca18df860d97340345b52aef) | `` rocmPackages.llvm: compress outputs of clang-offload-bundler ``              |
| [`4d151d7a`](https://github.com/NixOS/nixpkgs/commit/4d151d7a336f7acc8490cf4da4379123b894516a) | `` mlv-app: 1.11 -> 1.14 ``                                                     |