### PR TITLE
chore(flake/home-manager): `1c43dcfa` -> `fa8c16e2`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713166971,
-        "narHash": "sha256-t0P/rKlsE5l1O3O2LYtAelLzp7PeoPCSzsIietQ1hSM=",
+        "lastModified": 1713294767,
+        "narHash": "sha256-LmaabaQZdx52MPGKPRt9Opoc9Gd9RbwvCdysUUYQoXI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1c43dcfac48a2d622797f7ab741670fdbcf8f609",
+        "rev": "fa8c16e2452bf092ac76f09ee1fb1e9f7d0796e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                            |
| ----------------------------------------------------------------------------------------------------------- | ---------------------------------- |
| [`fa8c16e2`](https://github.com/nix-community/home-manager/commit/fa8c16e2452bf092ac76f09ee1fb1e9f7d0796e7) | `` systemd: add `enable` option `` |