### PR TITLE
chore(flake/home-manager): `fa8c16e2` -> `178e2689`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713294767,
-        "narHash": "sha256-LmaabaQZdx52MPGKPRt9Opoc9Gd9RbwvCdysUUYQoXI=",
+        "lastModified": 1713453913,
+        "narHash": "sha256-vbXq52VRlL1defMHrwhsoeHm95O3mFefsSSJyNEghbA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "fa8c16e2452bf092ac76f09ee1fb1e9f7d0796e7",
+        "rev": "178e26895b3aef028a00a32fb7e7ed0fc660645c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                  |
| ----------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`178e2689`](https://github.com/nix-community/home-manager/commit/178e26895b3aef028a00a32fb7e7ed0fc660645c) | `` home-manager: error out on missing option argument `` |
| [`f46814ec`](https://github.com/nix-community/home-manager/commit/f46814ec7cbef9c2aef18ca1cbe89f2bb1e8c394) | `` treewide: prefer the official wiki ``                 |
| [`93b917d4`](https://github.com/nix-community/home-manager/commit/93b917d49f0b2ab75ff91e17573e112b95fdd95c) | `` flake.lock: Update ``                                 |