### PR TITLE
chore(flake/nixpkgs-master): `4231f20d` -> `d205596f`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1224,11 +1224,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1713286975,
-        "narHash": "sha256-WS+b3oeIErX1SVqbw6d9+6FiGeXZ7TTe9l5ERw4KTG0=",
+        "lastModified": 1713372677,
+        "narHash": "sha256-q2QLEHvN4Qwj/xIQSUr4OtjI8kIJRWVE6ju98c640B0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4231f20d15397c762793b21e09074fc741576b19",
+        "rev": "d205596f17d89a7205af1c7a9cd419be382d7557",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                        |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
| [`23e6179e`](https://github.com/NixOS/nixpkgs/commit/23e6179e7d06c4c8bfd95678b0f6dabccd2d0849) | `` linux_latest-libre: 19527 -> 19536 ``                                       |
| [`2234f0fa`](https://github.com/NixOS/nixpkgs/commit/2234f0fa7849671e4885e1af489ebec477828f9d) | `` linux_5_15: 5.15.155 -> 5.15.156 ``                                         |
| [`a943f8eb`](https://github.com/NixOS/nixpkgs/commit/a943f8ebc090c12af0aa4b3b407661c2ca7b5430) | `` linux_6_1: 6.1.86 -> 6.1.87 ``                                              |
| [`f1fc24e9`](https://github.com/NixOS/nixpkgs/commit/f1fc24e92188d911b8a09a71348faa98ad43bd18) | `` linux_6_6: 6.6.27 -> 6.6.28 ``                                              |
| [`0e44a84d`](https://github.com/NixOS/nixpkgs/commit/0e44a84db511c8afeeebd88350af01a459f226d6) | `` linux_6_8: 6.8.6 -> 6.8.7 ``                                                |
| [`c45b36bc`](https://github.com/NixOS/nixpkgs/commit/c45b36bc45eb3fdde7164decf4ef9fd01a3e959e) | `` linux_testing: 6.9-rc3 -> 6.9-rc4 ``                                        |
| [`4c5b0237`](https://github.com/NixOS/nixpkgs/commit/4c5b0237a435d4946dd64dec77bee606ccbf3297) | `` realvnc-vnc-viewer: replace fetchurl by requireFile to fix captcha ``       |
| [`b101fcd0`](https://github.com/NixOS/nixpkgs/commit/b101fcd01b2b1b2e8afc9caab901aef829c7f53a) | `` terraform: 1.8.0 -> 1.8.1 (#304763) ``                                      |
| [`4dcd08c9`](https://github.com/NixOS/nixpkgs/commit/4dcd08c9d4c84e2f5d94bc0344bdfd55f876ce0e) | `` plasmahud: fix runtime errors and other cleanup (#271479) ``                |
| [`cdf2f465`](https://github.com/NixOS/nixpkgs/commit/cdf2f46541241ecdec0c98e37c980e971b9d40ef) | `` fm-go: 1.0.0 -> 1.1.0 ``                                                    |
| [`586726d3`](https://github.com/NixOS/nixpkgs/commit/586726d3e1a13435671de034bd0af75f455cb9a8) | `` grandorgue: 3.14.0-1 -> 3.14.1-1 ``                                         |
| [`57fa33ad`](https://github.com/NixOS/nixpkgs/commit/57fa33ad54295a28999c99a88de437dfc9fef873) | `` go-judge: 1.8.2 -> 1.8.3 ``                                                 |
| [`d91bfb27`](https://github.com/NixOS/nixpkgs/commit/d91bfb279d8adce0b7e389746260e1bd9c0c7625) | `` git-instafix: 0.2.1 -> 0.2.2 ``                                             |
| [`745cafd0`](https://github.com/NixOS/nixpkgs/commit/745cafd0b1db00332a550860aaf9ed6316616974) | `` gh: 2.47.0 -> 2.48.0 ``                                                     |
| [`036cfda4`](https://github.com/NixOS/nixpkgs/commit/036cfda40d303074bac166e46dad352830a62437) | `` flix: 0.45.0 -> 0.46.0 ``                                                   |
| [`be242933`](https://github.com/NixOS/nixpkgs/commit/be2429339c817010689927352ec31826029ff373) | `` kraft: 0.8.2 -> 0.8.3 ``                                                    |
| [`5430291c`](https://github.com/NixOS/nixpkgs/commit/5430291c3996159bdb1488f78dd5474a90693960) | `` atac: 0.11.3 -> 0.12.0 ``                                                   |
| [`1175703b`](https://github.com/NixOS/nixpkgs/commit/1175703bd2f9f61fd84d8766d10b0c00b069e792) | `` bitcoin: 26.1 -> 27.0 ``                                                    |
| [`6bb6c845`](https://github.com/NixOS/nixpkgs/commit/6bb6c845457ab20ffd468e96205e3bc6db5824f7) | `` checkov: 3.2.68 -> 3.2.69 ``                                                |
| [`44f73650`](https://github.com/NixOS/nixpkgs/commit/44f73650e88128cb3d62ae58a4b4cc4c88143edb) | `` craft-parts: skip failing tests on aarch64 ``                               |
| [`d9792591`](https://github.com/NixOS/nixpkgs/commit/d97925912aeec5065f910b5992404a632e6b2ebe) | `` neverest: init at 1.0.0-beta ``                                             |
| [`1ddecd7c`](https://github.com/NixOS/nixpkgs/commit/1ddecd7cd42ee6e8d3e7e804eebe4b0d4998aff1) | `` renode-dts2repl: unstable-2024-03-24 -> unstable-2024-04-16 ``              |
| [`f53ced03`](https://github.com/NixOS/nixpkgs/commit/f53ced0368afd9eac3c9d63397f6619d5ac9a8e2) | `` nixos/ollama: set service working directory to `home` ``                    |
| [`bda3941d`](https://github.com/NixOS/nixpkgs/commit/bda3941d7799be656f06f60b7b13b8a8c3e55335) | `` ollama: fix compilation errors caused by dependency changes ``              |
| [`92bd0da0`](https://github.com/NixOS/nixpkgs/commit/92bd0da0a11c1382347fa77c2fb902bfc1426519) | `` python312Packages.jsonargparse: format with nixfmt ``                       |
| [`737fb5a5`](https://github.com/NixOS/nixpkgs/commit/737fb5a5aeb3119ae8ce4a43f32d7921fe33846f) | `` python312Packages.jsonargparse: refactor ``                                 |
| [`b4aab7ce`](https://github.com/NixOS/nixpkgs/commit/b4aab7ced4f7f565f9cddd578b8a5ac78571d819) | `` python312Packages.jsonargparse: 4.27.7 -> 4.28.0 ``                         |
| [`d9e19c19`](https://github.com/NixOS/nixpkgs/commit/d9e19c19d7ef0f7b3134d7d1f5a311dea41b42db) | `` python311Packages.types-aiobotocore: format with nixfmt ``                  |
| [`5c2437c5`](https://github.com/NixOS/nixpkgs/commit/5c2437c53d3e53ae073c2a6a89c0fdbc673f8167) | `` python311Packages.types-awscrt: format with nixfmt ``                       |
| [`751025a3`](https://github.com/NixOS/nixpkgs/commit/751025a3d09026d4305cc3116761848f2fabee5f) | `` python311Packages.types-awscrt: refactor ``                                 |
| [`6fc8210c`](https://github.com/NixOS/nixpkgs/commit/6fc8210c0ea7d47f209187f4cb77f3b17ab47372) | `` vscode-extensions.timonwong.shellcheck: 0.37.0 -> 0.37.1 ``                 |
| [`bc46ba53`](https://github.com/NixOS/nixpkgs/commit/bc46ba538e301b9d60247d7e68c77e37d57f919a) | `` python311Packages.google-cloud-bigquery-datatransfer: format with nixfmt `` |
| [`42d36243`](https://github.com/NixOS/nixpkgs/commit/42d362433bebd9a3be2de8aa7360bf4cd547f791) | `` python311Packages.google-cloud-bigquery-datatransfer: refactor ``           |
| [`89d91db8`](https://github.com/NixOS/nixpkgs/commit/89d91db8c4f9cbf05522726a75eb15130e8fb228) | `` cloudfox: format with nixfmt ``                                             |
| [`cd839afe`](https://github.com/NixOS/nixpkgs/commit/cd839afeed51be04deadfb35c94a73fb0c4fbfa1) | `` python312Packages.yfinance: format with nixfmt ``                           |
| [`84065cfa`](https://github.com/NixOS/nixpkgs/commit/84065cfaa79aad318059eee9dee37a924496736e) | `` python312Packages.yfinance: refactor ``                                     |
| [`1dcf30f1`](https://github.com/NixOS/nixpkgs/commit/1dcf30f141f60da0c540d9972fa41b54011888c3) | `` nixos/prometheus-redis-exporter: allow `AF_UNIX` ``                         |
| [`dae18691`](https://github.com/NixOS/nixpkgs/commit/dae18691d508bd4b96321f60fe5a4411039e6eda) | `` wyoming-faster-whisper: 2.0.0 -> 2.1.0 ``                                   |
| [`063b6f02`](https://github.com/NixOS/nixpkgs/commit/063b6f02b5e89684c763903337cc6b375df8e46c) | `` python312Packages.peaqevcore: 19.7.14 -> 19.7.15 ``                         |
| [`c653c1bb`](https://github.com/NixOS/nixpkgs/commit/c653c1bbc0977a9cd541edef42887d6ceda3b8d8) | `` nix-inspect: Fix package description ``                                     |
| [`ced48067`](https://github.com/NixOS/nixpkgs/commit/ced480670ac5dca532cf5f5e66d775472b4ebf9d) | `` nix-inspect: 0.1.0 -> 0.1.1 ``                                              |
| [`5b4f016c`](https://github.com/NixOS/nixpkgs/commit/5b4f016c805b9c281868e1f73c98b3b44626d87f) | `` python312Packages.dbt-redshift: 1.7.5 -> 1.7.6 ``                           |
| [`8f67b3d4`](https://github.com/NixOS/nixpkgs/commit/8f67b3d4469c5b5eb939d106c6eee4ead597df12) | `` nginxModules.spnego-http-auth: fix support for nginx 1.23+ ``               |
| [`ade68e36`](https://github.com/NixOS/nixpkgs/commit/ade68e36f2828e018334d4e82bd574d775145f4c) | `` python312Packages.yfinance: 0.2.37 -> 0.2.38 ``                             |
| [`f189d959`](https://github.com/NixOS/nixpkgs/commit/f189d9599c23dfe5e3dd07c279178820afc69ba7) | `` python312Packages.pysignalclirestapi: 0.3.23 -> 0.3.24 ``                   |
| [`2ba2244f`](https://github.com/NixOS/nixpkgs/commit/2ba2244fdde0bad5898f1ce24296351691bed58a) | `` vendir: 0.40.0 -> 0.40.1 ``                                                 |
| [`99afffdc`](https://github.com/NixOS/nixpkgs/commit/99afffdc3a54612249e17a15f387d70b7f13f84f) | `` nginxModules.lua: remove patch that is already applied ``                   |
| [`d2a75a01`](https://github.com/NixOS/nixpkgs/commit/d2a75a01f4f1bdd981e773e67d54d8e334104c02) | `` python312Packages.msgraph-sdk: 1.2.0 -> 1.3.0 ``                            |
| [`df5dd954`](https://github.com/NixOS/nixpkgs/commit/df5dd95472f9ebc6e4b936fb85e5e7d191aebd19) | `` python312Packages.pydiscourse: 1.6.1 -> 1.7.0 ``                            |
| [`b5f809bb`](https://github.com/NixOS/nixpkgs/commit/b5f809bb334dbd5182a1ff4f092010d095d8c854) | `` python312Packages.dbt-core: 1.7.11 -> 1.7.12 ``                             |
| [`7a6a2708`](https://github.com/NixOS/nixpkgs/commit/7a6a2708daeb52af16f7bae18a81b26054668d5d) | `` python312Packages.apsw: 3.45.2.0 -> 3.45.3.0 ``                             |
| [`499c8303`](https://github.com/NixOS/nixpkgs/commit/499c8303737f9c63fa00e38f4f23f7fded8f47dc) | `` hilbish: 2.2.1 -> 2.2.2 ``                                                  |
| [`e8abfd98`](https://github.com/NixOS/nixpkgs/commit/e8abfd98b083c86c1dee005456ae19700be9b1e0) | `` nomad: 1.7.6 -> 1.7.7 ``                                                    |
| [`97e276a9`](https://github.com/NixOS/nixpkgs/commit/97e276a9022d205ccad0a63bb87f03e9861b8361) | `` netscanner: 0.4.1 -> 0.4.2 ``                                               |
| [`128501b1`](https://github.com/NixOS/nixpkgs/commit/128501b16723f8675d2b75cf4a5d2886610b7137) | `` hugo: 0.124.1 -> 0.125.0 ``                                                 |
| [`dbb83ec4`](https://github.com/NixOS/nixpkgs/commit/dbb83ec44db794e7a917211460bd9cee2048eb82) | `` juicity: 0.4.0 -> 0.4.1 ``                                                  |
| [`518ebacf`](https://github.com/NixOS/nixpkgs/commit/518ebacf79b49361332d540ea91d85e2e573871b) | `` vscode: 1.88.0 -> 1.88.1 ``                                                 |
| [`33f79c01`](https://github.com/NixOS/nixpkgs/commit/33f79c01a792ebd72ec67251454be90fb8b052f0) | `` govulncheck: 1.0.4 -> 1.1.0 ``                                              |
| [`16fbf531`](https://github.com/NixOS/nixpkgs/commit/16fbf5311458b0c4785f0c50eb21fec0a0db2b84) | `` waylock: 0.6.5 -> 1.0.0 ``                                                  |
| [`8f82a1f0`](https://github.com/NixOS/nixpkgs/commit/8f82a1f0d5e01c17419b9b88fc276104a109380c) | `` expr: 1.16.4 -> 1.16.5 ``                                                   |
| [`92a9b54d`](https://github.com/NixOS/nixpkgs/commit/92a9b54db14e3dbbad0085e37a75fc9f5823d20b) | `` Revert "rocmPackages.composable_kernel: compress output" ``                 |
| [`f21fc56f`](https://github.com/NixOS/nixpkgs/commit/f21fc56f267d073300dfeecb722f2dd803acbaf8) | `` cloudfox: 1.13.4 -> 1.14.0 ``                                               |
| [`2890d63c`](https://github.com/NixOS/nixpkgs/commit/2890d63ce3d7d204789fb8db21a75d229c3a48e1) | `` niri: drop redundant LIBCLANG_PATH ``                                       |
| [`229626d4`](https://github.com/NixOS/nixpkgs/commit/229626d4d005a5a93bcba8eb5ac5c4d93994a2e0) | `` planify: 4.5.12 -> 4.6 ``                                                   |
| [`07b9c62e`](https://github.com/NixOS/nixpkgs/commit/07b9c62ece39883adc3c1f8562093cb92c6c260f) | `` esphome: 2024.3.1 -> 2024.3.2 ``                                            |
| [`b4481e53`](https://github.com/NixOS/nixpkgs/commit/b4481e53021fb9602aecdee87161c60df31e996b) | `` python311Packages.ionoscloud: 6.1.8 -> 6.1.9 ``                             |
| [`a5df1b97`](https://github.com/NixOS/nixpkgs/commit/a5df1b97e35b6973f232b83a7dcaffb6039dc3bc) | `` meilisearch: 1.7.3 -> 1.7.6; fix darwin ``                                  |
| [`d4447030`](https://github.com/NixOS/nixpkgs/commit/d4447030c567945c238bbad9588bc9c0757a050b) | `` python311Packages.zodbpickle: 3.2 -> 3.3 ``                                 |
| [`3616548d`](https://github.com/NixOS/nixpkgs/commit/3616548db50e293fe742d92a321fffc5b3ad73ac) | `` telegram-desktop: 4.16.7 -> 4.16.8 ``                                       |
| [`87ef9f4b`](https://github.com/NixOS/nixpkgs/commit/87ef9f4b15980d134d5dbb4403ab91d80f1ae140) | `` castero: init at 0.9.5 ``                                                   |
| [`68142254`](https://github.com/NixOS/nixpkgs/commit/68142254d20256e617f596a5d50f9950f98fa36a) | `` nixos/zram: add compression algorithms to option enum ``                    |
| [`df719c9d`](https://github.com/NixOS/nixpkgs/commit/df719c9da537bb0a058f0afb2045ed1df9a13aac) | `` checkov: 3.2.66 -> 3.2.68 ``                                                |