### PR TITLE
chore(flake/sops-nix): `b94c6edb` -> `a929a011`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1534,11 +1534,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713457024,
-        "narHash": "sha256-31MpStyXedDL1fvuOvn6iz3JURSVShDtDVMyP1PTjtc=",
+        "lastModified": 1713532771,
+        "narHash": "sha256-vfKxhYVMzG2tg48/1rewBoSLCrKIjQsG1j7Nm/Y2gf4=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "b94c6edbb8355756c53efc8ca3874c63622f287a",
+        "rev": "a929a011a09db735abc45a8a45d1ff7fdee62755",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                                                  |
| ----------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
| [`a929a011`](https://github.com/Mic92/sops-nix/commit/a929a011a09db735abc45a8a45d1ff7fdee62755) | `` update vendorHash ``                                  |
| [`d63d2a0f`](https://github.com/Mic92/sops-nix/commit/d63d2a0fdfcbd5e24d5a19e97cd1ed3d78b6418d) | `` Bump golang.org/x/net from 0.21.0 to 0.23.0 ``        |
| [`6ef5c647`](https://github.com/Mic92/sops-nix/commit/6ef5c647a4f38f5608a63fdc80a58bf772b11be8) | `` drop docs unpinned ways of installing sops-nix ``     |
| [`e31339a2`](https://github.com/Mic92/sops-nix/commit/e31339a20491a2ed8363b73e87e5d83d1c411833) | `` home-manager: fix implicit dependency on coreutils `` |