### PR TITLE
chore(flake/nix-super): `afffb665` -> `05d4a869`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -997,11 +997,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1712350614,
-        "narHash": "sha256-q+fOInSvIDP1de1A3Pn4juBK2fkZJG3ezZNhhgHQpwc=",
+        "lastModified": 1713541547,
+        "narHash": "sha256-ZYgbuMJNVAIhNgMPmtlIjT89gi/6H5K+9ZcDOIKeG0s=",
         "owner": "privatevoid-net",
         "repo": "nix-super",
-        "rev": "afffb6659d3672e166f3d541f0656144e1cbbb27",
+        "rev": "05d4a86923ed8633b3f1c72239b58770b57366bb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                     | Message                                                                                                 |
| ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
| [`05d4a869`](https://github.com/privatevoid-net/nix-super/commit/05d4a86923ed8633b3f1c72239b58770b57366bb) | `` libcmd/modify-installables: build overrideValues differently ``                                      |
| [`1e28a137`](https://github.com/privatevoid-net/nix-super/commit/1e28a13720bf0f64ec3e86d34ede4aa0d4be023f) | `` libcmd: attrs -> attrs() ``                                                                          |
| [`8c4c2156`](https://github.com/privatevoid-net/nix-super/commit/8c4c2156bd786156a57219e78aa14a363ca8f041) | `` doc/glossary: Define output closure (#8311) ``                                                       |
| [`ad643cde`](https://github.com/privatevoid-net/nix-super/commit/ad643cde587805ac6e03cef4e51ca5a4268829d6) | `` C API: Add nix_init_apply ``                                                                         |
| [`f8a67d7e`](https://github.com/privatevoid-net/nix-super/commit/f8a67d7e26296c325410febdf10cf21b27ef57d1) | `` scripts/upload-release: fix riscv64 call ``                                                          |
| [`e3fa7c38`](https://github.com/privatevoid-net/nix-super/commit/e3fa7c38d7af8f34de0c24766b2e8cf1cd1330f0) | `` system: build for riscv64-unknown-linux-gnu (#10228) ``                                              |
| [`fb9f4208`](https://github.com/privatevoid-net/nix-super/commit/fb9f4208ed371afe23307f9b6cb9ada618bada9b) | `` Don't include `linux/` in `#include` ``                                                             |
| [`ba680451`](https://github.com/privatevoid-net/nix-super/commit/ba6804518772e6afb403dd55478365d4b863c854) | `` libstore/local-derivation-goal: prohibit creating setuid/setgid binaries ``                          |
| [`9c815db3`](https://github.com/privatevoid-net/nix-super/commit/9c815db36681ac01ea7422725a0ac2e183e39b16) | `` `file-descriptor.hh`: Avoid some Cism for better C++isms ``                                          |
| [`6fa3656a`](https://github.com/privatevoid-net/nix-super/commit/6fa3656a3286d3e73a54277965a1b1ae8d34300d) | `` Make a few commands that were Unix-only no longer ``                                                 |
| [`0774e8ba`](https://github.com/privatevoid-net/nix-super/commit/0774e8ba33c060f56bad3ff696796028249e915a) | `` Fix exportReferencesGraph when given store subpath ``                                                |
| [`21d9412d`](https://github.com/privatevoid-net/nix-super/commit/21d9412ddc07341df0194a0301d88e41ab9cf84c) | `` Improve `local-overlay` docs in a few ways ``                                                        |
| [`5fd28eeb`](https://github.com/privatevoid-net/nix-super/commit/5fd28eeba49c7bc23b539b677f63313925acb484) | `` docs: fix wiki link ``                                                                               |
| [`1063aa50`](https://github.com/privatevoid-net/nix-super/commit/1063aa502a3b931f96c1ff8bb6147ab73e63d582) | `` Relax store path canonicalization ``                                                                 |
| [`b529d919`](https://github.com/privatevoid-net/nix-super/commit/b529d91902a46e1fe0954d44fbc3622edcbe99ca) | `` Prefix `-DNIX_` paths to be windows-complient for windows ``                                         |
| [`98691b46`](https://github.com/privatevoid-net/nix-super/commit/98691b46e39fcaa0688e6f880e539bc88d86d63a) | `` Get rid of `shellCrossSystems` ``                                                                    |
| [`8433027e`](https://github.com/privatevoid-net/nix-super/commit/8433027e353b03bcbf36fae180394aaf8a21a19b) | `` Build a minimized Nix with MinGW ``                                                                  |
| [`2248a3f5`](https://github.com/privatevoid-net/nix-super/commit/2248a3f5451adf6c098fc871fb61fae6cc2b5979) | `` Create no-op Window pathlocks implementation ``                                                      |
| [`05b9dac7`](https://github.com/privatevoid-net/nix-super/commit/05b9dac7547009821f4a698b139a49d5d1e4bc9e) | `` Fix friend `struct`/`class` mismatch warning ``                                                      |
| [`d42a2643`](https://github.com/privatevoid-net/nix-super/commit/d42a2643b0de67c97449f05607f696c86015f0ed) | `` Auto label C API PRs ``                                                                              |
| [`7a113590`](https://github.com/privatevoid-net/nix-super/commit/7a1135901dd161318d70a7fdc03124e20c175eb9) | `` local.mk: Solve warnings ``                                                                          |
| [`1f1cd97c`](https://github.com/privatevoid-net/nix-super/commit/1f1cd97c715680369c36bb740e05636f0d29a1ed) | `` C API: Add section in Nix manual (#10519) ``                                                         |
| [`a863a75f`](https://github.com/privatevoid-net/nix-super/commit/a863a75f0b205e5c4ed09346b6b92322a7925ea4) | `` Remove the giy-submodule test from Github actions ``                                                 |
| [`45a1142a`](https://github.com/privatevoid-net/nix-super/commit/45a1142a8e771aeccd19c83e3a52c5dade510c83) | `` devShell: enable API docs ``                                                                         |
| [`94c861be`](https://github.com/privatevoid-net/nix-super/commit/94c861bebfd7d84607aa3d52617adea8c7eb5222) | `` labeler.yml: Add contributor-experience ``                                                           |
| [`c75b143b`](https://github.com/privatevoid-net/nix-super/commit/c75b143b6caf1e671c7f3a70dd91eb20c3036ceb) | `` C API: nix_get_string now accepts a callback to return the value ``                                  |
| [`28e0f0a0`](https://github.com/privatevoid-net/nix-super/commit/28e0f0a04cefee9820492b89ca54a93f6790b3ff) | `` Fix another typo ``                                                                                  |
| [`6892c980`](https://github.com/privatevoid-net/nix-super/commit/6892c9803c1559a7bfda57b7a5afdd6b62c4516e) | `` GitInputScheme: Fix path display for workdirs and submodules ``                                      |
| [`79363b22`](https://github.com/privatevoid-net/nix-super/commit/79363b22730cb1a0e20e34b9c9f63f5568217926) | `` MountedInputAccessor, FilteringInputAccessor: Respect the path display prefix/suffix ``              |
| [`548a12c1`](https://github.com/privatevoid-net/nix-super/commit/548a12c1fe9dc9b6065b575db0337033385e18f3) | `` Fix typo in hacking.md ``                                                                            |
| [`25265a93`](https://github.com/privatevoid-net/nix-super/commit/25265a9365ee8ad5917919be61d2c948a5dc6ffb) | `` Double word is superfluous ``                                                                        |
| [`6df58a08`](https://github.com/privatevoid-net/nix-super/commit/6df58a0891ecec7beb09b6459d432a005aafc7d4) | `` MercurialInputScheme: Improve path display ``                                                        |
| [`fa01db96`](https://github.com/privatevoid-net/nix-super/commit/fa01db9626a2e7ba97d9fea013f2f80f14251987) | `` StorePathAccessor: Fix path display ``                                                               |
| [`bcda38c2`](https://github.com/privatevoid-net/nix-super/commit/bcda38c27282124f37c2d9356539886291801f6e) | `` Have `clang-format` indent conditional CPP ``                                                        |
| [`774e7213`](https://github.com/privatevoid-net/nix-super/commit/774e7213e85447e159b93437f5f269a2f14621ff) | `` C API: Use `nix_get_string_callback` typedef ``                                                      |
| [`e3fed2eb`](https://github.com/privatevoid-net/nix-super/commit/e3fed2ebcf5d5b701f7c4a2d368006e20dfd4f8b) | `` update `fetchers::PublicKey` json (de)serialization ``                                               |
| [`ff4c286e`](https://github.com/privatevoid-net/nix-super/commit/ff4c286e8006e3d13da67076e973badf78edf22b) | `` add tests for `optionalValueAt` ``                                                                   |
| [`bb939d37`](https://github.com/privatevoid-net/nix-super/commit/bb939d37727f2a046c96dc6ca4a8b2ea8b85531f) | `` change implementation of `optionalValueAt` ``                                                        |
| [`76444a39`](https://github.com/privatevoid-net/nix-super/commit/76444a395825cca5e00b3eecef78109740b24114) | `` C API: proper `ifdef` `endif` indentation ``                                                         |
| [`01bad63c`](https://github.com/privatevoid-net/nix-super/commit/01bad63c720cb3d7280484f87f3ff9734b2b7117) | `` C API: Safer function pointer casting ``                                                             |
| [`95ae12b6`](https://github.com/privatevoid-net/nix-super/commit/95ae12b6079db7a30e2686138209e3a363eb85c9) | `` docs: Refer to the glossary with `@docroot@` instead of `..` ``                                      |
| [`13c2005e`](https://github.com/privatevoid-net/nix-super/commit/13c2005e7df7effe29449556edbc41314d0af915) | `` add intermediate variables and clarifying comments (#9274) ``                                        |
| [`cef677dd`](https://github.com/privatevoid-net/nix-super/commit/cef677ddbcad420220474935b660c147718a3a7c) | `` Test the inclusion of transitive symlinks in the sandbox ``                                          |
| [`acbb1523`](https://github.com/privatevoid-net/nix-super/commit/acbb1523c1dc28043d6dab729db696485938f969) | `` Fix the access of symlinks to host files in the sandbox ``                                           |
| [`f2522d4e`](https://github.com/privatevoid-net/nix-super/commit/f2522d4ecdcd693a2f94cd118eb7fa509983a54e) | `` libexpr-c: Add nix_store_path_name ``                                                                |
| [`a512f4ee`](https://github.com/privatevoid-net/nix-super/commit/a512f4eebcbfed5db8e8c48fd93d99201267df04) | `` test/libutil: Add OBSERVE_STRING macro ``                                                            |
| [`876e70bc`](https://github.com/privatevoid-net/nix-super/commit/876e70bc9afb15b5ee71d2f6b3090acca315f320) | `` tests/unit/libexpr/local.mk ``                                                                       |
| [`1233bcde`](https://github.com/privatevoid-net/nix-super/commit/1233bcde37e25a41f2230a64aded9bd5813098cd) | `` libstore-c: Add nix_store_path_clone ``                                                              |
| [`48808a53`](https://github.com/privatevoid-net/nix-super/commit/48808a53205ceec94bad761266c4325fd28963d1) | `` tests/unit/libexpr: Enable nix_store_realise test, and add docs ``                                   |
| [`94d9819b`](https://github.com/privatevoid-net/nix-super/commit/94d9819bdc9dfa0a62c1e75fc90b2df0409be1ec) | `` tests/unit/libexpr/main: Fix realisation ``                                                          |
| [`ed13cf05`](https://github.com/privatevoid-net/nix-super/commit/ed13cf05a224a08e4f120e0c932289db2d20be84) | `` build-hook: Allow empty ``                                                                           |
| [`1e4f902b`](https://github.com/privatevoid-net/nix-super/commit/1e4f902b28231497c6f2fe6db3f2d85352efc752) | `` Add gitSubmodules test to github actions ``                                                          |
| [`cd06193d`](https://github.com/privatevoid-net/nix-super/commit/cd06193d1387921caed8aa78b3f3617bea11fd00) | `` Add nixos test ``                                                                                    |
| [`1a76ca41`](https://github.com/privatevoid-net/nix-super/commit/1a76ca416108c8aefbafbf20f58f66725166b9f9) | `` Set the origin instead of hacking in the URL resolving ``                                            |
| [`1f73de26`](https://github.com/privatevoid-net/nix-super/commit/1f73de262961510318328463f943175833994a50) | `` git fetcher: relax absolute URL check of resolveSubmoduleUrl ``                                      |
| [`26a4688a`](https://github.com/privatevoid-net/nix-super/commit/26a4688a868e848760908ee15434eff2774952c3) | `` nix shell: Test that store paths cannot link outside of the store ``                                 |
| [`9d50f57f`](https://github.com/privatevoid-net/nix-super/commit/9d50f57fa360df96a4f92c73db25dcec2a6f39d4) | `` Doh ``                                                                                               |
| [`85b9f4ef`](https://github.com/privatevoid-net/nix-super/commit/85b9f4ef4fcc7b7fc03ff9503f280d736b5c65c7) | `` nix shell: Handle output paths that are symlinks ``                                                  |
| [`19c8867d`](https://github.com/privatevoid-net/nix-super/commit/19c8867d2a916fd5af46d8bc6b9449875145abb0) | `` Fix store-path.md (#10457) ``                                                                        |
| [`3e5797e9`](https://github.com/privatevoid-net/nix-super/commit/3e5797e97fe73f0468e2b3faa0ce6b1860617137) | `` Document the Nix Archive format ``                                                                   |
| [`664532c5`](https://github.com/privatevoid-net/nix-super/commit/664532c533457fb7bda113ea432fb53710fd7d92) | `` Do not rely on $stdenv/setup to set output variables ``                                              |
| [`50557adb`](https://github.com/privatevoid-net/nix-super/commit/50557adb3b58445f1ca176bc6f653afa5151567c) | `` doc/rl-2.20: clarify builders-use-substitutes vs. substitute-on-destination ``                       |
| [`ae473729`](https://github.com/privatevoid-net/nix-super/commit/ae4737294e91ab93526612b17950e1bc4f0b47f0) | `` doBind: Use our own lstat wrapper ``                                                                 |
| [`913db9f7`](https://github.com/privatevoid-net/nix-super/commit/913db9f7385b8717d9eaf6269e9f319e78e4c564) | `` Fix permission denied when building symlink derivation which points to a symlink out of the store `` |
| [`872d93eb`](https://github.com/privatevoid-net/nix-super/commit/872d93eb13f22e8705e03903b65c7eba8b26a99b) | `` Add a test for depending on a symlink store path ``                                                  |
| [`93d68e18`](https://github.com/privatevoid-net/nix-super/commit/93d68e18e588aa82e144fb6ab0cd1be0eae2e413) | `` Make `outputHashAlgo` accept `"nar"`, stay in sync ``                                                |
| [`f34b8de5`](https://github.com/privatevoid-net/nix-super/commit/f34b8de5b2ba9f5ed92924e30661b70ed427a123) | `` doc/rl-2.20: add missing entry about `nix copy --to ssh-ng://...` ``                                 |
| [`d29786f2`](https://github.com/privatevoid-net/nix-super/commit/d29786f25854c910e08d9a8438d589f02adc9569) | `` downloadFile(): Remove the "locked" (aka "immutable") flag ``                                        |
| [`e68f24f1`](https://github.com/privatevoid-net/nix-super/commit/e68f24f1e0d81d3d367057f149d43dfa883579cc) | `` Remove `resolve-system-dependencies` ``                                                              |
| [`737ce5e8`](https://github.com/privatevoid-net/nix-super/commit/737ce5e81f4eae292d193e38fec961f105909f0b) | `` Actually run the Mercurial tests ``                                                                  |
| [`bd8c276d`](https://github.com/privatevoid-net/nix-super/commit/bd8c276ddbb980be2f9024c071cd304ef8a91b40) | `` Improve the `config check` output for stores that don't know about trust ``                          |
| [`dea23c3c`](https://github.com/privatevoid-net/nix-super/commit/dea23c3c9b0f0770e915bef3b1006f8f6cb225d8) | `` "but doctor, I AM the untrusted store": nix doctor had wrong trustedness ``                          |
| [`bd7c26bc`](https://github.com/privatevoid-net/nix-super/commit/bd7c26bc7bb7af37c21d46faf28aa0e88606b98f) | `` Add comment explaining `LIBMOUNT_FORCE_MOUNT2=always` ``                                             |
| [`a2a633d3`](https://github.com/privatevoid-net/nix-super/commit/a2a633d332f4ca3a38b47f5a524d8d07cead5917) | `` Prevent nix-daemon.sh from leaking variable into user environment ``                                 |
| [`e73dc0e9`](https://github.com/privatevoid-net/nix-super/commit/e73dc0e938c59b071eb24252980935b51cb17106) | `` Use LIBMOUNT_FORCE_MOUNT2=always to workaround new mount API issues ``                               |
| [`910211f9`](https://github.com/privatevoid-net/nix-super/commit/910211f9ffba41f5fa269217192638773a0bf30c) | `` avoid markdown which the repl's :doc cannot handle ``                                                |
| [`c80cd6bb`](https://github.com/privatevoid-net/nix-super/commit/c80cd6bb0684c265f09cf0b17908859a306626fd) | `` path-info: print correct path when using `nix path-info --store file://... --all --json` ``          |
| [`513634ab`](https://github.com/privatevoid-net/nix-super/commit/513634ab5bf97c32256733d12e7381c4e83e1adf) | `` Make `cgroup.{cc,hh}` linux-only files ``                                                            |
| [`c145ce0e`](https://github.com/privatevoid-net/nix-super/commit/c145ce0e1a01f54f7ddf7d38909cf6bd8ec32a88) | `` realiseContext: Remove no-op replacements ``                                                         |
| [`02c41aba`](https://github.com/privatevoid-net/nix-super/commit/02c41aba5b5b135bae0de4961fcf4d3a888a9524) | `` libexpr-c: Add nix_string_realise ``                                                                 |
| [`c82623a6`](https://github.com/privatevoid-net/nix-super/commit/c82623a6cc918fb7657621250baf62726e94c4ea) | `` Remove value clearing since it no longer has an effect ``                                            |
| [`8c0590fa`](https://github.com/privatevoid-net/nix-super/commit/8c0590fa32395e8f66bad11049fb40458d94424b) | `` Never update values after setting the type ``                                                        |
| [`cd35e001`](https://github.com/privatevoid-net/nix-super/commit/cd35e0010322bbf30b967cb7991e84dd740e43df) | `` Adding missing tracking URL for local overlay store ``                                               |
| [`fe42a0ea`](https://github.com/privatevoid-net/nix-super/commit/fe42a0ead70db8f5b82dec42a14682bbe4414577) | `` Documentation typo ``                                                                                |
| [`5a298543`](https://github.com/privatevoid-net/nix-super/commit/5a2985431c8b03be7d434a39ea62a8b3d26e4f51) | `` Revert "Revert "Merge pull request #9546 from NixOS/nixos-23.11"" ``                                 |
| [`d6d7d2cb`](https://github.com/privatevoid-net/nix-super/commit/d6d7d2cb4617c571e1ee7c152818f3b7a07a5f81) | `` Revert "Merge pull request #9546 from NixOS/nixos-23.11" ``                                          |
| [`bcd6b33d`](https://github.com/privatevoid-net/nix-super/commit/bcd6b33dbcbd2e9c2ef3eaf50b9339fe9a33a49d) | `` Polish local overlay store docs ``                                                                   |
| [`9b506ff0`](https://github.com/privatevoid-net/nix-super/commit/9b506ff0c1e48fa805eab86eb43bd99ac1ae24a3) | `` Activate `hermetic.nix` variation only for new layered store tests ``                                |
| [`dc439eaf`](https://github.com/privatevoid-net/nix-super/commit/dc439eaf236ea1ef5c291b50de25817df8103041) | `` Fill in missing markdown link dest ``                                                                |
| [`eae2717e`](https://github.com/privatevoid-net/nix-super/commit/eae2717e00e82a61884b3f53a50db94272a1fad1) | `` tests: Use `cp -ar` instead of tar-untar pipe ``                                                     |
| [`4a2cee8e`](https://github.com/privatevoid-net/nix-super/commit/4a2cee8e6cf2cfe0975b11fbccf6beb36b99cc60) | `` Document expected filesystem layout and OverlayFS mount command. ``                                  |
| [`8d0a03b5`](https://github.com/privatevoid-net/nix-super/commit/8d0a03b5a22df6f764686386edde6b90d290b8e4) | `` Fix tests after last rename (`path` -> `pathInLowerStore`) ``                                        |
| [`c90e46d3`](https://github.com/privatevoid-net/nix-super/commit/c90e46d3f0c6614921b42ba5506a409ca11b5c30) | `` Update tests/functional/local-overlay-store/common.sh ``                                             |
| [`b3bdd70e`](https://github.com/privatevoid-net/nix-super/commit/b3bdd70ea2a69ec2ddd547ee475219f5b38b8f59) | `` Clarify `toUpperPath` docs ``                                                                        |
| [`c93f78f6`](https://github.com/privatevoid-net/nix-super/commit/c93f78f6fabdc4f01d3af98c68c4225be9d2c546) | `` Fix test a bit from previous commit ``                                                               |
| [`6bb13358`](https://github.com/privatevoid-net/nix-super/commit/6bb13358e6746d1746abf4bd926420ad94ea0ff4) | `` Update tests/functional/local-overlay-store/redundant-add-inner.sh ``                                |
| [`bf0bf3d1`](https://github.com/privatevoid-net/nix-super/commit/bf0bf3d1be47aa1bcf9cb3c8f0923e1304fc7065) | `` local-overlay store tests: `storeDirs` -> `setupStoreDirs` ``                                        |
| [`b21ee605`](https://github.com/privatevoid-net/nix-super/commit/b21ee60594c637b4ea5ab98d5cc60b34a66bdde4) | `` Get rid of `verifyAllValidPaths` boolean blindness ``                                                |
| [`c30b5d8a`](https://github.com/privatevoid-net/nix-super/commit/c30b5d8a0bc7766e55b5254c75b264597bd2935e) | `` Apply suggestions from code review ``                                                                |
| [`250c3541`](https://github.com/privatevoid-net/nix-super/commit/250c3541bb7ffffae81e873f09f781d3b57e5935) | `` Use `local-overlay://` not `local-overlay` for store URL ``                                          |
| [`6f0a9589`](https://github.com/privatevoid-net/nix-super/commit/6f0a95897cacf6edb8d753e19aedf2f4f1f12108) | `` Revert "Fix hard linking issue causing overlay fs copy-ups" ``                                       |
| [`d137002e`](https://github.com/privatevoid-net/nix-super/commit/d137002e941ffdaa46efdffbca9fdc6fbb108522) | `` Add API docs for all overridden local overlay methods ``                                             |
| [`7ad16c9d`](https://github.com/privatevoid-net/nix-super/commit/7ad16c9d1283c14df410a933eff560da258c11bf) | `` Add some docs for the local overlay store ``                                                         |
| [`4d99e407`](https://github.com/privatevoid-net/nix-super/commit/4d99e407fd8c2a257304a622b93abd69149413fc) | `` Remove FIXME on why something doesn't work ``                                                        |
| [`4f5b01f5`](https://github.com/privatevoid-net/nix-super/commit/4f5b01f5cd83f1ce0d36ea8f4be8b06e9526cbe3) | `` Start to document the local-overlay store ``                                                         |
| [`2556c4d7`](https://github.com/privatevoid-net/nix-super/commit/2556c4d7531c1303ec3e5db5d5dd1b3a9b91a3b4) | `` Rename test group `overlay-local-store` -> `local-overlay-store` ``                                  |
| [`4b9a6218`](https://github.com/privatevoid-net/nix-super/commit/4b9a6218125c23e95b7397069f6fc2796fb70fd2) | `` Guard the local overlay store behind an experimental feature ``                                      |
| [`6b297e58`](https://github.com/privatevoid-net/nix-super/commit/6b297e5895e62d91963be49e5d301604d0b8fd09) | `` Make `verifyAllValidPaths` more functional ``                                                        |
| [`19164cf7`](https://github.com/privatevoid-net/nix-super/commit/19164cf727030dc75c11533f11dc84645658b7c3) | `` Test that remounting fixes 'stale file handle' errors. ``                                            |
| [`c712369e`](https://github.com/privatevoid-net/nix-super/commit/c712369ec597c706f985f2f998215f5ab913d61a) | `` Document remount-hook store parameter. ``                                                            |
| [`c409a753`](https://github.com/privatevoid-net/nix-super/commit/c409a753dbc6318f5454f058dbf55786327035b7) | `` Fix new lines in comment. ``                                                                         |
| [`1255866e`](https://github.com/privatevoid-net/nix-super/commit/1255866e16bbbf2ac93ade99ae5ef2f68f64d8c6) | `` Update src/libstore/local-overlay-store.hh ``                                                        |
| [`6a8de4c9`](https://github.com/privatevoid-net/nix-super/commit/6a8de4c9dcd5c329f6488818517995647c577c87) | `` Avoid enumerating entire overlay store dir upfront. ``                                               |
| [`50ce8d15`](https://github.com/privatevoid-net/nix-super/commit/50ce8d15eb5fed11080a3b94991c55e880c22252) | `` Preparatory refactor of LocalStore::verifyStore. ``                                                  |
| [`c2d54496`](https://github.com/privatevoid-net/nix-super/commit/c2d54496a0c8611a7008181e2dc4fc57d520752f) | `` Forgot to check flag and early out. ``                                                               |
| [`3a9fe1a0`](https://github.com/privatevoid-net/nix-super/commit/3a9fe1a085edc8db3e3cd35531829ddab51bcd81) | `` Made remountRequired atomic to avoid concurrency issues. ``                                          |
| [`ca1a108d`](https://github.com/privatevoid-net/nix-super/commit/ca1a108dad93f00f18929c02bf29bbe5347035ac) | `` Update tests/overlay-local-store/remount.sh ``                                                       |
| [`5744a500`](https://github.com/privatevoid-net/nix-super/commit/5744a500d66214f6d833100924a2f7362b7b82a7) | `` Use debug instead of writing directly to stderr. ``                                                  |
| [`6da05c0a`](https://github.com/privatevoid-net/nix-super/commit/6da05c0a11365c8cd138c15600ec966e9c2b5940) | `` Rename test to delete-duplicate. ``                                                                  |
| [`ed142869`](https://github.com/privatevoid-net/nix-super/commit/ed1428692409f94cd5553b66c9f5e6aa3c048e86) | `` Invoke remount-hook program when necessary. ``                                                       |
| [`33ebae75`](https://github.com/privatevoid-net/nix-super/commit/33ebae75ca4a7fd81585928b36a1cc18995f8212) | `` Reuse deletion logic for optimiseStore and rename method. ``                                         |
| [`11c493f8`](https://github.com/privatevoid-net/nix-super/commit/11c493f8fa88a81645318844077392020618887f) | `` Avoid creating whiteout for duplicate store paths. ``                                                |
| [`cc6f8aa9`](https://github.com/privatevoid-net/nix-super/commit/cc6f8aa91a1716ed1801f51fb3a6a1fa468f338f) | `` Test that delete works for duplicate file edge case. ``                                              |
| [`d9688ba7`](https://github.com/privatevoid-net/nix-super/commit/d9688ba70881f1735cf36161244a9a6b2acf4d48) | `` Add new remount-hook store parameter. ``                                                             |
| [`b0877ad3`](https://github.com/privatevoid-net/nix-super/commit/b0877ad3c90a806e70cac3e7f6e5c26151239bb8) | `` Give test a more specific name ``                                                                    |
| [`07b34edc`](https://github.com/privatevoid-net/nix-super/commit/07b34edc449f25e9b4062d7f6d90dad1f6c71760) | `` Fix deletion test ``                                                                                 |
| [`19c43c5d`](https://github.com/privatevoid-net/nix-super/commit/19c43c5d787c113053ef651c3d22fdfde61075e2) | `` Write test for deleting objects referenced from below ``                                             |
| [`9ef0a9e8`](https://github.com/privatevoid-net/nix-super/commit/9ef0a9e8aa2e27991434c104ad73b1b95b241f08) | `` Fix hard linking issue causing overlay fs copy-ups ``                                                |
| [`497464f4`](https://github.com/privatevoid-net/nix-super/commit/497464f4945200522f05a318720ad0a158095e8e) | `` Extend verify test to check that repair is supported. ``                                             |
| [`3731208d`](https://github.com/privatevoid-net/nix-super/commit/3731208dc120b5d12f1c5c63ec58bcdb34c42195) | `` Adopt GC test for local-overlay store ``                                                             |
| [`0e595a52`](https://github.com/privatevoid-net/nix-super/commit/0e595a52a32003ed448b1da9319a639059f993a6) | `` Remove trailing whitespace ``                                                                        |
| [`2fc00ec1`](https://github.com/privatevoid-net/nix-super/commit/2fc00ec19f8eb7ec2285135a180763d632102762) | `` Fix unbound variable error in optimise test. ``                                                      |
| [`2c66a093`](https://github.com/privatevoid-net/nix-super/commit/2c66a093e05bc466d00c9365bc43567fd9d5c334) | `` Define storeBRoot variable distinct from storeB URI. ``                                              |
| [`878c84d5`](https://github.com/privatevoid-net/nix-super/commit/878c84d5ee88f2e6c56abb42211a729c4d342e14) | `` Fix errors about NIX_STORE_DIR being unset. ``                                                       |
| [`9769a0ae`](https://github.com/privatevoid-net/nix-super/commit/9769a0ae7d840f1df7db3de4524180016830e57e) | `` Ensure all overlay tests use new tmpfs store paths. ``                                               |
| [`7fda19e2`](https://github.com/privatevoid-net/nix-super/commit/7fda19e2f139a7e41cb53cdbdd692dbc98755d91) | `` Mount tmpfs first to ensure overlayfs works consistently. ``                                         |
| [`44f855d1`](https://github.com/privatevoid-net/nix-super/commit/44f855d14ee40dfeaf52c4f01e2de124fe0f18fc) | `` Missing addTextToStore function. ``                                                                  |
| [`d1c77b20`](https://github.com/privatevoid-net/nix-super/commit/d1c77b201a1b0e6c14470b69c134652a8858fc18) | `` Explicitly exec shell to fix ENOENT errors. ``                                                       |
| [`8ddbcb73`](https://github.com/privatevoid-net/nix-super/commit/8ddbcb736a17d08ce899de345548064eebf673c9) | `` Implement overlay store deduplication. ``                                                            |
| [`a9510f95`](https://github.com/privatevoid-net/nix-super/commit/a9510f950228957cde98001b67e123aa2d4d62c9) | `` Implement test for store path deduplication. ``                                                      |
| [`614efc12`](https://github.com/privatevoid-net/nix-super/commit/614efc1240dbfefbdabced808decd8defd33df8e) | `` Add test for store optimise path deduplication. ``                                                   |
| [`d5cd74a4`](https://github.com/privatevoid-net/nix-super/commit/d5cd74a4012d583d11d491bec9f1fa9a07b11973) | `` Override verifyStore to always pass NoRepair for LocalOverlayStore. ``                               |
| [`58085e4e`](https://github.com/privatevoid-net/nix-super/commit/58085e4eff1e06524f9ad8f6e9f271c19dcbba9e) | `` Have verify test exercise check-contents too. ``                                                     |
| [`0ccf6382`](https://github.com/privatevoid-net/nix-super/commit/0ccf6382af4c34dafacd2a417ba658e62d81adbf) | `` Add test for verifying overlay store. ``                                                             |
| [`a33ee5c8`](https://github.com/privatevoid-net/nix-super/commit/a33ee5c84305b85f5bcd0ea1be43b44cf601693f) | `` Paths added to lower store are accessible via overlay. ``                                            |
| [`f66b65a3`](https://github.com/privatevoid-net/nix-super/commit/f66b65a30ad1f14dd757874c12255eef42368b04) | `` Revert "Skip build-remote-trustless unless sandbox is supported." ``                                 |
| [`37598a13`](https://github.com/privatevoid-net/nix-super/commit/37598a13e877980d4654c632d10921c41c9ad976) | `` Revert "Check _NIX_TEST_NO_SANDBOX when setting _canUseSandbox." ``                                  |
| [`83cfa82e`](https://github.com/privatevoid-net/nix-super/commit/83cfa82e52e26a287a5bdb60863751096ab02c63) | `` Add unset to NIX_STORE_DIR for local-overlay tests ``                                                |
| [`735a672e`](https://github.com/privatevoid-net/nix-super/commit/735a672e1f3bbad8e32b211ce33fa4a308ae355a) | `` Introduce notion of a test group, use for CA tests ``                                                |
| [`2add2309`](https://github.com/privatevoid-net/nix-super/commit/2add2309397bd576712c1b90d364fb90525f4797) | `` Fix build ``                                                                                         |
| [`4e72b848`](https://github.com/privatevoid-net/nix-super/commit/4e72b8483ede9242ddde99eb8011b18098172444) | `` Update src/libstore/sqlite.hh ``                                                                     |
| [`ba492a98`](https://github.com/privatevoid-net/nix-super/commit/ba492a98baa0fa37b0914e3f7d00f2859cef5bcd) | `` Update src/libstore/local-store.hh ``                                                                |
| [`b09baa3b`](https://github.com/privatevoid-net/nix-super/commit/b09baa3bc31226cac5ccdbd7ba9d72a2ed389207) | `` Link to LocalStore section of nix3-help-stores section. ``                                           |
| [`ef40448b`](https://github.com/privatevoid-net/nix-super/commit/ef40448b1cb33165af5522f72d5d352d66035671) | `` Remove redundant description on experimental flag. ``                                                |
| [`feb8d552`](https://github.com/privatevoid-net/nix-super/commit/feb8d552aeca36adde5a9c25b92fd9eb205a761e) | `` Update src/libstore/local-store.hh ``                                                                |
| [`f5d83a80`](https://github.com/privatevoid-net/nix-super/commit/f5d83a80293426b2f869af206b93b5cdfeb34ec9) | `` One line per sentence in markdown docs. ``                                                           |
| [`f2fe9822`](https://github.com/privatevoid-net/nix-super/commit/f2fe9822c14bc86e5da8f8cb97cb16a961ecc46f) | `` Comment explaining what schema version 0 means. ``                                                   |
| [`4642b60a`](https://github.com/privatevoid-net/nix-super/commit/4642b60afe2a79b00ae51ca1ec1fc35eb5a224c5) | `` Update src/libstore/local-store.hh ``                                                                |
| [`a7b1b92d`](https://github.com/privatevoid-net/nix-super/commit/a7b1b92d817348669fc2cd34c085dae57ceed5b8) | `` Update src/libstore/local-store.hh ``                                                                |
| [`984b0192`](https://github.com/privatevoid-net/nix-super/commit/984b01924a58dc80b0e5da7722ccfa108cbca036) | `` Update src/libstore/local-store.cc ``                                                                |
| [`78e2f931`](https://github.com/privatevoid-net/nix-super/commit/78e2f931d048f9c41e5432cd8e49bf6bc0c3baae) | `` Update src/libstore/local-store.cc ``                                                                |
| [`7cdaa0b8`](https://github.com/privatevoid-net/nix-super/commit/7cdaa0b8a626004b19b87b1eec74d1adb5f20263) | `` Update tests/read-only-store.sh ``                                                                   |
| [`264b644c`](https://github.com/privatevoid-net/nix-super/commit/264b644c534418f3a27b7e6013afa4aee7bdf89c) | `` More detail on why read-only mode disables locking. ``                                               |
| [`fad0dd4a`](https://github.com/privatevoid-net/nix-super/commit/fad0dd4afb66577f9c17b5a315d120ac0f5acd94) | `` Skip build-remote-trustless unless sandbox is supported. ``                                          |
| [`7ed0ab2d`](https://github.com/privatevoid-net/nix-super/commit/7ed0ab2dabececd84578ddf70ecad0e528d67a28) | `` Check _NIX_TEST_NO_SANDBOX when setting _canUseSandbox. ``                                           |
| [`ee1241da`](https://github.com/privatevoid-net/nix-super/commit/ee1241da8649fb310f8b5ac28d27f3c08117cdf9) | `` Remove unnecessary overrides of add methods. ``                                                      |
| [`8a9baa0a`](https://github.com/privatevoid-net/nix-super/commit/8a9baa0a3091bd2ebd8d6027e0130c8b6dec76c5) | `` More sensible to have deleteGCPath in LocalStore. ``                                                 |
| [`a48acfd6`](https://github.com/privatevoid-net/nix-super/commit/a48acfd68424960c9a7a5d4eeb1af2a7ea91835d) | `` Skip deletion of lower paths for overlay store GC. ``                                                |
| [`98edbb96`](https://github.com/privatevoid-net/nix-super/commit/98edbb968617b2478f52ab527bc4b1a75933b8c6) | `` Factor out GC path deletion so it can be overridden. ``                                              |
| [`c47f744e`](https://github.com/privatevoid-net/nix-super/commit/c47f744e05d8c80bd65083b0fc0fbfef2ff0c08f) | `` Also skip makeStoreWritable when read-only=true. ``                                                  |
| [`d6ea3b6a`](https://github.com/privatevoid-net/nix-super/commit/d6ea3b6a19b7d48a7fb4cc03b0eaf080217fa84f) | `` Need to enable read-only-local-store flag for test. ``                                               |