### PR TITLE
chore(flake/nixpkgs-unstable): `3ad65e9f` -> `edd8117b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1303,11 +1303,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1713281235,
-        "narHash": "sha256-nqZNK4gUBQBagw3sCoUdH+2mOKiFNkI0ICSU3asUX+E=",
+        "lastModified": 1713319785,
+        "narHash": "sha256-2MGHSNWFV6abENbLr9AKqXiJnIO3gehWM2H7AmcMCl0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3ad65e9f48fd31c89121feb6e9c582ff7e4bb664",
+        "rev": "edd8117bfa116596c6b924ac7c8a10280d6c0981",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                           |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
| [`518ebacf`](https://github.com/NixOS/nixpkgs/commit/518ebacf79b49361332d540ea91d85e2e573871b) | `` vscode: 1.88.0 -> 1.88.1 ``                                                                    |
| [`229626d4`](https://github.com/NixOS/nixpkgs/commit/229626d4d005a5a93bcba8eb5ac5c4d93994a2e0) | `` planify: 4.5.12 -> 4.6 ``                                                                      |
| [`68142254`](https://github.com/NixOS/nixpkgs/commit/68142254d20256e617f596a5d50f9950f98fa36a) | `` nixos/zram: add compression algorithms to option enum ``                                       |
| [`0dd2e005`](https://github.com/NixOS/nixpkgs/commit/0dd2e005638c3697738a12dad102ffb18fd3df12) | `` haskell.packages.ghc{810,90}.hashable: don't pull in os-string ``                              |
| [`159fb644`](https://github.com/NixOS/nixpkgs/commit/159fb644748849a5b77a4b571c9798e8055aaa71) | `` python311Packages.bundlewrap-pass: init at 1.0.2 ``                                            |
| [`9137a06f`](https://github.com/NixOS/nixpkgs/commit/9137a06f940826a94431b8bf8452130c428c44de) | `` python311Packages.bundlewrap-keepass: init at 0.1.0 ``                                         |
| [`4175642b`](https://github.com/NixOS/nixpkgs/commit/4175642bd13d386a80801530562f3bdc83ed76df) | `` python311Packages.bundlewrap-teamvault: init at 3.1.5 ``                                       |
| [`4be3af37`](https://github.com/NixOS/nixpkgs/commit/4be3af3783a7f2c654471c9aa44d6d8e33f248c5) | `` blackmagic-desktop-video,decklink: 12.5a15 -> 12.9a3 ``                                        |
| [`2d02c287`](https://github.com/NixOS/nixpkgs/commit/2d02c287d361f45d92da26d4ec739e49665eaed0) | `` python311Packages.llama-index-core: fix `pythonImportCheck` failures for dependant packages `` |
| [`e4c62bd9`](https://github.com/NixOS/nixpkgs/commit/e4c62bd902156c13b2b4b480cdd94d9ea1be8f75) | `` python3Packages.wavefile: unbreak  ``                                                          |
| [`2e699b78`](https://github.com/NixOS/nixpkgs/commit/2e699b782e25a7e94cd81a9e21ada67b849beca7) | `` python312Packages.cle: 9.2.98 -> 9.2.99 ``                                                     |
| [`ddc3a743`](https://github.com/NixOS/nixpkgs/commit/ddc3a743859f1ba87aba8f00941ab86e4ec2f683) | `` python312Packages.angr: 9.2.98 -> 9.2.99 ``                                                    |
| [`826a6ff1`](https://github.com/NixOS/nixpkgs/commit/826a6ff1426aa70b7c7d245f5a69d84204fff15a) | `` python312Packages.claripy: 9.2.98 -> 9.2.99 ``                                                 |
| [`4b748860`](https://github.com/NixOS/nixpkgs/commit/4b7488606d45dc209994bd2fe89a4a89f7118f36) | `` python312Packages.pyvex: 9.2.98 -> 9.2.99 ``                                                   |
| [`02f01681`](https://github.com/NixOS/nixpkgs/commit/02f0168166b63f9ead833ecbfca52dba2873cc44) | `` python312Packages.ailment: 9.2.98 -> 9.2.99 ``                                                 |
| [`970021bf`](https://github.com/NixOS/nixpkgs/commit/970021bf509b8e82d6eda514ed768290d388ea13) | `` python312Packages.archinfo: 9.2.98 -> 9.2.99 ``                                                |
| [`fe161951`](https://github.com/NixOS/nixpkgs/commit/fe1619514a93f14a2335c893bddcf98d41523d87) | `` cnspec: 10.11.1 -> 10.12.2 ``                                                                  |
| [`772fc787`](https://github.com/NixOS/nixpkgs/commit/772fc787d154b01db16fc84073c44af930b12031) | `` vscode-extensions.sourcery.sourcery: init at 1.16.0 ``                                         |
| [`4c0599b6`](https://github.com/NixOS/nixpkgs/commit/4c0599b6ce6e408b46f13c69ab1c9d5d25834bcd) | `` firefox-bin-unwrapped: 125.0 -> 125.0.1 ``                                                     |
| [`283867bd`](https://github.com/NixOS/nixpkgs/commit/283867bd9ac846d5051905c408aa5a8fd3163837) | `` firefox-unwrapped: 125.0 -> 125.0.1 ``                                                         |
| [`a6aa2cfc`](https://github.com/NixOS/nixpkgs/commit/a6aa2cfc68e808042332239eae00b8dcba07b884) | `` sourcery: init at 1.16.0 ``                                                                    |
| [`463eae1a`](https://github.com/NixOS/nixpkgs/commit/463eae1a17a776b50c5b67c042c084c2c58463a5) | `` redo: fix src ``                                                                               |
| [`6e1ec998`](https://github.com/NixOS/nixpkgs/commit/6e1ec9985c6ecbf9ce0ee60b6fc48596b3576c09) | `` labelle: init at 1.1.0 ``                                                                      |
| [`c7aae499`](https://github.com/NixOS/nixpkgs/commit/c7aae499f8e3698f171d2f4a1cdcf6521c2dcd95) | `` eigenpy: fix hash ``                                                                           |
| [`1863e4a7`](https://github.com/NixOS/nixpkgs/commit/1863e4a7bc216c67ee85df927cbaa2929cad4b87) | `` eigenpy: clean ``                                                                              |
| [`60807215`](https://github.com/NixOS/nixpkgs/commit/608072151ba6978a86f0ea69d21c4f43d0c78ba4) | `` rtl-sdr: add myself as maintainer ``                                                           |
| [`a1080ded`](https://github.com/NixOS/nixpkgs/commit/a1080ded576e7abdaa87a4a35fcd49566a2969f2) | `` rtl-sdr: refactor, add rtl-sdr-blog and set it as default ``                                   |
| [`49716578`](https://github.com/NixOS/nixpkgs/commit/49716578cc6c546048a945d9af168a48d28975df) | `` maintainers: remove star-szr ``                                                                |
| [`179f8e0a`](https://github.com/NixOS/nixpkgs/commit/179f8e0aa4d6208d43c867c4e48ca49517397709) | `` haskell.compiler.ghc965: init at 9.6.5 ``                                                      |
| [`481a9dc0`](https://github.com/NixOS/nixpkgs/commit/481a9dc0d920deba5fb7102ed933e5934d3400b7) | `` bloop: 1.5.15 -> 1.5.17 ``                                                                     |
| [`e4c6bbd4`](https://github.com/NixOS/nixpkgs/commit/e4c6bbd4f78fab0a1d17cfcb26dc17dbf58dd74c) | `` dotnetCorePackages.dotnet_8: 8.0.3 -> 8.0.4 ``                                                 |
| [`23dfb91c`](https://github.com/NixOS/nixpkgs/commit/23dfb91c3195581ec6d4ecd0a5a729a60d60f204) | `` dotnetCorePackages.sdk_8_0: 8.0.3 -> 8.0.4 ``                                                  |
| [`637f3aa1`](https://github.com/NixOS/nixpkgs/commit/637f3aa120ab428d4e96a6bac94c48d5de0740f2) | `` dotnetCorePackages.sdk_7_0: 7.0.117 -> 7.0.118 ``                                              |
| [`739e58ea`](https://github.com/NixOS/nixpkgs/commit/739e58eae52af521819ede1376a05796c75643be) | `` dotnetCorePackages.sdk_6_0: 6.0.28 -> 6.0.29 ``                                                |
| [`5ad4b8b0`](https://github.com/NixOS/nixpkgs/commit/5ad4b8b068cde9f4a595886150ab3e48acf12e01) | `` dotnet: allow update.sh to be run from root ``                                                 |
| [`5518ca20`](https://github.com/NixOS/nixpkgs/commit/5518ca2098320b2b3b869a5a7f44b2c42ab1937c) | `` garnet: remove sdk packages from deps ``                                                       |
| [`a5e78b35`](https://github.com/NixOS/nixpkgs/commit/a5e78b356d063506061f84db1390a462a29d7811) | `` python311Packages.nats-py: disable failing tests ``                                            |
| [`b104cf86`](https://github.com/NixOS/nixpkgs/commit/b104cf86f277784cab0bd07301fdb4a29c28ee4a) | `` python311Packages.nats-py: refactor ``                                                         |
| [`77502bb5`](https://github.com/NixOS/nixpkgs/commit/77502bb56ecc6aec14dc2bc02fde1858ed08132b) | `` python311Packages.nats-py: format with nixfmt ``                                               |
| [`5fd2a206`](https://github.com/NixOS/nixpkgs/commit/5fd2a2067ec3af433afc5c8de7e53a39639c63d2) | `` python312Packages.pulsar-client: Fix Darwin hashes ``                                          |
| [`c2526093`](https://github.com/NixOS/nixpkgs/commit/c2526093d07e9fbd466f43adbbc4750e1d6945da) | `` python311Packages.openai: 1.17.0 -> 1.20.0 ``                                                  |
| [`3fbb8ce5`](https://github.com/NixOS/nixpkgs/commit/3fbb8ce546df6b18dca86d8a232bd65369eb7212) | `` gleam: 1.0.0 -> 1.1.0 ``                                                                       |
| [`bd9e20ae`](https://github.com/NixOS/nixpkgs/commit/bd9e20aedfcb2b37f2e3c44bbb1ccf6367a2ca37) | `` boolector: unpin stdenv on darwin ``                                                           |
| [`06c817b2`](https://github.com/NixOS/nixpkgs/commit/06c817b2acf67a707a1df00032d22311641deee8) | `` s6-rc: use --replace-fail for cross substitutions ``                                           |
| [`4b46c7e8`](https://github.com/NixOS/nixpkgs/commit/4b46c7e8eb051752d5a43b985e3c76f9fe0aeb7c) | `` s6-linux-init: fix cross compilation ``                                                        |
| [`d2a5fa0d`](https://github.com/NixOS/nixpkgs/commit/d2a5fa0d55dc88b561fefefd334c6b921b439a10) | `` chess-tui: 1.2.0 -> 1.2.1 ``                                                                   |
| [`628dcc76`](https://github.com/NixOS/nixpkgs/commit/628dcc7692a17ca491d442827092d782a88876e3) | `` modsecurity_standalone: point to owasp-modsecurity ``                                          |
| [`5d660042`](https://github.com/NixOS/nixpkgs/commit/5d660042398435e5436fcc39857e7681b92d758a) | `` python311Packages.sigstore: format with nixfmt ``                                              |
| [`c59ceae8`](https://github.com/NixOS/nixpkgs/commit/c59ceae809fbdfc67b0db58b0fb661f3cbafe55c) | `` python311Packages.sigstore: 2.1.0 -> 2.1.5 ``                                                  |
| [`428f5e5a`](https://github.com/NixOS/nixpkgs/commit/428f5e5ae78fa0a79967a88d6aa0359cd3ecffca) | `` python312Packages.sigstore-rekor-types: refactor ``                                            |
| [`63d75f26`](https://github.com/NixOS/nixpkgs/commit/63d75f2617fdfb0c63e8c1e9d55ead863554727e) | `` Revert "python3Packages.sigstore-rekor-types: 0.0.11 -> 0.0.12" ``                             |
| [`1a65ceb3`](https://github.com/NixOS/nixpkgs/commit/1a65ceb3d17b52630634b1c3e8f3a3ea1d825600) | `` python311Packages.sigstore: refactor ``                                                        |
| [`79d9b3f0`](https://github.com/NixOS/nixpkgs/commit/79d9b3f02bc3d427f045a2e9b904ff54f023e3a6) | `` umpire: 2024.02.0 -> 2024.02.1 ``                                                              |
| [`1ad2a4a8`](https://github.com/NixOS/nixpkgs/commit/1ad2a4a801a5e630ad995f02cb8c0cc3ef0eb408) | `` storj-uplink: 1.100.4 -> 1.102.2 ``                                                            |
| [`1c139576`](https://github.com/NixOS/nixpkgs/commit/1c139576be6f5ec26e40d63e441686b867c3684d) | `` python312Packages.betterproto: refactor ``                                                     |
| [`ed71d169`](https://github.com/NixOS/nixpkgs/commit/ed71d169badcb759a041f7016512f9a4d263fd2d) | `` python312Packages.betterproto: disable flaky test ``                                           |
| [`6568eccf`](https://github.com/NixOS/nixpkgs/commit/6568eccf17c4d3b8b078f6acf34675fb42e8939f) | `` python312Packages.betterproto: format with nixfmt ``                                           |
| [`2a95659c`](https://github.com/NixOS/nixpkgs/commit/2a95659c3804ae27d6fb475b178ba83e4014d23c) | `` python312Packages.grpclib: 0.4.4 -> 0.4.7 ``                                                   |
| [`b4e8b0ff`](https://github.com/NixOS/nixpkgs/commit/b4e8b0ff296eaf74e50657febf715013b44aa84a) | `` python312Packages.grpclib: format with nixfmt ``                                               |
| [`54dfe662`](https://github.com/NixOS/nixpkgs/commit/54dfe6624be6de7a9641cdff7f5fca9b67638a83) | `` python312Packages.grpclib: refactor ``                                                         |
| [`a6a45ac1`](https://github.com/NixOS/nixpkgs/commit/a6a45ac1575bd42bcad685eab56933ac07c47432) | `` python311Packages.securesystemslib: format with nixfmt ``                                      |
| [`a3dddfc2`](https://github.com/NixOS/nixpkgs/commit/a3dddfc24454ef94451ce260982a45d4762b3750) | `` river: 0.2.6 -> 0.3.0 ``                                                                       |
| [`c3729d32`](https://github.com/NixOS/nixpkgs/commit/c3729d328fe8fa8008feec2878b431c8fe57470f) | `` tio: 2.7 -> 2.8 ``                                                                             |
| [`f6560d06`](https://github.com/NixOS/nixpkgs/commit/f6560d060be96046ed47979406dc235e193735fe) | `` heroku: 8.11.1 -> 8.11.2 ``                                                                    |
| [`4101ac95`](https://github.com/NixOS/nixpkgs/commit/4101ac950637e7b8313d5ceb6d0ed2d5b772812e) | `` python311Packages.sphinxcontrib-tikz: 0.4.17 -> 0.4.18 ``                                      |
| [`f1d25d5f`](https://github.com/NixOS/nixpkgs/commit/f1d25d5f24358d3b1277a8eb53070c4b75047321) | `` haskellPackages.jsaddle-{dom,webkit2gtk}: downgrade to match jsaddle ``                        |
| [`78b03789`](https://github.com/NixOS/nixpkgs/commit/78b037896facf2e7aa0e773b4820b79df8fd4681) | `` haskellPackages: mark builds failing on hydra as broken ``                                     |
| [`e4330b39`](https://github.com/NixOS/nixpkgs/commit/e4330b3996980ccf70918af3c86ea3d89cd5433d) | `` haskellPackages.ghcjs-dom: remove obsolete override ``                                         |
| [`0d67a0d2`](https://github.com/NixOS/nixpkgs/commit/0d67a0d2f63f74b989e2347b1f3ef9130d9e2409) | `` python312Packages.ed25519: refactor ``                                                         |
| [`6702cf1f`](https://github.com/NixOS/nixpkgs/commit/6702cf1f7379f02ef1426a5861ed903a66e0ccca) | `` python311Packages.ed25519: format with nixfmt ``                                               |
| [`d1a9f32e`](https://github.com/NixOS/nixpkgs/commit/d1a9f32eac6ebadc25afb84d3382c1c6edfbd7b6) | `` python312Packages.azure-keyvault-keys: foramt with nixfmt ``                                   |
| [`6dd0f5df`](https://github.com/NixOS/nixpkgs/commit/6dd0f5dfc30120724f7d0e74916bb29d743ca8b3) | `` python312Packages.azure-keyvault-keys: refactor ``                                             |
| [`f267cdf4`](https://github.com/NixOS/nixpkgs/commit/f267cdf4a1049250190f9bb7fb8eaff1a8837b25) | `` python312Packages.azure-keyvault-keys: 4.8.0 -> 4.9.0 ``                                       |
| [`38a4ac56`](https://github.com/NixOS/nixpkgs/commit/38a4ac5695dc0568024a81f7785fb9ddc88098c0) | `` qrtool: 0.10.7 -> 0.10.8 ``                                                                    |
| [`13fabc79`](https://github.com/NixOS/nixpkgs/commit/13fabc794762b6fbe1df56c98861e55eb5a11dbf) | `` fantomas: 6.3.1 -> 6.3.4 ``                                                                    |
| [`65f0b821`](https://github.com/NixOS/nixpkgs/commit/65f0b821c60455afcb1245dc94129fdd96a5d7f4) | `` wordpress: update languages and plugins ``                                                     |
| [`37945e7f`](https://github.com/NixOS/nixpkgs/commit/37945e7f0853fd0966e1123137e5c142fd644226) | `` wordpress6_5: 6.5 -> 6.5.2 ``                                                                  |
| [`f6b207fc`](https://github.com/NixOS/nixpkgs/commit/f6b207fc02071d32aafe3f4024143c4d9d19d502) | `` wordpress6_4: 6.4.3 -> 6.4.4 ``                                                                |
| [`6bc1dbb6`](https://github.com/NixOS/nixpkgs/commit/6bc1dbb64c530c62b48793adfb2ea74cb5bb6c56) | `` wordpress6_3: 6.3.2 -> 6.3.4 ``                                                                |
| [`89708930`](https://github.com/NixOS/nixpkgs/commit/89708930c4e2bfc038fc9cc4532c3e2aa416bf13) | `` cargo-llvm-cov: don't use leaveDotGit ``                                                       |
| [`e17fe7b7`](https://github.com/NixOS/nixpkgs/commit/e17fe7b7ea227807e6888c8299b7ca91917a3c83) | `` atuin: 18.1.0 -> 18.2.0 ``                                                                     |
| [`b95450cd`](https://github.com/NixOS/nixpkgs/commit/b95450cd1867f767b8673ec44a2e394b47ab585c) | `` tailscale: 1.64.0 -> 1.64.1 ``                                                                 |
| [`5f830f5f`](https://github.com/NixOS/nixpkgs/commit/5f830f5faceb02eee7e7e771d61b6548f67c92f1) | `` code-server: 4.19.1 -> 4.23.1 ``                                                               |
| [`ca2d76fe`](https://github.com/NixOS/nixpkgs/commit/ca2d76febc9d760f8f25722d6862be2366d6d5ad) | `` gitlab: 16.10.2 -> 16.10.3 ``                                                                  |
| [`a927dcf0`](https://github.com/NixOS/nixpkgs/commit/a927dcf027cf2c2334bee1d2bd591b9cd70c03c6) | `` zed-editor: 0.130.6 -> 0.130.7 ``                                                              |
| [`96487480`](https://github.com/NixOS/nixpkgs/commit/96487480d46e00e1dd4b762aa17a1dafa049456d) | `` snipe-it: 6.3.3 -> 6.3.4 ``                                                                    |
| [`44d15901`](https://github.com/NixOS/nixpkgs/commit/44d15901d771b2df86b9e74a24f6f5246c32f828) | `` sshuttle: 1.1.1 → 1.1.2 ``                                                                     |
| [`0560d26b`](https://github.com/NixOS/nixpkgs/commit/0560d26b68d46e55edad154adf7520edeabc9155) | `` palemoon-bin: 33.0.0 -> 33.0.2 ``                                                              |
| [`35aa61ba`](https://github.com/NixOS/nixpkgs/commit/35aa61baf1671b8aabf95cfe222d9f7040a8192c) | `` palemoon-bin: Add meta.updateScript ``                                                         |
| [`50af023d`](https://github.com/NixOS/nixpkgs/commit/50af023d028f15a3010742b263af89d83ad46b65) | `` vendir: fix version number in binary ``                                                        |
| [`e7e99e2e`](https://github.com/NixOS/nixpkgs/commit/e7e99e2e219a74753ff8aa14ed57231597ad6b75) | `` jetbrains.clion: add missing dependencies ``                                                   |
| [`79c288a8`](https://github.com/NixOS/nixpkgs/commit/79c288a84209b7a6f8c87a7cdb2ef0765b58fc90) | `` pslib: fix build on darwin ``                                                                  |
| [`ceb58ade`](https://github.com/NixOS/nixpkgs/commit/ceb58ade832d05e8e5124d5bd3e7e27d5083481b) | `` python312Packages.zeroconf: 0.132.0 -> 0.132.2 ``                                              |
| [`dae37bab`](https://github.com/NixOS/nixpkgs/commit/dae37baba2b57066953ab2a28a2b3e01fd8015c7) | `` odin: dev-2024-03 -> dev-2024-04a ``                                                           |
| [`03a60cc3`](https://github.com/NixOS/nixpkgs/commit/03a60cc32d650164edc4459fe43e6726bd3170ae) | `` bambu-studio: 01.09.00.60 -> 01.09.00.70 ``                                                    |
| [`354a6827`](https://github.com/NixOS/nixpkgs/commit/354a6827066030b81fb0a6dbf9be4b949cd0ddb9) | `` containerlab: 0.49.0 -> 0.54.2 ``                                                              |
| [`96614a06`](https://github.com/NixOS/nixpkgs/commit/96614a06f441e860e44aa73fb952ea51b562e218) | `` pyprland: 2.2.3 -> 2.2.5 ``                                                                    |
| [`b0835756`](https://github.com/NixOS/nixpkgs/commit/b0835756b85a273b8373e7c79a9f77734eabb1fa) | `` kaggle: 1.6.11 -> 1.6.12 ``                                                                    |
| [`322fb8dd`](https://github.com/NixOS/nixpkgs/commit/322fb8dde5d5d6af4c05df945c114cc808677deb) | `` electron_29-bin: 29.2.0 -> 29.3.0 ``                                                           |
| [`9ebdca62`](https://github.com/NixOS/nixpkgs/commit/9ebdca62d5d5a4da4740cf974e869430d57fc9d2) | `` electron_28-bin: 28.2.10 -> 28.3.0 ``                                                          |
| [`1a41f441`](https://github.com/NixOS/nixpkgs/commit/1a41f44111bd79ecdd2f797c4f653f5f947f8a9e) | `` electron_27-bin: 27.3.9 -> 27.3.10 ``                                                          |
| [`596cd141`](https://github.com/NixOS/nixpkgs/commit/596cd1416e8619d1f843cc8c98f230654b98b5ec) | `` evdi: 1.14.1-unstable-2024-01-30 1.14.4 ``                                                     |
| [`59f0aeb7`](https://github.com/NixOS/nixpkgs/commit/59f0aeb71b56d67835a5ab9ead33e00be2f9f387) | `` youtrack: 2024.1.26888 -> 2024.1.27971 ``                                                      |
| [`07c5d2d3`](https://github.com/NixOS/nixpkgs/commit/07c5d2d3f96037bab9524cfff6cf14cd784cb88a) | `` haskell.compiler.ghcHEAD: 9.11.20240323 -> 9.11.20240410 ``                                    |
| [`379428c4`](https://github.com/NixOS/nixpkgs/commit/379428c412cc45cc70fe1d0770a8fb988309f411) | `` vscode-extensions.usernamehw.errorlens: 3.14.0 -> 3.16.0 ``                                    |
| [`2023f95e`](https://github.com/NixOS/nixpkgs/commit/2023f95e626b84ef5296dfdbc8e19fdafbb06730) | `` vscode-extensions.mkhl.direnv: 0.16.0 -> 0.17.0 ``                                             |
| [`90f000a7`](https://github.com/NixOS/nixpkgs/commit/90f000a74d4bfc3eba8ee097acf2d4ac1198d236) | `` vscode-extensions.jnoortheen.nix-ide: 0.2.2 -> 0.3.1 ``                                        |
| [`89bc9067`](https://github.com/NixOS/nixpkgs/commit/89bc906791f28daa87ca9e59c08d2122ee24adb7) | `` drawterm: unstable-2024-03-31 -> unstable-2024-04-05 ``                                        |
| [`ab631a7f`](https://github.com/NixOS/nixpkgs/commit/ab631a7f60c8a649070d19917e1ec34587714530) | `` vscode-extensions.signageos.signageos-vscode-sops: init 0.9.1 ``                               |
| [`97b892e8`](https://github.com/NixOS/nixpkgs/commit/97b892e8209854936fbe993184b054867e97837e) | `` firefox-devedition-unwrapped: 125.0b3 -> 125.0b9 ``                                            |
| [`d906a05e`](https://github.com/NixOS/nixpkgs/commit/d906a05e5bb8bbb0dac9bee82823dacfcd81389c) | `` firefox-beta-unwrapped: 125.0b3 -> 125.0b9 ``                                                  |
| [`c7f89ecf`](https://github.com/NixOS/nixpkgs/commit/c7f89ecf3bd8e624cf174f427ecec8c6c2be5846) | `` firefox-devedition-bin-unwrapped: 125.0b3 -> 125.0b9 ``                                        |
| [`aba81ce0`](https://github.com/NixOS/nixpkgs/commit/aba81ce08407f4eeef7471f451397ae2135a9435) | `` firefox-beta-bin-unwrapped: 125.0b3 -> 125.0b9 ``                                              |
| [`70538e71`](https://github.com/NixOS/nixpkgs/commit/70538e710c3833b2348848e076129fbb10b2ee2c) | `` typescript: 5.4.4 -> 5.4.5 ``                                                                  |
| [`2b6e682f`](https://github.com/NixOS/nixpkgs/commit/2b6e682f913f6dac1a23f1eb5d8ab07f95582aee) | `` mdbook-katex: 0.7.0 -> 0.8.0 ``                                                                |
| [`d0415e57`](https://github.com/NixOS/nixpkgs/commit/d0415e5734f5ed2c58d7ba96b5153e3028f6ca20) | `` vscode-extensions.vadimcn.vscode-lldb: fix on Darwin ``                                        |
| [`e584b6be`](https://github.com/NixOS/nixpkgs/commit/e584b6beb0dddd5a6b58ffc10033ed0159e8a213) | `` cdxgen: 10.2.6 -> 10.3.5 ``                                                                    |
| [`91a91b9a`](https://github.com/NixOS/nixpkgs/commit/91a91b9ae468de8500dccb74c7896b1218e9c1de) | `` haskell.compiler.ghcHEAD: fix hash mismatch on case insensitive fs ``                          |
| [`f89299e2`](https://github.com/NixOS/nixpkgs/commit/f89299e248d3834913f9e4d6963339cc3c862e61) | `` lbreakouthd: 1.1.6 -> 1.1.7 ``                                                                 |
| [`d9bbcd5f`](https://github.com/NixOS/nixpkgs/commit/d9bbcd5f81c1abcccc275c0777c86605b4173da7) | `` haskellPackages: regenerate package set based on current config ``                             |
| [`8f2ca208`](https://github.com/NixOS/nixpkgs/commit/8f2ca20859c824caeb061ed561bc4c32d085df8f) | `` all-cabal-hashes: 2024-03-31T04:36:22Z -> 2024-04-09T20:48:09Z ``                              |
| [`9bb98c69`](https://github.com/NixOS/nixpkgs/commit/9bb98c69ad65df80ad80e53b970f70bcce4b36ad) | `` haskellPackages: stackage LTS 22.14 -> LTS 22.16 ``                                            |
| [`d44e3ce2`](https://github.com/NixOS/nixpkgs/commit/d44e3ce231a35fe0afc1537df3ca7b9aa3e276e6) | `` codeql: 2.16.6 -> 2.17.0 ``                                                                    |
| [`ebf91c6f`](https://github.com/NixOS/nixpkgs/commit/ebf91c6fb5ddba041ad04c5d03660da629f43491) | `` wasmedge: unpin llvmPackages_12 ``                                                             |
| [`bd0b014e`](https://github.com/NixOS/nixpkgs/commit/bd0b014e47398ff2313d9ff34c952875d902c7aa) | `` fuc: 2.0.0 -> 2.1.0 ``                                                                         |
| [`287b462f`](https://github.com/NixOS/nixpkgs/commit/287b462f856656bc5115e2fde137ef794a2995c8) | `` sosreport: 4.7.0 -> 4.7.1 ``                                                                   |
| [`b9837788`](https://github.com/NixOS/nixpkgs/commit/b983778816e2652cba78ec714f2d19e3d25e0c61) | `` mongodb-compass: 1.42.3 -> 1.42.5 ``                                                           |
| [`dd1b905a`](https://github.com/NixOS/nixpkgs/commit/dd1b905af696491081b4b9f28ff807964872b96f) | `` level-zero: 1.16.11 -> 1.16.14 ``                                                              |
| [`0e16431e`](https://github.com/NixOS/nixpkgs/commit/0e16431ee301709c73ade9eebda68d400a17d723) | `` obs-studio-plugins.advanced-scene-switcher: 1.25.3 -> 1.25.4 ``                                |
| [`a935b194`](https://github.com/NixOS/nixpkgs/commit/a935b1941910eec4f3b896f6a61ec7d246197360) | `` istioctl: 1.21.0 -> 1.21.1 ``                                                                  |
| [`67f3c384`](https://github.com/NixOS/nixpkgs/commit/67f3c384bc1c2f1e0293c7e231022e6cd0b01d3f) | `` rivalcfg: 4.12.0 -> 4.13.0 ``                                                                  |
| [`c4f3df41`](https://github.com/NixOS/nixpkgs/commit/c4f3df41de0520fc64cf77a2e52a883c8d6c4d37) | `` jellyfin-ffmpeg: 6.0.1-3 -> 6.0.1-5 ``                                                         |
| [`b851b1c6`](https://github.com/NixOS/nixpkgs/commit/b851b1c68fd1de2f4daeff0b8bd7d2f23932872b) | `` python311Packages.pytest-spec: format, remove unused, use new names ``                         |
| [`98f0fb13`](https://github.com/NixOS/nixpkgs/commit/98f0fb13adaaca42450b30e0c0ac1cdf3669c16b) | `` python311Packages.pytest-spec: fix version name ``                                             |
| [`36625172`](https://github.com/NixOS/nixpkgs/commit/366251726eff7eb3473186ac9eed671c254687b0) | `` node-problem-detector: 0.8.16 -> 0.8.18 ``                                                     |
| [`cafa7d14`](https://github.com/NixOS/nixpkgs/commit/cafa7d144345106e9ffad5c944589885e0200217) | `` sngrep: 1.8.0 -> 1.8.1 ``                                                                      |
| [`9d42d7b6`](https://github.com/NixOS/nixpkgs/commit/9d42d7b64574bba8ca82ab511f050056f534106a) | `` exiftool: 12.80 -> 12.82 ``                                                                    |
| [`ac0cdeb1`](https://github.com/NixOS/nixpkgs/commit/ac0cdeb10c961bf0453a5283be0936201a81178f) | `` nixpkgs-hammering: unstable-2023-11-06 -> unstable-2024-03-25 ``                               |
| [`9996f284`](https://github.com/NixOS/nixpkgs/commit/9996f28455e6578904d699fcfeb66e1256696b83) | `` nixpkgs-hammering: add passthru.updateScript ``                                                |
| [`ed0c2371`](https://github.com/NixOS/nixpkgs/commit/ed0c2371a111791f347bb962be8a6760d6a3dda9) | `` catppuccin-sddm-corners: add qt dependencies ``                                                |
| [`e79b3963`](https://github.com/NixOS/nixpkgs/commit/e79b396303c55e905922654d2333d9fe95a70a3a) | `` catppuccin-sddm-corners: unstable-2023-02-17 -> unstable-2023-05-30 ``                         |
| [`49521230`](https://github.com/NixOS/nixpkgs/commit/495212307ee5eee425325be3111ef02e6b816827) | `` espflash: fix build on darwin ``                                                               |
| [`6254db61`](https://github.com/NixOS/nixpkgs/commit/6254db6165231d0e5a3eedb84daf555fd86b50ce) | `` python3Packages.openusd: 23.11 -> 24.03 ``                                                     |
| [`bc55ffb1`](https://github.com/NixOS/nixpkgs/commit/bc55ffb14ab98a83c38507eca9e25c11bfeff9d6) | `` espflash: 2.1.0 -> 3.0.0 ``                                                                    |
| [`a5e79024`](https://github.com/NixOS/nixpkgs/commit/a5e790248ab70ae58b96f4633532be8ea0cc46fe) | `` release-notes/23.05: fix link to alice-lg ``                                                   |
| [`e57d5580`](https://github.com/NixOS/nixpkgs/commit/e57d5580acc75aaca8fc255515b552dc76c8e081) | `` git-pw: init at 2.6.0 ``                                                                       |
| [`b4338acf`](https://github.com/NixOS/nixpkgs/commit/b4338acf4ce90a08d44437e41cdb1419c4a55ed2) | `` obs-studio-plugins.waveform: fix data directory ``                                             |
| [`71e72bd6`](https://github.com/NixOS/nixpkgs/commit/71e72bd66ad60b16e01dfb989933942e917282b8) | `` obs-studio-plugins.input-overlay: 5.0.0 -> 5.0.4 ``                                            |