### PR TITLE
chore(flake/nixfmt): `87c4879b` -> `a8b578d1`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1160,11 +1160,11 @@
         "flake-utils": "flake-utils_11"
       },
       "locked": {
-        "lastModified": 1713291528,
-        "narHash": "sha256-Xx0hY9XXXOmOgTlgpX9r1bQkigWhNXXEzeVRBI46EfY=",
+        "lastModified": 1713478555,
+        "narHash": "sha256-Sdhv/YQxvF6OJeEY+iyg3f2p6XCankrYQffsxMajnGs=",
         "owner": "nixos",
         "repo": "nixfmt",
-        "rev": "87c4879b7a72a69726b76392847fb79a7044c6a6",
+        "rev": "a8b578d124cfda7540957a2172f89aa12d99609f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                        | Message                                                             |
| --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
| [`27f80162`](https://github.com/NixOS/nixfmt/commit/27f80162729de92c77337ba96304ca91df9d41de) | `` treefmt: Ensure all Haskell files are formatted with fourmolu `` |
| [`c697c0a7`](https://github.com/NixOS/nixfmt/commit/c697c0a7a9406639acaf9a3325b896c777525261) | `` treefmt: Ensure all Nix files are formatted ``                   |
| [`c60836d4`](https://github.com/NixOS/nixfmt/commit/c60836d413dd8dcf0d059aaff4d33b8cc5dea567) | `` Add treefmt, empty config for now ``                             |