### PR TITLE
chore(flake/hyprland): `fe7b748e` -> `78b04c3a`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -687,11 +687,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713283263,
-        "narHash": "sha256-Urb/njWiHYUudXpmK8EKl9Z58esTIG0PxXw5LuM2r5g=",
+        "lastModified": 1713372286,
+        "narHash": "sha256-TgwYLtNx9lLQjoVbAlvDfabAo3RaeM7jd9hh/ndFH/w=",
         "owner": "hyprwm",
         "repo": "hyprland",
-        "rev": "fe7b748eb668136dd0558b7c8279bfcd7ab4d759",
+        "rev": "78b04c3a76614015a6f79f7b3c0e4ebe05548594",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                           | Message                                                                    |
| ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
| [`78b04c3a`](https://github.com/hyprwm/Hyprland/commit/78b04c3a76614015a6f79f7b3c0e4ebe05548594) | `` hyprctl: fix activewindow request not showing workspace name (#5623) `` |
| [`e57a2d7e`](https://github.com/hyprwm/Hyprland/commit/e57a2d7ec87ae775828ea8628ef4eeafce8e6e70) | `` keybindmgr: add optional `silent` suffix to `movewindow`. (#5597) ``    |
| [`e8e02e81`](https://github.com/hyprwm/Hyprland/commit/e8e02e81e84bb04efa0c926361ec80c60744f665) | `` README: minor cleanup ``                                                |