### PR TITLE
chore(flake/devshell): `2c8e04e5` -> `12e91474`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -120,11 +120,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713195852,
-        "narHash": "sha256-MEb4Hx/Aw7pcsmcHXBuldFsrVTfl9Q9dz1JSlxUanmE=",
+        "lastModified": 1713532798,
+        "narHash": "sha256-wtBhsdMJA3Wa32Wtm1eeo84GejtI43pMrFrmwLXrsEc=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "2c8e04e5c29299bec53c2e5a73da0f9afa8dabb5",
+        "rev": "12e914740a25ea1891ec619bb53cf5e6ca922e40",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                            | Message                                                               |
| ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
| [`6dee0dd5`](https://github.com/numtide/devshell/commit/6dee0dd58da5054b9c403a47b14ba87b7966f2f9) | `` feat(tests): test packagesFrom with a null in buildInputs ``       |
| [`cbd803c7`](https://github.com/numtide/devshell/commit/cbd803c76bd1df4aedef30bcbb82e83818282a67) | `` fix(modules > devshell): filter out non-derivation dependencies `` |