### PR TITLE
chore(flake/sops-nix): `cc535d07` -> `b94c6edb`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1534,11 +1534,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713174909,
-        "narHash": "sha256-APoDs2GtzVrsE+Z9w72qpHzEtEDfuinWcNTN7zhwLxg=",
+        "lastModified": 1713457024,
+        "narHash": "sha256-31MpStyXedDL1fvuOvn6iz3JURSVShDtDVMyP1PTjtc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "cc535d07cbcdd562bcca418e475c7b1959cefa4b",
+        "rev": "b94c6edbb8355756c53efc8ca3874c63622f287a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                                               |
| ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`b94c6edb`](https://github.com/Mic92/sops-nix/commit/b94c6edbb8355756c53efc8ca3874c63622f287a) | `` fix symlink directory not existing ``                                              |
| [`6b259336`](https://github.com/Mic92/sops-nix/commit/6b259336bd009e8a056ea740e75e6ac95e0f0c1f) | `` Lint fixes (#539) ``                                                               |
| [`ac538092`](https://github.com/Mic92/sops-nix/commit/ac538092be2723b68fd4ff75eba7684480451c8f) | `` flake.lock: Update ``                                                              |
| [`58b9a13a`](https://github.com/Mic92/sops-nix/commit/58b9a13a37691ef282826ab553d165197d6e8695) | `` home-manager: fix key store path check for strings ``                              |
| [`a9795d19`](https://github.com/Mic92/sops-nix/commit/a9795d1959fe17a38bc901323d25f4e70acef511) | `` home-manager: Change defaultSymlinkPath to "<xdg-config-home>/sops-nix/secrets" `` |
| [`74f03c1a`](https://github.com/Mic92/sops-nix/commit/74f03c1a517ed437da1c00c4ede2aee8bd337ea8) | `` Refuse age keyfile paths that are in the nix store ``                              |
| [`7f491112`](https://github.com/Mic92/sops-nix/commit/7f49111254333bda6881b0dfa8cf7d82fe305f93) | `` update vendorHash ``                                                               |
| [`3a30a388`](https://github.com/Mic92/sops-nix/commit/3a30a38816fbd79f9c2f3fcf9fb7904cf5b5d951) | `` Bump github.com/ProtonMail/go-crypto ``                                            |
| [`dacc9519`](https://github.com/Mic92/sops-nix/commit/dacc9519f5a45a8a32d64fe91ef13cb3f97b9f48) | `` home-manager: Include home.activation-script for linux similar to macos ``         |