### PR TITLE
chore(flake/spicetify-nix): `fdc292b9` -> `c087ebcc`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1555,11 +1555,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713327133,
-        "narHash": "sha256-e+ex3BaV1LKzGDf+RHzdTwQ2JPxd9C5/0krEdTOsvP0=",
+        "lastModified": 1713413457,
+        "narHash": "sha256-irhOcCubT8u1leCJHlyYmS+ay8D2ctlpJB++/aM5n0k=",
         "owner": "gerg-l",
         "repo": "spicetify-nix",
-        "rev": "fdc292b94f7a2137b710f175e7954feac30e8a9f",
+        "rev": "c087ebccf75e3db5b902b574304b39103c75f8d2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                           |
| ----------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`c087ebcc`](https://github.com/Gerg-L/spicetify-nix/commit/c087ebccf75e3db5b902b574304b39103c75f8d2) | `` CI update 2024-04-18 (#135) `` |