### PR TITLE
chore(flake/spicetify-nix): `c087ebcc` -> `43adac8c`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1555,11 +1555,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713413457,
-        "narHash": "sha256-irhOcCubT8u1leCJHlyYmS+ay8D2ctlpJB++/aM5n0k=",
+        "lastModified": 1713499829,
+        "narHash": "sha256-fJsqV5L/mGbKb/ih0iJGpovay43NNglKhjqdGS+7oOQ=",
         "owner": "gerg-l",
         "repo": "spicetify-nix",
-        "rev": "c087ebccf75e3db5b902b574304b39103c75f8d2",
+        "rev": "43adac8c911bb335f51ea2698f3a24c73c28ca36",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                | Message                           |
| ----------------------------------------------------------------------------------------------------- | --------------------------------- |
| [`43adac8c`](https://github.com/Gerg-L/spicetify-nix/commit/43adac8c911bb335f51ea2698f3a24c73c28ca36) | `` CI update 2024-04-19 (#136) `` |