### PR TITLE
chore(flake/emacs-overlay): `208d00a7` -> `925e7b36`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713373570,
-        "narHash": "sha256-+ZtrHsUp8vEbQ9FFTj+4ku7byW/ly1JVNqgdiNVBMis=",
+        "lastModified": 1713460029,
+        "narHash": "sha256-UwM5DAeSKEeGDT0vog2GspvVEmK2fsj6+K52XBIRTFY=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "208d00a7f96d920a153ab90f257357e1aa1d6d77",
+        "rev": "925e7b367814ff67e1e8cbf96835c0c68534a4ed",
         "type": "github"
       },
       "original": {
@@ -1255,11 +1255,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1713145326,
-        "narHash": "sha256-m7+IWM6mkWOg22EC5kRUFCycXsXLSU7hWmHdmBfmC3s=",
+        "lastModified": 1713344939,
+        "narHash": "sha256-jpHkAt0sG2/J7ueKnG7VvLLkBYUMQbXQ2L8OBpVG53s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "53a2c32bc66f5ae41a28d7a9a49d321172af621e",
+        "rev": "e402c3eb6d88384ca6c52ef1c53e61bdc9b84ddd",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`925e7b36`](https://github.com/nix-community/emacs-overlay/commit/925e7b367814ff67e1e8cbf96835c0c68534a4ed) | `` Updated emacs ``        |
| [`b5e46308`](https://github.com/nix-community/emacs-overlay/commit/b5e4630819981552584ff27fc69fa0c472b461e7) | `` Updated melpa ``        |
| [`b8bf90d8`](https://github.com/nix-community/emacs-overlay/commit/b8bf90d80070c41f391f0919c0f2683687110ccb) | `` Updated elpa ``         |
| [`a7f6c87c`](https://github.com/nix-community/emacs-overlay/commit/a7f6c87c5d1d2bdb2e4e5c2b73834a08b5fb360d) | `` Updated flake inputs `` |
| [`7d09630b`](https://github.com/nix-community/emacs-overlay/commit/7d09630bc39feefd09f165bc31d98563eee5bb02) | `` Updated emacs ``        |
| [`4cdb48fe`](https://github.com/nix-community/emacs-overlay/commit/4cdb48fe37dcea1ace636a943ebed823de84d5f6) | `` Updated melpa ``        |
| [`d925614f`](https://github.com/nix-community/emacs-overlay/commit/d925614faac9750fcdba7072576b0ce366dd7229) | `` Updated emacs ``        |
| [`d40c0689`](https://github.com/nix-community/emacs-overlay/commit/d40c0689b14e99cc930671008913e81bf7b73e62) | `` Updated melpa ``        |
| [`cd78b29e`](https://github.com/nix-community/emacs-overlay/commit/cd78b29e11bd11d9569eb51d857e43b144deaf9d) | `` Updated elpa ``         |