### PR TITLE
chore(flake/emacs-overlay): `cf218237` -> `502906af`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713200735,
-        "narHash": "sha256-6qPfZsYW3BvyJq+BahgygLdFd5bdqrFue8QGat4lSQo=",
+        "lastModified": 1713287188,
+        "narHash": "sha256-LpbYsViVHQ19Qyjw4FxlTWcZNSbiagMfPMrUBuDVTBk=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cf218237d0d80f1ec8109677ebc82ded2ca84c43",
+        "rev": "502906af674eae890790ec48cad959d42dc2f040",
         "type": "github"
       },
       "original": {
@@ -1255,11 +1255,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1713013257,
-        "narHash": "sha256-ZEfGB3YCBVggvk0BQIqVY7J8XF/9jxQ68fCca6nib+8=",
+        "lastModified": 1713145326,
+        "narHash": "sha256-m7+IWM6mkWOg22EC5kRUFCycXsXLSU7hWmHdmBfmC3s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "90055d5e616bd943795d38808c94dbf0dd35abe8",
+        "rev": "53a2c32bc66f5ae41a28d7a9a49d321172af621e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`502906af`](https://github.com/nix-community/emacs-overlay/commit/502906af674eae890790ec48cad959d42dc2f040) | `` Updated emacs ``        |
| [`10b148d3`](https://github.com/nix-community/emacs-overlay/commit/10b148d3b245cd8abf3064c9ed4470125b0d5816) | `` Updated melpa ``        |
| [`63221ee3`](https://github.com/nix-community/emacs-overlay/commit/63221ee331da17e5c14e6682224218573bdc3951) | `` Updated elpa ``         |
| [`433c5449`](https://github.com/nix-community/emacs-overlay/commit/433c54490f99473a5fb9d41e857044a62ffa9baf) | `` Updated emacs ``        |
| [`e8fd7616`](https://github.com/nix-community/emacs-overlay/commit/e8fd7616e8b998a5835755dbc7c963fe66967565) | `` Updated melpa ``        |
| [`0eb7c2ed`](https://github.com/nix-community/emacs-overlay/commit/0eb7c2ed361b74817364818fc0289eb44208e76a) | `` Updated emacs ``        |
| [`35f1a712`](https://github.com/nix-community/emacs-overlay/commit/35f1a712b49b07233a8aa29823ca9f0bf1adb11e) | `` Updated melpa ``        |
| [`bcd935f9`](https://github.com/nix-community/emacs-overlay/commit/bcd935f930b6b673170331e484426cfeefc06e0d) | `` Updated elpa ``         |
| [`86d9b02f`](https://github.com/nix-community/emacs-overlay/commit/86d9b02f8d928ea1c27bcf421ec685df5e68c6bb) | `` Updated flake inputs `` |