### PR TITLE
chore(flake/home-manager): `178e2689` -> `6a171bfd`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713453913,
-        "narHash": "sha256-vbXq52VRlL1defMHrwhsoeHm95O3mFefsSSJyNEghbA=",
+        "lastModified": 1713540971,
+        "narHash": "sha256-Hh9RjnywCx8bOEhtbzgsuI6in/MOXWRImTHZiCbU2lI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "178e26895b3aef028a00a32fb7e7ed0fc660645c",
+        "rev": "6a171bfd84ee9b3df83f6eb76dab042219978439",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                                       |
| ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
| [`6a171bfd`](https://github.com/nix-community/home-manager/commit/6a171bfd84ee9b3df83f6eb76dab042219978439) | `` kconfig: add module ``                                     |
| [`1f305c36`](https://github.com/nix-community/home-manager/commit/1f305c363ecd7c6505f03fc7baba15505f3aa630) | `` remmina: add module ``                                     |
| [`31c77dcc`](https://github.com/nix-community/home-manager/commit/31c77dcc2e4b6b9f73df0e7eaa89536f175954e8) | `` sway: systemd customization ``                             |
| [`068dd4ae`](https://github.com/nix-community/home-manager/commit/068dd4ae292b5bf64bda18a48bcd80f39dd76257) | `` alacritty: cleanup after 0.13 merge in nixpkgs ``          |
| [`7ca7025c`](https://github.com/nix-community/home-manager/commit/7ca7025cf2fa88bebc2190955c44263c3989b706) | `` alacritty: fix escape sequence in example and test ``      |
| [`dc906b19`](https://github.com/nix-community/home-manager/commit/dc906b197bc20c518e497fb040bb8240543fa634) | `` kdeconnect: require "tray.target" for kdeconnect ``        |
| [`0184c818`](https://github.com/nix-community/home-manager/commit/0184c8180f5cbb8e3a54a239b874fe849d3073cb) | `` neomutt: add some options ``                               |
| [`b1a5b3d6`](https://github.com/nix-community/home-manager/commit/b1a5b3d6a524c80c7dd20888bff227d52adf5f03) | `` vdirsyncer: set `postHook` to null when not set (#5294) `` |
| [`b62cad68`](https://github.com/nix-community/home-manager/commit/b62cad68b754224caec1e3b0dbadf86821b0b255) | `` spotify-player: add module ``                              |
| [`b5b2b1ac`](https://github.com/nix-community/home-manager/commit/b5b2b1ac63458357e205bcb2df2d0840a2acca13) | `` helix: add ignores option ``                               |
| [`8ff7bb3f`](https://github.com/nix-community/home-manager/commit/8ff7bb3f4d82a05a52d5242ec454bba14f5d6cc6) | `` tofi: add module ``                                        |
| [`f3506ba8`](https://github.com/nix-community/home-manager/commit/f3506ba86cbc5f8620ea6b4e108146702a4627e9) | `` bash: add bash package to home.packages ``                 |
| [`ffc3600f`](https://github.com/nix-community/home-manager/commit/ffc3600f4009ca39b6cb63b24127ca4f93792854) | `` fd: add module ``                                          |
| [`54e35e0e`](https://github.com/nix-community/home-manager/commit/54e35e0e1c1b6b4888c34423335a448ab3ec78d5) | `` qt: use warnings API ``                                    |
| [`be2b1761`](https://github.com/nix-community/home-manager/commit/be2b17615c536c31d0ea4989a959298b115353b3) | `` qt: fix adwaita decorations link ``                        |
| [`b31019d6`](https://github.com/nix-community/home-manager/commit/b31019d64f9ddd1a869fa8fdb371c32c7ed9b578) | `` qt: add adwaita platform theme ``                          |
| [`7cebe921`](https://github.com/nix-community/home-manager/commit/7cebe921eaffd5f9880f0dab7a23789d15f6169b) | `` Update translation files ``                                |