### PR TITLE
chore(flake/nixpkgs-master): `d205596f` -> `1b7469ab`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1224,11 +1224,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1713372677,
-        "narHash": "sha256-q2QLEHvN4Qwj/xIQSUr4OtjI8kIJRWVE6ju98c640B0=",
+        "lastModified": 1713459744,
+        "narHash": "sha256-xdfSUKjXDQSvTLKReRPckLp0DcxVAQKrx4r/BwdA06g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d205596f17d89a7205af1c7a9cd419be382d7557",
+        "rev": "1b7469ab47f305667f4da1af1e70b2577474d77c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                               |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
| [`8f8dc631`](https://github.com/NixOS/nixpkgs/commit/8f8dc63108454115dc5352e2a497f75c40ca24af) | `` fira-code: avoid use of rec ``                                                     |
| [`05b242b1`](https://github.com/NixOS/nixpkgs/commit/05b242b1884a9c7e185048f80977fdd1155c384a) | `` fira-code: add option to install regular fonts instead ``                          |
| [`76c69af6`](https://github.com/NixOS/nixpkgs/commit/76c69af624667a412e0afabdda43b9c3f0c7c649) | `` nixos/lxd-virtual-machine: enable CPU hotplug for x86 VMs ``                       |
| [`083e90af`](https://github.com/NixOS/nixpkgs/commit/083e90af2f6c20e14e464efb56bb343d095eb7c8) | `` python312Packages.findpython: 0.6.0 -> 0.6.1 ``                                    |
| [`95eca14c`](https://github.com/NixOS/nixpkgs/commit/95eca14cb709bad9603dbf18e5fab0e43d55b66c) | `` slither-analyzer: 0.10.1 -> 0.10.2 ``                                              |
| [`77e8d6f0`](https://github.com/NixOS/nixpkgs/commit/77e8d6f0583d251b8f645d216ca9ac0eb436238f) | `` slither-analyzer: add testing in the check phase ``                                |
| [`ae93076f`](https://github.com/NixOS/nixpkgs/commit/ae93076f570e692bcd9fafa11a2832ad5dc1fee7) | `` python311Packages.rlp: 3.0.0 -> 4.0.0 ``                                           |
| [`ed217bf9`](https://github.com/NixOS/nixpkgs/commit/ed217bf9ef3e3174db63bb998e18cbe8a7cf5a89) | `` python311Packages.hexbytes: 0.3.1 -> 1.2.0 ``                                      |
| [`f064c1cc`](https://github.com/NixOS/nixpkgs/commit/f064c1cc8fe339f1fef49a0f3382529a1c2d4ce1) | `` python311Packages.eth-rlp: 0.3.0 -> 2.1.0 ``                                       |
| [`ad60a863`](https://github.com/NixOS/nixpkgs/commit/ad60a863f11b61016b9006128209b6baece608ac) | `` python311Packages.eth-keys: 0.4.0 -> 0.5.0 ``                                      |
| [`ca83cf51`](https://github.com/NixOS/nixpkgs/commit/ca83cf515c04953235e60115eb3dde94e3720031) | `` python311Packages.eth-keyfile: 0.6.0 -> 0.8.0 ``                                   |
| [`4e1cc02c`](https://github.com/NixOS/nixpkgs/commit/4e1cc02c20d7600e8455b07dce926167e75a8d24) | `` nexttrace: 1.2.9 -> 1.3.0 ``                                                       |
| [`31fbe72f`](https://github.com/NixOS/nixpkgs/commit/31fbe72fe8eaf5489624059de29fc647cf65a0ae) | `` kube-bench: 0.7.2 -> 0.7.3 ``                                                      |
| [`afa2e295`](https://github.com/NixOS/nixpkgs/commit/afa2e2959d915d84900eb663d0208bc5b0131ecd) | `` granted: 0.23.0 -> 0.23.1 ``                                                       |
| [`4e69073e`](https://github.com/NixOS/nixpkgs/commit/4e69073ead43bad93bb8754605dca27dc2c0e007) | `` cloudsmith-cli: 1.2.2 -> 1.2.3 ``                                                  |
| [`6c3221aa`](https://github.com/NixOS/nixpkgs/commit/6c3221aa6b3ff15ac652cf54ffdb894462fdfd70) | `` vscode-extensions.davidanson.vscode-markdownlint: 0.54.0 -> 0.55.0 ``              |
| [`33fe90ae`](https://github.com/NixOS/nixpkgs/commit/33fe90ae394d201965cc4a30621d5130b6374af6) | `` civo: 1.0.80 -> 1.0.81 ``                                                          |
| [`862cc79e`](https://github.com/NixOS/nixpkgs/commit/862cc79eb1c8f20024e8fea970653ef0e969e2be) | `` python311Packages.gpsoauth: 1.0.4 -> 1.1.0 ``                                      |
| [`d694b988`](https://github.com/NixOS/nixpkgs/commit/d694b988671f2735c7591aff7b0fd337bba2c63f) | `` nom: 2.1.4 -> 2.1.6 ``                                                             |
| [`b4a6d1ed`](https://github.com/NixOS/nixpkgs/commit/b4a6d1eddb91ec658c05792e8c66a5e5560537af) | `` nom: format with nixfmt-rfc-style ``                                               |
| [`efd03112`](https://github.com/NixOS/nixpkgs/commit/efd031124d9098a01425304f5f7dde8a02ab542a) | `` myxer: init at 1.3.0 ``                                                            |
| [`9262fa56`](https://github.com/NixOS/nixpkgs/commit/9262fa56921da42c88b1b6210201066e786905a9) | `` gnome.gnome-mahjongg: 3.40.0 -> 3.40.1 ``                                          |
| [`973184bd`](https://github.com/NixOS/nixpkgs/commit/973184bd1cbc07dffb562850b37f6c7c607db091) | `` perlPackages.NetDNS: 1.40 -> 1.44 ``                                               |
| [`91b878a4`](https://github.com/NixOS/nixpkgs/commit/91b878a48bfa7e6446be4f08a65b6f3be7457a94) | `` lilypond: fix $PATH (#302423) ``                                                   |
| [`e20b16e5`](https://github.com/NixOS/nixpkgs/commit/e20b16e5a32d8a16bf08898972b5c494b3404aed) | `` mu: 1.12.2 -> 1.12.4 ``                                                            |
| [`0290cccc`](https://github.com/NixOS/nixpkgs/commit/0290ccccd5d0dc34783bba9eef82600684477998) | `` python312Packages.langchain-community: 0.0.32 -> 0.0.33 ``                         |
| [`8510358f`](https://github.com/NixOS/nixpkgs/commit/8510358f9b6305ff0007387d2a1ac7d6e9bd6f89) | `` python312Packages.langchain-core: 0.1.42 -> 0.1.44 ``                              |
| [`1db6f3b6`](https://github.com/NixOS/nixpkgs/commit/1db6f3b6b066248fe3e157d01941b0122208fa97) | `` python312Packages.langsmith: 0.1.45 -> 0.1.48 ``                                   |
| [`28bf5e76`](https://github.com/NixOS/nixpkgs/commit/28bf5e76ddd20dd7f0fd6de84dcdd40a7bb7e631) | `` python311Packages.langsmith: attr is linux-only ``                                 |
| [`9361945d`](https://github.com/NixOS/nixpkgs/commit/9361945d5f079401a5d1acca4333a10e83959b1b) | `` where-is-my-sddm-theme: 1.9.0 -> 1.9.1 ``                                          |
| [`1cd15300`](https://github.com/NixOS/nixpkgs/commit/1cd153003cc4eaf89dbfff40084ec0a4758d4a2b) | `` yq: 3.3.0 -> 3.4.1 ``                                                              |
| [`8896a21b`](https://github.com/NixOS/nixpkgs/commit/8896a21b019825ef730c36267730f8d4a25171cb) | `` python312Packages.peaqevcore: 19.7.15 -> 19.9.0 ``                                 |
| [`b059edb5`](https://github.com/NixOS/nixpkgs/commit/b059edb5e7241b70936760efb459bb49af9a426f) | `` python312Packages.llama-index-readers-file: 0.1.18 -> 0.1.19 ``                    |
| [`88846e31`](https://github.com/NixOS/nixpkgs/commit/88846e3170faf83174cf04121cfe8a1d9698e4e0) | `` python312Packages.llama-index-core: 0.10.29 -> 0.10.30 ``                          |
| [`b411e0d4`](https://github.com/NixOS/nixpkgs/commit/b411e0d4f292a911ba37332b772a18590af2ee1d) | `` python312Packages.tencentcloud-sdk-python: 3.0.1130 -> 3.0.1131 ``                 |
| [`1076af3b`](https://github.com/NixOS/nixpkgs/commit/1076af3b622ccf49615cb50dee153b20f46cf68e) | `` use passthru tests ``                                                              |
| [`8f86496f`](https://github.com/NixOS/nixpkgs/commit/8f86496f70b6be335b508ca26dc603cab80e08df) | `` python311Packages.llama-index-cli: format with nixfmt ``                           |
| [`861d189a`](https://github.com/NixOS/nixpkgs/commit/861d189a3c453aaec365e7eb880234239509e4dc) | `` kodi: use stable `mirror://` source urls for apache deps ``                        |
| [`f5fa30df`](https://github.com/NixOS/nixpkgs/commit/f5fa30df65646793a576a4e5ebc27c6a730c781c) | `` swww: 0.9.1 -> 0.9.4 ``                                                            |
| [`5e141118`](https://github.com/NixOS/nixpkgs/commit/5e1411181013e2a73d652d0fb2938e2e809b5c89) | `` add sourceProvenance ``                                                            |
| [`36fbcec3`](https://github.com/NixOS/nixpkgs/commit/36fbcec3e0323a9a29e7a9a226a9cfdcee4ab614) | `` himalaya: 1.0.0-beta.3 -> 1.0.0-beta.4 ``                                          |
| [`d180e5e9`](https://github.com/NixOS/nixpkgs/commit/d180e5e9c5165a77be8d941103398997190e04fb) | `` scala-cli: 1.2.1 -> 1.2.2 ``                                                       |
| [`706b9c23`](https://github.com/NixOS/nixpkgs/commit/706b9c23c9180733d732104b6e7220b9f941ff74) | `` jfrog-cli: add aidalgol as maintainer ``                                           |
| [`d5aa6c69`](https://github.com/NixOS/nixpkgs/commit/d5aa6c693c649c0d49f1af602a4402ad04ea25cf) | `` jfrog-cli: 2.52.10 -> 2.56.0 ``                                                    |
| [`daf77292`](https://github.com/NixOS/nixpkgs/commit/daf77292452d8e8097c46db4afbfe7a5e2335db4) | `` makima: 0.4.4 -> 0.5.2 ``                                                          |
| [`2e51e3cd`](https://github.com/NixOS/nixpkgs/commit/2e51e3cda5db2edc889237da747592c3e510ec85) | `` markdown-oxide: 0.0.16 -> 0.0.17 ``                                                |
| [`0220f52d`](https://github.com/NixOS/nixpkgs/commit/0220f52db043afeec1e62f136bb963b00b062743) | `` python311Packages.botocore-stubs: 1.34.84 -> 1.34.86 ``                            |
| [`35863bff`](https://github.com/NixOS/nixpkgs/commit/35863bff312bb956cfa071c88c68c6bce0c7224f) | `` zapzap: 5.2.1 -> 5.3 ``                                                            |
| [`5b35aba7`](https://github.com/NixOS/nixpkgs/commit/5b35aba730645dd84f38d9189135a4a93973f595) | `` grpc-client-cli: 1.20.1 -> 1.20.2 ``                                               |
| [`d5851d56`](https://github.com/NixOS/nixpkgs/commit/d5851d56761da0750ade90bc4a693d414671b045) | `` nixos/dockerRegistry: add `configFile` option ``                                   |
| [`e25bf1fb`](https://github.com/NixOS/nixpkgs/commit/e25bf1fb930620ed64de9c5c66cd2ec185e57d64) | `` python311Packages.google-cloud-securitycenter: 1.30.1 -> 1.31.0 ``                 |
| [`95afbd32`](https://github.com/NixOS/nixpkgs/commit/95afbd32ba1bfd710c97115f9db45424c15294d9) | `` exoscale-cli: 1.77.0 -> 1.77.1 ``                                                  |
| [`bd2a81c7`](https://github.com/NixOS/nixpkgs/commit/bd2a81c7408a38a98a0a4a1d9e612b800415144f) | `` orchard: 0.16.1 -> 0.17.0 ``                                                       |
| [`56e584de`](https://github.com/NixOS/nixpkgs/commit/56e584de753dc1e7463e8da0746472be57c5e618) | `` protoc-gen-connect-go: 1.16.0 -> 1.16.1 ``                                         |
| [`853a8ac9`](https://github.com/NixOS/nixpkgs/commit/853a8ac938059a96a07b42431555ee680426d4a6) | `` mongosh: 2.2.3 -> 2.2.4 ``                                                         |
| [`786a4922`](https://github.com/NixOS/nixpkgs/commit/786a4922146c72c80a22932a3caf0b52331290ca) | `` littlefs-fuse: 2.7.6 -> 2.7.7 ``                                                   |
| [`79f80cd1`](https://github.com/NixOS/nixpkgs/commit/79f80cd18aedbe29481329355509802c78b2092d) | `` libnats-c: 3.8.0 -> 3.8.2 ``                                                       |
| [`ce51f39c`](https://github.com/NixOS/nixpkgs/commit/ce51f39cb5b10c449d4c5be72ce7f9814e0f9970) | `` grpc_cli: 1.62.1 -> 1.62.2 ``                                                      |
| [`219743d7`](https://github.com/NixOS/nixpkgs/commit/219743d77afaa5cb25a034ecfed56902a249529a) | `` gbsplay: 0.0.96 -> 0.0.97 ``                                                       |
| [`bf984bff`](https://github.com/NixOS/nixpkgs/commit/bf984bffe8e2f009afaf4d83e5d3b777333b0204) | `` flow: 0.233.0 -> 0.234.0 ``                                                        |
| [`eb8da8bc`](https://github.com/NixOS/nixpkgs/commit/eb8da8bcc1e58df4a6d6422c888500c8eb722059) | `` python311Packages.llama-index-cli: 0.1.11 -> 0.1.12 ``                             |
| [`932ed186`](https://github.com/NixOS/nixpkgs/commit/932ed18631fe8c02ef02334b17be6e6390f2cf0b) | `` earthly: 0.8.7 -> 0.8.8 ``                                                         |
| [`037ac21a`](https://github.com/NixOS/nixpkgs/commit/037ac21a40a2f62d0738ed3336c5731c3e958b17) | `` emacs-lsp-booster: 0.2.0 -> 0.2.1 ``                                               |
| [`f45414f4`](https://github.com/NixOS/nixpkgs/commit/f45414f4b75cf1d73198a0549a1f6c94e4c9a1e1) | `` cargo-hack: 0.6.27 -> 0.6.28 ``                                                    |
| [`582312a1`](https://github.com/NixOS/nixpkgs/commit/582312a14de21d67a330b87787e6b4b308fb45f2) | `` bazel-buildtools: 7.1.0 -> 7.1.1 ``                                                |
| [`5e315a08`](https://github.com/NixOS/nixpkgs/commit/5e315a083d7a8665542719f210612b31d9e411f9) | `` converseen: 0.12.1.0 -> 0.12.2.2 ``                                                |
| [`d05592ea`](https://github.com/NixOS/nixpkgs/commit/d05592ea7e9656648093dfe0e817819486bd5054) | `` bun: 1.1.3 -> 1.1.4 ``                                                             |
| [`6f59495c`](https://github.com/NixOS/nixpkgs/commit/6f59495cf3bde2eb600c7b2c97b30da89a07a0bf) | `` kubernetes: 1.29.3 -> 1.29.4 ``                                                    |
| [`7799ff5c`](https://github.com/NixOS/nixpkgs/commit/7799ff5cb6eba42037c9d5b6491637e7b51a093e) | `` python312Packages.meep: unbreak by patching distutils ``                           |
| [`cd851f54`](https://github.com/NixOS/nixpkgs/commit/cd851f5499fc4600a9febe8347edd333d8bc9b1f) | `` fermyon-spin: 2.2.0 -> 2.4.2 ``                                                    |
| [`78005853`](https://github.com/NixOS/nixpkgs/commit/78005853c697fc5c6f90c1e5ed788a5159411312) | `` workout-tracker: 0.12.0 -> 0.13.4 ``                                               |
| [`b1fd84f6`](https://github.com/NixOS/nixpkgs/commit/b1fd84f6ec16aec5fa8cd65201b3fc856188f7d6) | `` nixosTests.networking: start network-online.target manually ``                     |
| [`ef95bc2e`](https://github.com/NixOS/nixpkgs/commit/ef95bc2eaf38e020efb8961ef60a95be2469cc35) | `` gonic: add release note warning about playlists-path ``                            |
| [`f7c74085`](https://github.com/NixOS/nixpkgs/commit/f7c740853dccdc0ab120182503c8d2710a658f8a) | `` nixosTests.gonic: set up all necessary paths using tmpfiles ``                     |
| [`759812cc`](https://github.com/NixOS/nixpkgs/commit/759812cc34ee9cf74757b23c5c8d3648d38cbf32) | `` nixos/gonic: allow access to playlists ``                                          |
| [`0e78517a`](https://github.com/NixOS/nixpkgs/commit/0e78517af1ba8b45575725515127c94d257f81fa) | `` gonic: add myself as maintainer ``                                                 |
| [`02d0eb6a`](https://github.com/NixOS/nixpkgs/commit/02d0eb6a45bd28b07377ff25eb6131a5ebcd724f) | `` gonic: 0.15.2 -> 0.16.4 ``                                                         |
| [`2d370798`](https://github.com/NixOS/nixpkgs/commit/2d37079853d5975b19c95c3e82736d4c66880868) | `` python312Packages.uptime-kuma-api: unbreak with missing dependency ``              |
| [`351e96ff`](https://github.com/NixOS/nixpkgs/commit/351e96ff3f4d4338fdee6f740cccb3be41b23951) | `` jfrog-cli: specify passthru.updateScript ``                                        |
| [`b4826e16`](https://github.com/NixOS/nixpkgs/commit/b4826e16d996bf4923a11dfe4e607d46ced5c356) | `` sequoia-sqv: fix build by updating nettle-sys ``                                   |
| [`6c2a3e96`](https://github.com/NixOS/nixpkgs/commit/6c2a3e96d5ccf00416380569ff03e8c3bfd7d5f9) | `` libsignal-ffi: 0.41.0 -> 0.44.0 ``                                                 |
| [`a9116047`](https://github.com/NixOS/nixpkgs/commit/a911604762beaccb2efdc64f993fb8dad6635ecf) | `` nixos/oauth2-proxy-nginx: lift auth_request to http block ``                       |
| [`01f7561d`](https://github.com/NixOS/nixpkgs/commit/01f7561d9f6a2ff637ced7c7fe1c48cecc40fb75) | `` podman: 5.0.1 -> 5.0.2 ``                                                          |
| [`c5371710`](https://github.com/NixOS/nixpkgs/commit/c5371710de5d244b45e0c3e689e3afef1dddf990) | `` nixos/shells-environment: allow int and float in environment variables ``          |
| [`d4b989ca`](https://github.com/NixOS/nixpkgs/commit/d4b989cafc77ffa10affa46a730159ff30726bd9) | `` nixos/deconz: delay signalling service readiness until it's actually up ``         |
| [`27865166`](https://github.com/NixOS/nixpkgs/commit/27865166ef3e25db853a67ca98d3e4ef06981dc5) | `` pdfpc: convert to using lib.cmakeBool ``                                           |
| [`cf1b2a6c`](https://github.com/NixOS/nixpkgs/commit/cf1b2a6cf5f9f6ee345a122e7db4ff107aed433e) | `` bazecor: 1.3.9 -> 1.3.11 ``                                                        |
| [`2bbf89b9`](https://github.com/NixOS/nixpkgs/commit/2bbf89b92c5097d72c3c2fdae249a26da4f263ab) | `` pdfpc: allow compiling with markdown3 ``                                           |
| [`418cc441`](https://github.com/NixOS/nixpkgs/commit/418cc441066ffa3b9452de100fa7aa97fc2867c6) | `` nixos/soundmodem: drop lib.mdDoc, use package option everywhere (#304811) ``       |
| [`9ab90120`](https://github.com/NixOS/nixpkgs/commit/9ab90120f3d3974166e5607ee13ffaa612dfa5c8) | `` numix-icon-theme-square: 24.03.12 -> 24.04.16 ``                                   |
| [`35614f61`](https://github.com/NixOS/nixpkgs/commit/35614f6132854a1c5161c3fe28f26b398fe7ebc7) | `` tests/lomiri: Adjust for network indicator ``                                      |
| [`dda8bfd4`](https://github.com/NixOS/nixpkgs/commit/dda8bfd4215386207f3f9e3e4984b9fea5172acc) | `` nixos/lomiri: Add network indicator ``                                             |
| [`e20e4d5d`](https://github.com/NixOS/nixpkgs/commit/e20e4d5ddd282ef21482902cc246ee68ddf1d281) | `` lomiri.lomiri-indicator-network: Update patching to newer CMake's possibilities `` |
| [`fd74d0d4`](https://github.com/NixOS/nixpkgs/commit/fd74d0d49ac082ffba5c733bbc9d3fea3abd2a7f) | `` tree-sitter-grammars: Add earthfile ``                                             |
| [`a65395a7`](https://github.com/NixOS/nixpkgs/commit/a65395a7a767c31c42098859dd0753b878e0aa02) | `` fzf-make: 0.27.0 -> 0.28.0 ``                                                      |
| [`8b31909a`](https://github.com/NixOS/nixpkgs/commit/8b31909a795c61afadb4441f88c8409965d44b72) | `` codeowners: add Janik to NetworkManager module and tests ``                        |
| [`51cccffa`](https://github.com/NixOS/nixpkgs/commit/51cccffa951d0bf44ad690eb9f58b11089586a20) | `` networkmanager: add passthru.tests ``                                              |
| [`8612ed1e`](https://github.com/NixOS/nixpkgs/commit/8612ed1ee9be2ee0240e51672e2aae1880f3427f) | `` nixos/networkmanager: change config generation to use the ini generator ``         |
| [`52e01114`](https://github.com/NixOS/nixpkgs/commit/52e01114beb7e915d74eb97f1dce98d584dc5458) | `` nixosTests.networking: refactor and add NetworkManager support ``                  |
| [`57142a23`](https://github.com/NixOS/nixpkgs/commit/57142a23e778426016667b554a2e98639cf3ce92) | `` vscode-extensions.k--kato.intellij-idea-keybindings: init at 1.7.0 ``              |
| [`b7b3a078`](https://github.com/NixOS/nixpkgs/commit/b7b3a078ac64248c0876858dab3da6c0e74d0ba6) | `` linuxPackages.nvidiaPackages.production: 550.67 -> 550.76 ``                       |
| [`e92b2239`](https://github.com/NixOS/nixpkgs/commit/e92b223980781d2e00938533b12faf7d8379e2b2) | `` python311Packages.adlfs: 2024.4.0 -> 2024.4.1 ``                                   |
| [`d786d77b`](https://github.com/NixOS/nixpkgs/commit/d786d77b4a82d7449f0d3bb1a7ea6f1a97d23c3c) | `` foot: 1.17.1 -> 1.17.2 ``                                                          |
| [`188ece5f`](https://github.com/NixOS/nixpkgs/commit/188ece5f629829ab1a7c5b708a63a145e6ac3db8) | `` tenki: 1.6.0 -> 1.7.0 ``                                                           |
| [`5fa90efd`](https://github.com/NixOS/nixpkgs/commit/5fa90efdef852116ce4b7c09b04350168a125773) | `` trust-dns: 0.24.0 -> 0.24.1 ``                                                     |
| [`d69c3bd7`](https://github.com/NixOS/nixpkgs/commit/d69c3bd7514689b301ba681013d5df2568296359) | `` python312Packages.broadlink: format with nixfmt ``                                 |