### PR TITLE
chore(flake/emacs-overlay): `502906af` -> `208d00a7`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713287188,
-        "narHash": "sha256-LpbYsViVHQ19Qyjw4FxlTWcZNSbiagMfPMrUBuDVTBk=",
+        "lastModified": 1713373570,
+        "narHash": "sha256-+ZtrHsUp8vEbQ9FFTj+4ku7byW/ly1JVNqgdiNVBMis=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "502906af674eae890790ec48cad959d42dc2f040",
+        "rev": "208d00a7f96d920a153ab90f257357e1aa1d6d77",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`208d00a7`](https://github.com/nix-community/emacs-overlay/commit/208d00a7f96d920a153ab90f257357e1aa1d6d77) | `` Updated emacs ``        |
| [`68b08d5c`](https://github.com/nix-community/emacs-overlay/commit/68b08d5cd11d3c005f017ca2199c5164362d26d1) | `` Updated melpa ``        |
| [`57295046`](https://github.com/nix-community/emacs-overlay/commit/57295046afe433216a389f73b1bcd351de852842) | `` Updated elpa ``         |
| [`03342208`](https://github.com/nix-community/emacs-overlay/commit/0334220804cb13f86e1e7ba83b135c9fbffa9d89) | `` Updated emacs ``        |
| [`50b2646a`](https://github.com/nix-community/emacs-overlay/commit/50b2646a6560eeb9119e66b22da87a3dce1e272a) | `` Updated melpa ``        |
| [`68ed87aa`](https://github.com/nix-community/emacs-overlay/commit/68ed87aa28ef073f9e6a482977f07591aae61639) | `` Updated emacs ``        |
| [`b40ce49e`](https://github.com/nix-community/emacs-overlay/commit/b40ce49e63df574d5de122796e60ab8089e6ea78) | `` Updated melpa ``        |
| [`32256276`](https://github.com/nix-community/emacs-overlay/commit/32256276525e8cdc4e9ec285660acd5e7e26e4e1) | `` Updated elpa ``         |
| [`d3c01e02`](https://github.com/nix-community/emacs-overlay/commit/d3c01e025103a7fc9a1946775e191a82cf3af4fa) | `` Updated nongnu ``       |
| [`dd5697cf`](https://github.com/nix-community/emacs-overlay/commit/dd5697cf3687ddc010b66b8eeecd43a144f5ed88) | `` Updated flake inputs `` |