### PR TITLE
chore(flake/nixfmt): `3cb264c8` -> `87c4879b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1160,11 +1160,11 @@
         "flake-utils": "flake-utils_11"
       },
       "locked": {
-        "lastModified": 1713194606,
-        "narHash": "sha256-slz9WHQEWIfJWpCDFG1aiiiBEutIZcK2eoaSDARZc6E=",
+        "lastModified": 1713291528,
+        "narHash": "sha256-Xx0hY9XXXOmOgTlgpX9r1bQkigWhNXXEzeVRBI46EfY=",
         "owner": "nixos",
         "repo": "nixfmt",
-        "rev": "3cb264c8c748ca7a059bba676ebd9c6465797e48",
+        "rev": "87c4879b7a72a69726b76392847fb79a7044c6a6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                  |
| --------------------------------------------------------------------------------------------- | ---------------------------------------- |
| [`e5c6c31e`](https://github.com/NixOS/nixfmt/commit/e5c6c31e8315d46b02237ae42d0b2f58c89c650b) | `` Fix duplicate Nixpkgs diff comment `` |