### PR TITLE
chore(flake/emacs-overlay): `925e7b36` -> `0be1306b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713460029,
-        "narHash": "sha256-UwM5DAeSKEeGDT0vog2GspvVEmK2fsj6+K52XBIRTFY=",
+        "lastModified": 1713545714,
+        "narHash": "sha256-GUYuOD5+oc2jcCi/D9ZXpI1LxAAMqTaRhWu2x+N7XuE=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "925e7b367814ff67e1e8cbf96835c0c68534a4ed",
+        "rev": "0be1306bf44aedaf54642c4dc9bbbc210267dcd7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`0be1306b`](https://github.com/nix-community/emacs-overlay/commit/0be1306bf44aedaf54642c4dc9bbbc210267dcd7) | `` Updated melpa ``        |
| [`7600854b`](https://github.com/nix-community/emacs-overlay/commit/7600854b9d7d7e4a897638a1df6ea2275682a8ab) | `` Updated elpa ``         |
| [`a8692d4e`](https://github.com/nix-community/emacs-overlay/commit/a8692d4e570e93061d2bbe10af4a1590afe82e15) | `` Updated emacs ``        |
| [`d66e33b9`](https://github.com/nix-community/emacs-overlay/commit/d66e33b94492c5e897729f1aac2094e618a5001a) | `` Updated melpa ``        |
| [`65297336`](https://github.com/nix-community/emacs-overlay/commit/65297336c6db39d94adb8156d811d800b253fded) | `` Updated emacs ``        |
| [`d2d351a8`](https://github.com/nix-community/emacs-overlay/commit/d2d351a80e5487cd45269ff5dfc6247c7478948c) | `` Updated melpa ``        |
| [`1457c4eb`](https://github.com/nix-community/emacs-overlay/commit/1457c4ebe76260189cd021766876b17ef13eadf3) | `` Updated elpa ``         |
| [`380de855`](https://github.com/nix-community/emacs-overlay/commit/380de855a8d44f009c50306ec9585c60a12371f8) | `` Updated nongnu ``       |
| [`e63c323f`](https://github.com/nix-community/emacs-overlay/commit/e63c323fdd81ca2a50542ed02eb3870a0f95c415) | `` Updated flake inputs `` |