### PR TITLE
chore(flake/nixpkgs-master): `1b7469ab` -> `45a89f4e`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1224,11 +1224,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1713459744,
-        "narHash": "sha256-xdfSUKjXDQSvTLKReRPckLp0DcxVAQKrx4r/BwdA06g=",
+        "lastModified": 1713545265,
+        "narHash": "sha256-dq+dUC6VX2rMrpRXlSjVDcuNmBgEdD3pvpy58vBWTh8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1b7469ab47f305667f4da1af1e70b2577474d77c",
+        "rev": "45a89f4ea3ccb6dc08b06f746a968992464d410f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                                              |
| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
| [`45a89f4e`](https://github.com/NixOS/nixpkgs/commit/45a89f4ea3ccb6dc08b06f746a968992464d410f) | `` eog: add `jxl` support ``                                                                                         |
| [`0518f07b`](https://github.com/NixOS/nixpkgs/commit/0518f07b8e2cbc41b588add9cf8a41a3f7d0411d) | `` gnome: add `jxl` thumbnails and wallpapers support ``                                                             |
| [`02c9aec5`](https://github.com/NixOS/nixpkgs/commit/02c9aec57a8d5953996ba74eea399501dde94261) | `` neovide: remove multisn8 from maintainers ``                                                                      |
| [`cc5b3054`](https://github.com/NixOS/nixpkgs/commit/cc5b30542b0202032f2ad5792cfa3955446fdfdf) | `` doc: remove links to docbook documentation (#305328) ``                                                           |
| [`9cb1d6ed`](https://github.com/NixOS/nixpkgs/commit/9cb1d6edbb4d81e5793b3140fc9dd3366ac00f7b) | `` rippkgs: add cdmistman as maintainer ``                                                                           |
| [`9b76c3bf`](https://github.com/NixOS/nixpkgs/commit/9b76c3bff5999eb24918157eb8f5c41da0540545) | `` doc: move note on configuring Nixpkgs in NixOS to the NixOS manual (#304307) ``                                   |
| [`1a2d905c`](https://github.com/NixOS/nixpkgs/commit/1a2d905c2c619072d12acc81564bb06c10eb899e) | `` rkpd2: 2.0.3 -> 2.0.5 ``                                                                                          |
| [`1d2b5bed`](https://github.com/NixOS/nixpkgs/commit/1d2b5bed131c376bf79115196e53d27f138086cf) | `` python311Packages.mailchecker: refactor ``                                                                        |
| [`b22002d9`](https://github.com/NixOS/nixpkgs/commit/b22002d97f5e9dbcbca3746a53ffe86b3c5529c5) | `` wiremock: 3.5.2 -> 3.5.3 ``                                                                                       |
| [`eee733a8`](https://github.com/NixOS/nixpkgs/commit/eee733a88de54288798d59e05c198edc77120924) | `` libreswan: 4.12 -> 4.15 ``                                                                                        |
| [`3cdf165a`](https://github.com/NixOS/nixpkgs/commit/3cdf165a2701d836eba24dce827f492792ef1f60) | `` nixVersions.nix*: correct license to lgpl21Plus ``                                                                |
| [`f1e8e483`](https://github.com/NixOS/nixpkgs/commit/f1e8e4837d258a15a5564fdaadc436bee2c38f87) | `` coqPackages.CoLoR: 1.8.4 → 1.8.5 ``                                                                               |
| [`4237fee2`](https://github.com/NixOS/nixpkgs/commit/4237fee22db7ee89d831e671073d9e2ab36dc59a) | `` Revert "icu: refactor to avoid runtime dependency on bash" ``                                                     |
| [`ae4e2c93`](https://github.com/NixOS/nixpkgs/commit/ae4e2c93b7c72776b5fecc85f80c21c8e7ee9192) | `` _1password-gui: 8.10.28 → 8.10.30 ``                                                                              |
| [`4913b78e`](https://github.com/NixOS/nixpkgs/commit/4913b78e35e5edf3ee90c3b42625f60ae29f4e79) | `` jan: 0.4.10 -> 0.4.11 ``                                                                                          |
| [`93c36c00`](https://github.com/NixOS/nixpkgs/commit/93c36c006ac81d9894b2280d11c1ea336b159351) | `` ncspot: Rename dependency Cross to Crossterm ``                                                                   |
| [`7067c4b0`](https://github.com/NixOS/nixpkgs/commit/7067c4b0bb925263b848a895fcca03e4934d438f) | `` nixosTests.paperless: Test tesseract compiles when english is not staged ``                                       |
| [`f0721f37`](https://github.com/NixOS/nixpkgs/commit/f0721f377955cbd33a3613750b43629580ade724) | `` nixos/paperless: Always buidl tesseract with english ``                                                           |
| [`9c1f3b30`](https://github.com/NixOS/nixpkgs/commit/9c1f3b305a16581259888edc12adbd18bef01ba8) | `` buildCrystalPackage: add copyShardDeps flag ``                                                                    |
| [`da03c8fb`](https://github.com/NixOS/nixpkgs/commit/da03c8fb0a127580ccb95d4430f8f1f67a89cf38) | `` python312Packages.cytoolz: fix build ``                                                                           |
| [`a0692d3b`](https://github.com/NixOS/nixpkgs/commit/a0692d3b21b4da1f041839884195a33fbbd3c5e7) | `` systembus-notify: fix dbus connection failure ``                                                                  |
| [`7e8628d6`](https://github.com/NixOS/nixpkgs/commit/7e8628d67df46d9ec7a7db805d889d309a6c4e1a) | `` typos: 1.20.8 -> 1.20.9 ``                                                                                        |
| [`ae9a721a`](https://github.com/NixOS/nixpkgs/commit/ae9a721adad459a63bec2eadce83e4046c1f8dd0) | `` python312Packages.accuweather: format with nixfmt ``                                                              |
| [`656eeaf3`](https://github.com/NixOS/nixpkgs/commit/656eeaf39c31ebfabfbedb775e6c403803949e15) | `` python312Packages.accuweather: 2.1.1 -> 3.0.0 ``                                                                  |
| [`720e1671`](https://github.com/NixOS/nixpkgs/commit/720e16714e31017493cf5d5c36a33ef93ae5e658) | `` python312Packages.llama-index-vector-stores-qdrant: 0.2.0 -> 0.2.1 ``                                             |
| [`bde35fd1`](https://github.com/NixOS/nixpkgs/commit/bde35fd16167cf8275c0bba56a4444ba393d1027) | `` python312Packages.boto3-stubs: 1.34.84 -> 1.34.87 ``                                                              |
| [`98e085d3`](https://github.com/NixOS/nixpkgs/commit/98e085d3e79268346c56f2e8e2958e5ca863ff45) | `` python312Packages.botocore-stubs: 1.34.86 -> 1.34.87 ``                                                           |
| [`fa2abc11`](https://github.com/NixOS/nixpkgs/commit/fa2abc1163a61ccff01c86955280e38a804a847c) | `` cnspec: 10.12.2 -> 11.0.2 ``                                                                                      |
| [`b249f3e4`](https://github.com/NixOS/nixpkgs/commit/b249f3e4b5f7d5b08cddd0f6a826a8ef1d99b45d) | `` androidStudioPackages.canary: 2024.1.1.3 -> 2024.1.1.4 ``                                                         |
| [`444887d0`](https://github.com/NixOS/nixpkgs/commit/444887d0482f2f5ccbbb7cfb72d61a3d6120b16f) | `` python312Packages.aiounifi: format with nixfmt ``                                                                 |
| [`ca78e3d7`](https://github.com/NixOS/nixpkgs/commit/ca78e3d77f260000a9a7bd0a1d89b0bcdfa76636) | `` python312Packages.google-cloud-bigquery: format with nixfmt ``                                                    |
| [`1e4cdb9c`](https://github.com/NixOS/nixpkgs/commit/1e4cdb9c60d01f8e1317bbd9cf818d8868fdf6a6) | `` python312Packages.pyenphase: foramt with nixfmt ``                                                                |
| [`c979169d`](https://github.com/NixOS/nixpkgs/commit/c979169d1a4b7c6513038777db6ed0c0b0c695bf) | `` qt6.qtdeclarative: fixup build on darwin ``                                                                       |
| [`e2c4ab09`](https://github.com/NixOS/nixpkgs/commit/e2c4ab09c7356b27f5eb561824a65cad321205b4) | `` python3Packages.dask: fixup build by upstream patches ``                                                          |
| [`5a4dab63`](https://github.com/NixOS/nixpkgs/commit/5a4dab63f6a112bfba9dc10b1cf6a046c6d83eb6) | `` govc: 0.37.0 -> 0.37.1 ``                                                                                         |
| [`30628699`](https://github.com/NixOS/nixpkgs/commit/306286998967e995ca2b7c80a8eddc9fd4500716) | `` python312Packages.dirigera: 1.1.2 -> 1.1.4 ``                                                                     |
| [`1d984ce7`](https://github.com/NixOS/nixpkgs/commit/1d984ce7ce7e63fc3b45d76f10e1ce1471906cc9) | `` mycli: enable fixed test ``                                                                                       |
| [`dfb4a5f8`](https://github.com/NixOS/nixpkgs/commit/dfb4a5f8541c2ee2cd4a25f6841bc5375aa9da1c) | `` twilio-cli: 5.19.3 -> 5.19.4 ``                                                                                   |
| [`c8cd170f`](https://github.com/NixOS/nixpkgs/commit/c8cd170f9c8cffa5635484dd784c44d82316f815) | `` python312Packages.argilla: 1.26.1 -> 1.27.0 ``                                                                    |
| [`d1a750bc`](https://github.com/NixOS/nixpkgs/commit/d1a750bcf7aceba31c3c166fbbe349b8ab524b05) | `` python312Packages.pyenphase: 1.20.1 -> 1.20.2 ``                                                                  |
| [`545aaee0`](https://github.com/NixOS/nixpkgs/commit/545aaee07d6770576e04d398519c9e50dff910d1) | `` python312Packages.google-cloud-bigquery: 3.20.1 -> 3.21.0 ``                                                      |
| [`cd8d2a36`](https://github.com/NixOS/nixpkgs/commit/cd8d2a3674d4f9be350e5ecbb8afae38b4049a90) | `` python312Packages.scikit-hep-testdata: 0.4.43 -> 0.4.44 ``                                                        |
| [`d0e24b16`](https://github.com/NixOS/nixpkgs/commit/d0e24b1602b1bc94dd5d0b3ba151203d10562deb) | `` python312Packages.aiounifi: 74 -> 75 ``                                                                           |
| [`b85de5d0`](https://github.com/NixOS/nixpkgs/commit/b85de5d0af75e0af91bb55896ab2dc273cde97a8) | `` python312Packages.green: 4.0.1 -> 4.0.2 ``                                                                        |
| [`cbebf81e`](https://github.com/NixOS/nixpkgs/commit/cbebf81e3a4fcf2bacc8b42b90600d7f2a05b720) | `` python312Packages.jupyter-server-fileid: 0.9.1 -> 0.9.2 ``                                                        |
| [`4ce3d2bf`](https://github.com/NixOS/nixpkgs/commit/4ce3d2bf5c34c51bdeee4072621e600210b0078f) | `` python312Packages.itemdb: 1.1.2 -> 1.2.0 ``                                                                       |
| [`8ab90c1c`](https://github.com/NixOS/nixpkgs/commit/8ab90c1cfab7bdb9034d42844830ba4964e2170c) | `` gqrx: 2.17.4 -> 2.17.5 ``                                                                                         |
| [`2408cfef`](https://github.com/NixOS/nixpkgs/commit/2408cfefbb593078e9f7fb4892da417e59854307) | `` maintainers: add willbush ``                                                                                      |
| [`10f4cecd`](https://github.com/NixOS/nixpkgs/commit/10f4cecd5e857f771e995a88c176526599301f08) | `` credhub-cli: 2.9.28 -> 2.9.29 ``                                                                                  |
| [`e6dabc58`](https://github.com/NixOS/nixpkgs/commit/e6dabc58c240276c3f09919b1673dc2b9737e36f) | `` uxn: unstable-2024-04-05 -> unstable-2024-04-15 ``                                                                |
| [`6f21d492`](https://github.com/NixOS/nixpkgs/commit/6f21d49225d529820625097ab98623e751d60b0d) | `` python311Packages.argilla: 1.26.1 -> 1.27.0 ``                                                                    |
| [`0793aedf`](https://github.com/NixOS/nixpkgs/commit/0793aedfe330c7cca912ad3dafd3b183d132172b) | `` python311Packages.ipyvue: 1.10.2 -> 1.11.0 ``                                                                     |
| [`e272e524`](https://github.com/NixOS/nixpkgs/commit/e272e5246afbd2fbb141b481eb5fd8db0966b630) | `` thunderbird-unwrapped: 115.9.0 -> 115.10.1 ``                                                                     |
| [`ef5bb98a`](https://github.com/NixOS/nixpkgs/commit/ef5bb98a93deb35e96474d7be07954a8a38c8039) | `` anilibria-winmaclinux: 1.2.16.1 -> 1.2.16.2 ``                                                                    |
| [`cc11e4aa`](https://github.com/NixOS/nixpkgs/commit/cc11e4aa72d3d1c8df9ff382966815d10bf9bbaf) | `` forgejo: 1.21.10-0 -> 1.21.11-0 ``                                                                                |
| [`e4a22a6d`](https://github.com/NixOS/nixpkgs/commit/e4a22a6d7a1cad3d21180a06b57e62058dad2fec) | `` hypridle: 0.1.1 -> 0.1.2 ``                                                                                       |
| [`4ff0c0ad`](https://github.com/NixOS/nixpkgs/commit/4ff0c0ad57d9eb9c4ba3043852197b5e44552953) | `` graalvmCEPackages.graalpy: 24.0.0 -> 24.0.1 ``                                                                    |
| [`1385946a`](https://github.com/NixOS/nixpkgs/commit/1385946a930b9887ad5495687d1ad7b9573b52b7) | `` knot-resolver: 5.7.1 -> 5.7.2 ``                                                                                  |
| [`90ace408`](https://github.com/NixOS/nixpkgs/commit/90ace408299576948f20a0e27f6910ec669940ad) | `` vscode-extensions.ms-python.vscode-pylance: switch to pyright package ``                                          |
| [`3d95a24d`](https://github.com/NixOS/nixpkgs/commit/3d95a24d44c3c583f59b719e6d8ac8263caaabd9) | `` pyright: repackage using buildNpmPackage ``                                                                       |
| [`3610489c`](https://github.com/NixOS/nixpkgs/commit/3610489cd2578b6cd598611695fa00f9a7e67164) | `` vimPlugins.gitignore-nvim: init at 2024-03-25 ``                                                                  |
| [`63f44f17`](https://github.com/NixOS/nixpkgs/commit/63f44f177df8f54ec70b1d5d3ada0c253ab95957) | `` rippkgs: init at 1.1.0 ``                                                                                         |
| [`20a4c15b`](https://github.com/NixOS/nixpkgs/commit/20a4c15bcf56f85f0f0b9d2da0820a178137b0d6) | `` nom: 2.1.6 -> 2.2.1 ``                                                                                            |
| [`5e8f10fe`](https://github.com/NixOS/nixpkgs/commit/5e8f10fe93d90b267dac446a6f06332228b4dc66) | `` expand-response-params: add description ``                                                                        |
| [`7be562d0`](https://github.com/NixOS/nixpkgs/commit/7be562d046bf8e3b74c325443f0fef4c74f76767) | `` wrapCC, wrapBintools: move expand-response-params bootstrapping out ``                                            |
| [`b2a56890`](https://github.com/NixOS/nixpkgs/commit/b2a568906aff1fe54b65e78b0a1a216247840734) | `` wrapCC, wrapBintools: use runtimeShell instead of stdenv shell ``                                                 |
| [`933b3f9a`](https://github.com/NixOS/nixpkgs/commit/933b3f9a0f76ee55c373b23fd3f091d0899d50b4) | `` api-linter: 1.65.0 -> 1.65.1 ``                                                                                   |
| [`3e45f8c0`](https://github.com/NixOS/nixpkgs/commit/3e45f8c0e6615d64cf0ae24bf8db6ac8032d6551) | `` cargo-show-asm: 0.2.31 -> 0.2.32 ``                                                                               |
| [`2e37446a`](https://github.com/NixOS/nixpkgs/commit/2e37446ac85067fb363f73fbab3b398f9d07220c) | `` nomore403: init at 1.0.1 ``                                                                                       |
| [`2817a4e0`](https://github.com/NixOS/nixpkgs/commit/2817a4e0da67b97b0a61bbfb5b3d5fc3f520b07b) | `` electron_source: add yayayayaka to maintainers ``                                                                 |
| [`101d7ae0`](https://github.com/NixOS/nixpkgs/commit/101d7ae0be058b7c40bc65ac4474468c8341152d) | `` electron_28-bin: 28.3.0 -> 28.3.1 ``                                                                              |
| [`0b00f7a2`](https://github.com/NixOS/nixpkgs/commit/0b00f7a2e69221896b9306d8bd96650d22502d6c) | `` electron_27-bin: 27.3.10 -> 27.3.11 ``                                                                            |
| [`0eefb442`](https://github.com/NixOS/nixpkgs/commit/0eefb442b4074dc68c78af01177a33f3d3a5510c) | `` electron-source.electron_28: 28.3.0 -> 28.3.1 ``                                                                  |
| [`e4b0bd36`](https://github.com/NixOS/nixpkgs/commit/e4b0bd3686a9b3a6f1b1dd803d063e75d596d79c) | `` electron-source.electron_27: 27.3.10 -> 27.3.11 ``                                                                |
| [`fe0775e2`](https://github.com/NixOS/nixpkgs/commit/fe0775e2978ade5f73251ab54fa34afa83fefff9) | `` snapcraft: init at 8.2.0 ``                                                                                       |
| [`22f79c94`](https://github.com/NixOS/nixpkgs/commit/22f79c94f78baa86c25362a7b0fde5120a65577c) | `` python311Packages.xmlschema: 3.2.1 -> 3.3.0 ``                                                                    |
| [`645630a4`](https://github.com/NixOS/nixpkgs/commit/645630a4dc1bc15913901a5771b9223f5b521661) | `` symfony-cli: 5.8.14 -> 5.8.15 ``                                                                                  |
| [`48fae187`](https://github.com/NixOS/nixpkgs/commit/48fae187c78e1da2ba5b57aac515310aeff37542) | `` quarkus: 3.9.3 -> 3.9.4 ``                                                                                        |
| [`7de6e523`](https://github.com/NixOS/nixpkgs/commit/7de6e523c1249a3bd4b80342374b059e5b53cd7e) | `` gtfocli: init at 0.0.4 ``                                                                                         |
| [`fb10ea41`](https://github.com/NixOS/nixpkgs/commit/fb10ea41b2a080cb4ecac34aa12cf056d8d3f90e) | `` chromium: fix `--ozone-platform-hint` flag on wayland ``                                                          |
| [`3cbd3952`](https://github.com/NixOS/nixpkgs/commit/3cbd3952c92fdb0d1963178125c18fbd79aa14ab) | `` katawa-shoujo-re-engineered: init at 1.4.4 ``                                                                     |
| [`a9c1e0b9`](https://github.com/NixOS/nixpkgs/commit/a9c1e0b9906b00d66bdd2056153e5ba0a0d067d5) | `` python3Packages.craft-providers: update snap injection patch to use beta for all crafts ``                        |
| [`65251f10`](https://github.com/NixOS/nixpkgs/commit/65251f102d3fd62cf267f592e09acf0ac0a31a1e) | `` nixos/podgrab: add 'dataDirectory' option ``                                                                      |
| [`2e1e5b9b`](https://github.com/NixOS/nixpkgs/commit/2e1e5b9b6b6e5b0336fff6c5312e7afcfcee1f8e) | `` python311Packages.trimesh: 4.3.0 -> 4.3.1 ``                                                                      |
| [`62ecfbc3`](https://github.com/NixOS/nixpkgs/commit/62ecfbc3328cacbf0be2c5a7707ee00ce816e5f8) | `` python312Packages.unearth: 0.15.1 -> 0.15.2 ``                                                                    |
| [`bc91f07f`](https://github.com/NixOS/nixpkgs/commit/bc91f07f9b075bbcbe7c66309822189394e967b3) | `` python3Packages.craft-application: init at 2.5.0 ``                                                               |
| [`6208368a`](https://github.com/NixOS/nixpkgs/commit/6208368a822cf27adfc7b743e3be6d96ebe91095) | `` cudaPackages.cudaFlags: drop unused cmakeCudaArchitectures attribute ``                                           |
| [`7a66dcf8`](https://github.com/NixOS/nixpkgs/commit/7a66dcf83f948c506472dec40f73330c4a9a37d1) | `` cuda-modules: use stdenv instead of backendStdenv for *Platform access ``                                         |
| [`843b91a0`](https://github.com/NixOS/nixpkgs/commit/843b91a0eee065972051c4be0945dd0ad8c628d3) | `` cuda-modules/cuda/overrides: refactor ``                                                                          |
| [`d5cbe889`](https://github.com/NixOS/nixpkgs/commit/d5cbe889f0476c97a7acfd8826ba0e7b88319205) | `` cuda-modules/generic-builders/manifest: add to brokenConditions, simplify src, break out comments in postPatch `` |
| [`0494330f`](https://github.com/NixOS/nixpkgs/commit/0494330fad2dde171bbb3f09795e4e6347f50ed8) | `` cudaPackages.nccl: switch to cudaAtLeast, cudaOlder, and __structuredAttrs ``                                     |
| [`5ed9f23d`](https://github.com/NixOS/nixpkgs/commit/5ed9f23d218223ce5ea280e43bdcf6739d8ace07) | `` cudaPackages.saxpy: switch to cudaAtLeast, cudaOlder, __structuredAttrs, and enable on Jetson post-11.4 ``        |
| [`e77b24b1`](https://github.com/NixOS/nixpkgs/commit/e77b24b15926bf690a6e69d2fb805edce0f4f4b1) | `` cudaPackages.flags: add cmakeCudaArchitectures and cmakeCudaArchitecturesString ``                                |
| [`5ee7bfc4`](https://github.com/NixOS/nixpkgs/commit/5ee7bfc443cc021354e020a3a2dc352227500f0e) | `` cudaPackages.setupCudaHook: fix error when reading empty marker ``                                                |
| [`02966afc`](https://github.com/NixOS/nixpkgs/commit/02966afc5481730c3ff8e09cb2c7a79d96b63be0) | `` cudaPackages.setupCudaHook: always set return explicitly ``                                                       |
| [`a31b0d7f`](https://github.com/NixOS/nixpkgs/commit/a31b0d7f95292293b4cddfc381c9242895c53c18) | `` cudaPackages.setupCudaHook: sourcing messages should match hook name ``                                           |
| [`9230c2cc`](https://github.com/NixOS/nixpkgs/commit/9230c2cc8d9b98f302fda10436b08185f5cb9eea) | `` cudaPackages.markForCudatoolkitRootHook: fix bug with strictDeps ``                                               |
| [`7a497b6f`](https://github.com/NixOS/nixpkgs/commit/7a497b6faabd952974c2fc030ce7fd37a2ce17d6) | `` python312Packages.fastapi-sso: 0.14.0 -> 0.14.2 ``                                                                |
| [`e99e4031`](https://github.com/NixOS/nixpkgs/commit/e99e4031880626da69a342e7ebe452fac4005294) | `` step-kms-plugin: 0.11.0 -> 0.11.1 ``                                                                              |
| [`e3de724a`](https://github.com/NixOS/nixpkgs/commit/e3de724ae87e19d9a8e1ce8876f1cece22e7831f) | `` python311Packages.uuid: remove ``                                                                                 |
| [`09cd7736`](https://github.com/NixOS/nixpkgs/commit/09cd7736d3a3ddbdbd3e150b1122325f60e98230) | `` python312Packages.proxy-py: 2.4.3 -> 2.4.4rc5 ``                                                                  |
| [`0e37b071`](https://github.com/NixOS/nixpkgs/commit/0e37b071387c33e8180985107340925f637b8cdf) | `` python312Packages.aiozeroconf: format with nixfmt ``                                                              |
| [`24cd8745`](https://github.com/NixOS/nixpkgs/commit/24cd8745c68537c5f0427e7b1eba95da723ea746) | `` python312Packages.aiozeroconf: refactor ``                                                                        |
| [`f994a55a`](https://github.com/NixOS/nixpkgs/commit/f994a55afeb54860e2b017429d3bec0ba4054b9b) | `` python312Packages.twilio: 9.0.4 -> 9.0.5 ``                                                                       |
| [`269218ec`](https://github.com/NixOS/nixpkgs/commit/269218ecffa87b3263784f7395a9eb66d4d32595) | `` python311Packages.itemloaders: refactor ``                                                                        |
| [`2cdb1a4b`](https://github.com/NixOS/nixpkgs/commit/2cdb1a4bc0ef087b807b2a06d7be6562fe885c8d) | `` python312Packages.itemloaders: 1.1.0 -> 1.2.0 ``                                                                  |
| [`4130313a`](https://github.com/NixOS/nixpkgs/commit/4130313acf7d50ed9fb4f35af13be10e551028b8) | `` nezha-agent: 0.16.4 -> 0.16.5 ``                                                                                  |
| [`3589873e`](https://github.com/NixOS/nixpkgs/commit/3589873e865f8711d29fc762e81f0ed56773b36d) | `` python3Packages.catkin-pkg: init at 0.5.2 ``                                                                      |
| [`ac694ae6`](https://github.com/NixOS/nixpkgs/commit/ac694ae6287906e091c9a3c2e815bcab8664effc) | `` python3Packages.python-apt: init at 2.7.6 ``                                                                      |
| [`4b51440d`](https://github.com/NixOS/nixpkgs/commit/4b51440d35801910e63fb1edb1465ea2b0e9c47d) | `` d2: 0.6.4 -> 0.6.5 ``                                                                                             |
| [`adaa6b74`](https://github.com/NixOS/nixpkgs/commit/adaa6b740ac1765eb67022bc850d389e9d0e5bdf) | `` ncspot: Adjust defaults to upstream ``                                                                            |
| [`06ccdd64`](https://github.com/NixOS/nixpkgs/commit/06ccdd64827dd973bfad0861bd9e3f968ce508ef) | `` home-assistant-custom-components.xiaomi_gateway3: init at 4.0.3 ``                                                |
| [`19777c0e`](https://github.com/NixOS/nixpkgs/commit/19777c0e96abfdfd189cd38409dfcb4c68d1379a) | `` python312Packages.uarray: 0.8.2 -> 0.8.8 ``                                                                       |
| [`8649937b`](https://github.com/NixOS/nixpkgs/commit/8649937b9c92c4da71251402fcabf320b18dca18) | `` btcpayserver: 1.12.5 -> 1.13.1 ``                                                                                 |
| [`6fa33939`](https://github.com/NixOS/nixpkgs/commit/6fa3393982447737ddd20e7f731eee3b93e19b1e) | `` nbxplorer: 2.5.0 -> 2.5.2 ``                                                                                      |
| [`84871db1`](https://github.com/NixOS/nixpkgs/commit/84871db15f87707aa564b458bd4099f38f9987ed) | `` python312Packages.yowsup: unbreak with missing pyasyncore ``                                                      |
| [`8541bf74`](https://github.com/NixOS/nixpkgs/commit/8541bf74864d83dd6d5af74c5449c12679fd5291) | `` python312Packages.matchpy: unbreak ``                                                                             |
| [`40b1df81`](https://github.com/NixOS/nixpkgs/commit/40b1df814015362a5d86832a56dd4c3505ef088b) | `` ceph: pin to cython_0 (#302358) ``                                                                                |
| [`af731570`](https://github.com/NixOS/nixpkgs/commit/af731570c8dee8705cc98ae1933ed12dbf39d9e3) | `` python312Packages.consonance: unbreak ``                                                                          |
| [`311aa96d`](https://github.com/NixOS/nixpkgs/commit/311aa96d8ad41c966e7e4909a91ddad81f8cafb3) | `` mcap-cli: 0.0.42 -> 0.0.43 ``                                                                                     |
| [`1df46edd`](https://github.com/NixOS/nixpkgs/commit/1df46edda35ae7ddad2d06b333a7816e636f48c6) | `` proton-ge-bin: GE-Proton9-2 -> GE-Proton9-4 ``                                                                    |
| [`93a10e1b`](https://github.com/NixOS/nixpkgs/commit/93a10e1b2d0282ae9b2c2203ce38b9fb2845010a) | `` phpPackages.opentelemetry: fix builds on Darwin ``                                                                |