### PR TITLE
chore(flake/nixpkgs-unstable): `b941d525` -> `3ad65e9f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1303,11 +1303,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1713156337,
-        "narHash": "sha256-oPG4CUVQGc/8q0k4nS8YK44o2q14cqQSo9OijH1E+Vs=",
+        "lastModified": 1713281235,
+        "narHash": "sha256-nqZNK4gUBQBagw3sCoUdH+2mOKiFNkI0ICSU3asUX+E=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b941d525061a6e4f43882318225799c901f1ad40",
+        "rev": "3ad65e9f48fd31c89121feb6e9c582ff7e4bb664",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                      |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
| [`3ad65e9f`](https://github.com/NixOS/nixpkgs/commit/3ad65e9f48fd31c89121feb6e9c582ff7e4bb664) | `` oh-my-zsh: 2023-11-29 -> 2024-04-12 (#303737) ``                          |
| [`354e22ca`](https://github.com/NixOS/nixpkgs/commit/354e22ca6bc0f86d461e49bfa3ed5ba3e2eaeb0a) | `` vscode-extensions.timonwong.shellcheck: move to a directory ``            |
| [`3e435829`](https://github.com/NixOS/nixpkgs/commit/3e4358290ca54fa1503217b21fd8253356e5dde8) | `` vscode-extensions.b4dm4n.vscode-nixpkgs-fmt: move to a directory ``       |
| [`024fe44e`](https://github.com/NixOS/nixpkgs/commit/024fe44e72d85f603885c004e154001b90a089f7) | `` vscode-extensions.nvarner.typst-lsp: move to a directory ``               |
| [`4e210b2a`](https://github.com/NixOS/nixpkgs/commit/4e210b2a3b058882222f1a61c25720d02687ebdf) | `` vscode-extensions.mgt19937.typst-preview: move to a directory ``          |
| [`6badd9fe`](https://github.com/NixOS/nixpkgs/commit/6badd9fe8481a31c1a8b69fe8ef99174674fa02c) | `` vscode-extensions.foxundermoon.shell-format: move to a directory ``       |
| [`e62a4088`](https://github.com/NixOS/nixpkgs/commit/e62a408834f77e180a7131a5e497886c3426d681) | `` vscode-extensions.kamadorueda.alejandra: move to a directory ``           |
| [`3ac536f6`](https://github.com/NixOS/nixpkgs/commit/3ac536f66b80e23dbcbf9fb93127e4cc75f57cb8) | `` vscode-extensions.myriad-dreamin.tinymist: move to directory ``           |
| [`f6d6f32f`](https://github.com/NixOS/nixpkgs/commit/f6d6f32fabc725fb682058a878b8a159a5ae994f) | `` vscode-extensions.asciidoctor.asciidoctor-vscode: move to a directory ``  |
| [`2745c03b`](https://github.com/NixOS/nixpkgs/commit/2745c03b3fe3604a6fa3d7db8f0add5001ab59cc) | `` vscode-extensions.eugleo.magic-racket: move to a directory ``             |
| [`31de7d15`](https://github.com/NixOS/nixpkgs/commit/31de7d1519378fa109dd3bc19c0acb29a187ed1c) | `` vscode-extensions.azdavis.millet: move to a directory ``                  |
| [`937b420b`](https://github.com/NixOS/nixpkgs/commit/937b420b663f3ae0727f152c7b2cb2de32876aa3) | `` vscode-extensions.jackmacwindows.craftos-pc: move to a directory ``       |
| [`b6eec2f5`](https://github.com/NixOS/nixpkgs/commit/b6eec2f5ce4802f12f05b2fcf95e61bbe420fabf) | `` vscode-extensions.betterthantomorrow.calva: move to a directory ``        |
| [`95459747`](https://github.com/NixOS/nixpkgs/commit/9545974783e1a77dcac409ab768729c25a66bd68) | `` vscode-extensions.ms-python.vscode-pylance: move to a directory ``        |
| [`9011e6c7`](https://github.com/NixOS/nixpkgs/commit/9011e6c722c89a95f708f243fa0dd8c1a2bc5522) | `` vscode-extensions: document criteria used to add new extensions ``        |
| [`f1901cf0`](https://github.com/NixOS/nixpkgs/commit/f1901cf020675e0e9efde6a6c43ffea738700982) | `` gitg: 41 -> 44 ``                                                         |
| [`11979c5f`](https://github.com/NixOS/nixpkgs/commit/11979c5f3d849a42ad63c8394642dcd34f40a6cf) | `` kdePackages.drkonqi: remove sleep hack ``                                 |
| [`f06bd769`](https://github.com/NixOS/nixpkgs/commit/f06bd769062980576af91613f2e2f12b052919fb) | `` linuxKernel.kernels.linux_lqx: 6.8.4-lqx1 -> 6.8.6-lqx2 ``                |
| [`78bca5ad`](https://github.com/NixOS/nixpkgs/commit/78bca5ada0628e326d8a022ec967e3fc3c48dd75) | `` linuxKernel.kernels.linux_zen: 6.8.4-zen1 -> 6.8.6-zen1 ``                |
| [`8a1dbedd`](https://github.com/NixOS/nixpkgs/commit/8a1dbedde5d596103cf7929b7286a2ba3535d8ea) | `` akkoma: make options work for 23.11 state ``                              |
| [`587b27b7`](https://github.com/NixOS/nixpkgs/commit/587b27b7a8c70d8e2964ce0fc3a90122c939e0fc) | `` gopls: 0.15.2 -> 0.15.3 (#304504) ``                                      |
| [`83db357f`](https://github.com/NixOS/nixpkgs/commit/83db357fdcd1b903c61ac5d174dc47e4d6828f9a) | `` Plasma 6: 6.0.3 -> 6.0.4 ``                                               |
| [`5c474c72`](https://github.com/NixOS/nixpkgs/commit/5c474c72f6bd711465b234923e494dbba0c471f6) | `` teams-for-linux: 1.4.24 -> 1.4.27 ``                                      |
| [`612aef98`](https://github.com/NixOS/nixpkgs/commit/612aef98cdead56e4c3a59c88732a7b11c89e5a0) | `` python312Packages.botocore-stubs: 1.34.69 -> 1.34.84 ``                   |
| [`909dd7af`](https://github.com/NixOS/nixpkgs/commit/909dd7af1ddf1c44bd82498c0c51e6cc39a9a77c) | `` ytt: 0.48.0 -> 0.49.0 ``                                                  |
| [`156c8695`](https://github.com/NixOS/nixpkgs/commit/156c869524e2f184b17667aee0ce066fbb47a533) | `` matrix-appservice-irc: 1.0.1 -> 2.0.0 ``                                  |
| [`77579368`](https://github.com/NixOS/nixpkgs/commit/775793680f7864153a1a046861795da79da110b0) | `` kopia: 0.16.1 -> 0.17.0 ``                                                |
| [`d408a6dc`](https://github.com/NixOS/nixpkgs/commit/d408a6dc80e06a67997ce430a168fb26c2ec364c) | `` vscode-extensions.myriad-dreamin.tinymist: 0.11.3 -> 0.11.4 ``            |
| [`287c7aea`](https://github.com/NixOS/nixpkgs/commit/287c7aea9909bf2e01fd9f0e2318b0bfc46339db) | `` python312Packages.ifconfig-parser: format with nixfmt ``                  |
| [`4e3c8707`](https://github.com/NixOS/nixpkgs/commit/4e3c870764013e4826fd63de7cff64e660a177ee) | `` python312Packages.ifconfig-parser: refactor ``                            |
| [`da42a0d4`](https://github.com/NixOS/nixpkgs/commit/da42a0d492a05ce66a04fb0bc73da79555509549) | `` tinymist: 0.11.3 -> 0.11.4 ``                                             |
| [`f4e89be3`](https://github.com/NixOS/nixpkgs/commit/f4e89be30768b1c6eb9a0848bfc7c8496abfbc62) | `` python311Packages.napalm: 4.1.0 -> 5.0.0 ``                               |
| [`a1ecc99f`](https://github.com/NixOS/nixpkgs/commit/a1ecc99f102f5dd1046c22db2f3c017f183d3211) | `` python312Packages.toggl-cli: 2.4.3 -> 2.4.4 ``                            |
| [`057c8ca9`](https://github.com/NixOS/nixpkgs/commit/057c8ca96d28d8c20c48a46648e61eb3784fd343) | `` rs: fix darwin ``                                                         |
| [`57a4d93b`](https://github.com/NixOS/nixpkgs/commit/57a4d93bc190aa5aefa0e933629a55a7725d90f9) | `` python311Packages.toggl-cli: format with nixfmt ``                        |
| [`13b33632`](https://github.com/NixOS/nixpkgs/commit/13b336328d0643ec5160f486fddeb1f2c7c2ed9c) | `` python312Packages.validate-email: format with nixfmt ``                   |
| [`faaddd16`](https://github.com/NixOS/nixpkgs/commit/faaddd164167bf2ab2dd9a8ebe872657d5ac13ad) | `` python312Packages.validate-email: refactor ``                             |
| [`051a88a3`](https://github.com/NixOS/nixpkgs/commit/051a88a36aef9464eee8512c7dae4535c45aa6d8) | `` python312Packages.aliyun-python-sdk-core: format with nxfmt ``            |
| [`bb69c640`](https://github.com/NixOS/nixpkgs/commit/bb69c640bc445e0c6fdedaa826258fe5bbd4fcd4) | `` python312Packages.aliyun-python-sdk-core: refactor ``                     |
| [`5cc869f2`](https://github.com/NixOS/nixpkgs/commit/5cc869f235b8784775b4484fd835036eb35da9da) | `` python312Packages.aliyun-python-sdk-core: 2.15.0 -> 2.15.1 ``             |
| [`5edc0fa5`](https://github.com/NixOS/nixpkgs/commit/5edc0fa5e618a1fc755f3d2ad985bb07a30babd3) | `` cni: 1.1.2 -> 1.2.0 ``                                                    |
| [`5abb7948`](https://github.com/NixOS/nixpkgs/commit/5abb79485939155ee780031ae118326592b665be) | `` chainsaw: format with nixfmt ``                                           |
| [`76b36229`](https://github.com/NixOS/nixpkgs/commit/76b3622967d34a4c7c0d8a1224cf89c4cbe1c071) | `` chainsaw: add ldflags ``                                                  |
| [`4e96fb5b`](https://github.com/NixOS/nixpkgs/commit/4e96fb5b233359ce2aedb33e3ad57e114f3e2610) | `` python312Packages.asyncstdlib: format with nixfmt ``                      |
| [`28a511eb`](https://github.com/NixOS/nixpkgs/commit/28a511eb25885b9819b4839c33912fc4495b6046) | `` python311Packages.google-cloud-bigtable: 2.23.0 -> 2.23.1 ``              |
| [`047bcae4`](https://github.com/NixOS/nixpkgs/commit/047bcae4573d562a34599cb0f961b4a32752381a) | `` python311Packages.google-cloud-bigtable: format with nixfmt ``            |
| [`9d8b922e`](https://github.com/NixOS/nixpkgs/commit/9d8b922e83f52992db67afdafa02b45b12901473) | `` python311Packages.google-cloud-bigtable: refactor ``                      |
| [`29e43304`](https://github.com/NixOS/nixpkgs/commit/29e43304e0c607bf2cb94217fc61ec0f6a908ed5) | `` flare-floss: 3.0.1 -> 3.1.0 ``                                            |
| [`8785ef0a`](https://github.com/NixOS/nixpkgs/commit/8785ef0a2d4d22af523b0dccabf7a3885f96af4d) | `` nixos/db-rest: init ``                                                    |
| [`9ed66442`](https://github.com/NixOS/nixpkgs/commit/9ed6644297f34f8405f910f40c2212a69dc2d6cf) | `` flare-floss: format with nixfmt ``                                        |
| [`d181aa11`](https://github.com/NixOS/nixpkgs/commit/d181aa11d9af9815c389055928dd88813956cb25) | `` flare-floss: refactor ``                                                  |
| [`6c3a2fe0`](https://github.com/NixOS/nixpkgs/commit/6c3a2fe04e6de212e1126effbd09c9a3a6e28f0a) | `` python312Packages.dirigera: 1.1.1 -> 1.1.2 ``                             |
| [`17a979d1`](https://github.com/NixOS/nixpkgs/commit/17a979d15938fee6272c68c3f0259f541ae9258b) | `` python312Packages.google-ai-generativelanguage: 0.6.1 -> 0.6.2 ``         |
| [`88795631`](https://github.com/NixOS/nixpkgs/commit/88795631d6de6d91a38de7d8e4a8e8cabcd88713) | `` python312Packages.publicsuffixlist: 0.10.0.20240412 -> 0.10.0.20240416 `` |
| [`342135f8`](https://github.com/NixOS/nixpkgs/commit/342135f8133456db66a7cff6de5c8a6cd6fb1544) | `` checkov: 3.2.60 -> 3.2.66 ``                                              |
| [`768ae3b9`](https://github.com/NixOS/nixpkgs/commit/768ae3b9b1cda5902b7af7f1af4e1788f5ecb3d5) | `` python312Packages.tencentcloud-sdk-python: 3.0.1129 -> 3.0.1130 ``        |
| [`b4ff69d0`](https://github.com/NixOS/nixpkgs/commit/b4ff69d04b64ec5d4319bd20a85bd1a2ac6b7368) | `` exploitdb: 2024-04-14 -> 2024-04-16 ``                                    |
| [`398f0276`](https://github.com/NixOS/nixpkgs/commit/398f02763a59e584f2814fbcec94e2c344fbab51) | `` zellij: 0.39.2 -> 0.40.0 ``                                               |
| [`bd8e6984`](https://github.com/NixOS/nixpkgs/commit/bd8e6984e55063b86f004781e97ddd5729be2c35) | `` python312Packages.mkdocs-material: format with nixfmt ``                  |
| [`95ba2f13`](https://github.com/NixOS/nixpkgs/commit/95ba2f132e4ea6e37f2f387590375e9a11ea8feb) | `` python312Packages.mkdocs-material: add mkdocs-rss-plugin ``               |
| [`6f364afd`](https://github.com/NixOS/nixpkgs/commit/6f364afdb21a6e59a52018638d8ee2584c3a3e95) | `` pythonPackages: update ordering of mkdocs modules ``                      |
| [`c24a03c9`](https://github.com/NixOS/nixpkgs/commit/c24a03c95c3aa08ed3503ec725e14cb08c4e8ed0) | `` python312Packages.mkdocs-rss-plugin: init at 1.12.1 ``                    |
| [`e0fff70a`](https://github.com/NixOS/nixpkgs/commit/e0fff70a2ccc120d11cf0364c1d06df6d2a9b37e) | `` git-machete: 3.24.2 -> 3.25.0 ``                                          |
| [`6cf5653c`](https://github.com/NixOS/nixpkgs/commit/6cf5653ceeaa4364f178445d944e9fd567ab57bb) | `` shorter-pixel-dungeon: use --replace-fail ``                              |
| [`25df9832`](https://github.com/NixOS/nixpkgs/commit/25df98327ba8b22bfafaf8926ba818d11f3a5c78) | `` shorter-pixel-dungeon: 1.2.0 -> 1.3.0 ``                                  |
| [`9e2b45d6`](https://github.com/NixOS/nixpkgs/commit/9e2b45d62e4abf30a1af4a2108fc630d2d8a95da) | `` shattered-pixel-dungeon: use --replace-fail ``                            |
| [`0bc3c975`](https://github.com/NixOS/nixpkgs/commit/0bc3c975150ce2dcb58910f9be8da538c1da9ef1) | `` experienced-pixel-dungeon: 2.16.2 -> 2.17.2 ``                            |
| [`bc112dce`](https://github.com/NixOS/nixpkgs/commit/bc112dce2ccece0bd434350ed3a88e0da9264820) | `` shattered-pixel-dungeon: 2.3.0 -> 2.3.2 ``                                |
| [`b46e2fb0`](https://github.com/NixOS/nixpkgs/commit/b46e2fb0fb4f1a5a44cda051c5816bb5bdebc94c) | `` python312Packages.jsonfeed: init at 0.0.1 ``                              |
| [`4ad3bba1`](https://github.com/NixOS/nixpkgs/commit/4ad3bba1b6de5d51ff3185bacecf51ab9cff413c) | `` python312Packages.validator-collection: init at 1.5.0 ``                  |
| [`46b289ab`](https://github.com/NixOS/nixpkgs/commit/46b289ab1e4a2be02cc97b39a09e878c5e468333) | `` python312Packages.griffe: format with nixfmt ``                           |
| [`e5af57fc`](https://github.com/NixOS/nixpkgs/commit/e5af57fcb1a1441dc907395d56197db31f52fdbd) | `` python312Packages.griffe: refactor ``                                     |
| [`ac630c49`](https://github.com/NixOS/nixpkgs/commit/ac630c499a0e815f759ff1eda6ddfe90e7791c9d) | `` gitu: 0.15.0 -> 0.16.0 ``                                                 |
| [`66a0993c`](https://github.com/NixOS/nixpkgs/commit/66a0993c150809fd917cf779f63fc8ed8b371501) | `` python311Packages.pyemvue: 0.18.4 -> 0.18.5 ``                            |
| [`060e03e1`](https://github.com/NixOS/nixpkgs/commit/060e03e117e2ba5aeeb7dcdeffcd47ce23630fd8) | `` kafka-cmak: init at 3.0.0.6 ``                                            |
| [`c28bddf3`](https://github.com/NixOS/nixpkgs/commit/c28bddf3886b864cb25d5c3dbb597518d1cb069c) | `` telegram-desktop: 4.16.6 -> 4.16.7 ``                                     |
| [`f99cb0df`](https://github.com/NixOS/nixpkgs/commit/f99cb0df130ae3e908a65947307e9c2ed00a413a) | `` spicetify-cli: 2.36.4 -> 2.36.5 ``                                        |
| [`aae75c75`](https://github.com/NixOS/nixpkgs/commit/aae75c75b7e4edb024a9fffe7a8aaa8c81131fcc) | `` topicctl: 1.16.0 -> 1.16.1 ``                                             |
| [`d4f32644`](https://github.com/NixOS/nixpkgs/commit/d4f326441ba58f797c4a9535af9765a5f714b9b2) | `` README: sync package count with https://search.nixos.org/packages ``      |
| [`690b6747`](https://github.com/NixOS/nixpkgs/commit/690b6747a37111ecd0093dd818b6a0f7cf4671c9) | `` mympd: 14.1.1 -> 14.1.2 ``                                                |
| [`3cc77d62`](https://github.com/NixOS/nixpkgs/commit/3cc77d62e11af3a6ed0829d3e26c59e917bf7d94) | `` python312Packages.mkdocs-material: 9.5.17 -> 9.5.18 ``                    |
| [`653c9320`](https://github.com/NixOS/nixpkgs/commit/653c932007a0285a9a2b5356b6522c9e801c44d8) | `` tdl: 0.16.1 -> 0.16.2 ``                                                  |
| [`72367a7f`](https://github.com/NixOS/nixpkgs/commit/72367a7f7fab5eb12c0ed6cc1833bed374623a14) | `` python312Packages.holidays: 0.46 -> 0.47 ``                               |
| [`a2e9ba30`](https://github.com/NixOS/nixpkgs/commit/a2e9ba30c8ab98756d0fb3ffb24a864d638471a3) | `` python312Packages.griffe: 0.42.1 -> 0.42.2 ``                             |
| [`79f52941`](https://github.com/NixOS/nixpkgs/commit/79f529412d275d5aab9f39baa233dc0d8ab3b228) | `` wizer: 5.0.0 -> 6.0.0 ``                                                  |
| [`2638a700`](https://github.com/NixOS/nixpkgs/commit/2638a700160d46f6d6912b8d9a65041a6e017437) | `` wazero: 1.7.0 -> 1.7.1 ``                                                 |
| [`c0476dd6`](https://github.com/NixOS/nixpkgs/commit/c0476dd6e6aceee9e23efbec5fe082cbed0c5b36) | `` grype: 0.75.0 -> 0.76.0 ``                                                |
| [`e1abaedf`](https://github.com/NixOS/nixpkgs/commit/e1abaedf96c784312df831f39533acaa23d21bc4) | `` python312Packages.bip-utils: 2.9.2 -> 2.9.3 ``                            |
| [`af9f5ddf`](https://github.com/NixOS/nixpkgs/commit/af9f5ddf5c14775934ad13fe8f3b3c7b99fa42a9) | `` vhs: 0.7.1 -> 0.7.2 ``                                                    |
| [`11659af6`](https://github.com/NixOS/nixpkgs/commit/11659af6c8b69563d3bf468eb9d1759aad34ffba) | `` python312Packages.oca-port: 0.14 -> 0.15 ``                               |
| [`14a57dac`](https://github.com/NixOS/nixpkgs/commit/14a57daca95626335cf7447455f48c1c3c8f40f8) | `` python312Packages.blinkpy: 0.22.6 -> 0.22.7 ``                            |
| [`50a64fdc`](https://github.com/NixOS/nixpkgs/commit/50a64fdc66ad67c21b6e7887f5f27a7ffa77997d) | `` nixpacks: 1.21.2 -> 1.21.3 ``                                             |
| [`2cb38a43`](https://github.com/NixOS/nixpkgs/commit/2cb38a43ff2b1eb5550c9839f4bce964856c9950) | `` ocamlPackages.otoml: 1.0.4 -> 1.0.5 ``                                    |
| [`2029561a`](https://github.com/NixOS/nixpkgs/commit/2029561a701a80f13dddf4960698eea4b5674851) | `` libsForQt5.libquotient: 0.8.1.2 -> 0.8.2 ``                               |
| [`1ddb4d18`](https://github.com/NixOS/nixpkgs/commit/1ddb4d18316a585b7d32f9869f2209becb9872ed) | `` influxdb2-cli: 2.7.3 -> 2.7.4 ``                                          |
| [`5c6a9c72`](https://github.com/NixOS/nixpkgs/commit/5c6a9c72e6360a86edbe92a36751a7c3827fad9b) | `` goresym: 2.7.2 -> 2.7.3 ``                                                |
| [`7995c0c7`](https://github.com/NixOS/nixpkgs/commit/7995c0c70b0c8b3f727e96202f024c5e10af2508) | `` goa: 3.16.0 -> 3.16.1 ``                                                  |
| [`f19b38d8`](https://github.com/NixOS/nixpkgs/commit/f19b38d8835da419308173c55fc31b057d28c89e) | `` squeezelite: 2.0.0.1481 -> 2.0.0.1486 ``                                  |
| [`1063186a`](https://github.com/NixOS/nixpkgs/commit/1063186a6696193d7766e29780d64b46bdf59df7) | `` cwltool: 3.1.20240112164112 -> 3.1.20240404144621 ``                      |
| [`2b8c8dcd`](https://github.com/NixOS/nixpkgs/commit/2b8c8dcd26492bb4948e70f11c8821c655d9ef1a) | `` python311Packages.lmcloud: 1.1.9 -> 1.1.10 ``                             |
| [`c5efa39b`](https://github.com/NixOS/nixpkgs/commit/c5efa39b46dfbca6a42a1a70925fa35b3c009082) | `` devbox: 0.10.4 -> 0.10.5 ``                                               |
| [`a18ffe20`](https://github.com/NixOS/nixpkgs/commit/a18ffe20f98f21a71cf4d89e27cfabc1970f87fa) | `` dep-scan: 5.3.2 -> 5.3.3 ``                                               |
| [`cd7b2fd6`](https://github.com/NixOS/nixpkgs/commit/cd7b2fd691a1a5a6f46a80d818470c9cef10ed17) | `` csview: 1.2.4 -> 1.3.0 ``                                                 |
| [`89a5fd74`](https://github.com/NixOS/nixpkgs/commit/89a5fd745a77c7325043d1e7789f94e100b9cc8d) | `` cargo-component: 0.10.1 -> 0.11.0 ``                                      |
| [`f3c53de0`](https://github.com/NixOS/nixpkgs/commit/f3c53de0eb5b4cd2dbf42361bee436d80db66179) | `` chainsaw: 2.8.1 -> 2.9.0 ``                                               |
| [`7bf9024e`](https://github.com/NixOS/nixpkgs/commit/7bf9024e5868e915537f8547a1a09f9f865e8108) | `` ryujinx: 1.1.1248 -> 1.1.1281 ``                                          |
| [`e60dd4e5`](https://github.com/NixOS/nixpkgs/commit/e60dd4e5ae159b0d34e5c83a1b104be2fae3a710) | `` edir: 2.27 -> 2.28 ``                                                     |
| [`974b3376`](https://github.com/NixOS/nixpkgs/commit/974b3376c58e359d9c962f7946989206129a39b4) | `` rke: 1.5.7 -> 1.5.8 ``                                                    |
| [`073d3bda`](https://github.com/NixOS/nixpkgs/commit/073d3bdad2ae5b06610b1402b3c66fe782749677) | `` tcsh: remove AndersonTorres from maintainers ``                           |