### PR TITLE
chore(flake/emacs-overlay): `c5caaf3b` -> `9fa2385d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -227,11 +227,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1713546495,
-        "narHash": "sha256-5I/Nn0ibs16JVU5xLEjPx3AXBQxs86wxrJOWH8iVHTg=",
+        "lastModified": 1713718371,
+        "narHash": "sha256-lhQ7VDJXfo/tEvKlsQz4Uz0M53t1TTcxwRiUBXn7Pbs=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c5caaf3b6d4f711e5a408ada4dc4c36537a18372",
+        "rev": "9fa2385df7c4d8ccf8727b74f2edccc1dea7a914",
         "type": "github"
       },
       "original": {
@@ -1256,11 +1256,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1713344939,
-        "narHash": "sha256-jpHkAt0sG2/J7ueKnG7VvLLkBYUMQbXQ2L8OBpVG53s=",
+        "lastModified": 1713564160,
+        "narHash": "sha256-YguPZpiejgzLEcO36/SZULjJQ55iWcjAmf3lYiyV1Fo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e402c3eb6d88384ca6c52ef1c53e61bdc9b84ddd",
+        "rev": "bc194f70731cc5d2b046a6c1b3b15f170f05999c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                       | Message                    |
| ------------------------------------------------------------------------------------------------------------ | -------------------------- |
| [`9fa2385d`](https://github.com/nix-community/emacs-overlay/commit/9fa2385df7c4d8ccf8727b74f2edccc1dea7a914) | `` Updated melpa ``        |
| [`89247aa1`](https://github.com/nix-community/emacs-overlay/commit/89247aa1a7d6d113c859f2f3b2e6674066369aa1) | `` Updated elpa ``         |
| [`c663a0f8`](https://github.com/nix-community/emacs-overlay/commit/c663a0f86514516f717479075a07b31f93f31e75) | `` Updated melpa ``        |
| [`a9c6d1dc`](https://github.com/nix-community/emacs-overlay/commit/a9c6d1dc8ddcf32d9e67ea95761aac0f3f34b4cc) | `` Updated emacs ``        |
| [`e4ee7be8`](https://github.com/nix-community/emacs-overlay/commit/e4ee7be879a0300b414d5565602a8b70d38c3467) | `` Updated melpa ``        |
| [`0313ac9c`](https://github.com/nix-community/emacs-overlay/commit/0313ac9c196ba3a90566b72666a5220b2a841b71) | `` Updated elpa ``         |
| [`1bfe488b`](https://github.com/nix-community/emacs-overlay/commit/1bfe488b3692880609a32576ab47bd3911b2fa00) | `` Updated nongnu ``       |
| [`5ca32142`](https://github.com/nix-community/emacs-overlay/commit/5ca321429707401c358ca92d3a11615904591ac9) | `` Updated flake inputs `` |
| [`557a6976`](https://github.com/nix-community/emacs-overlay/commit/557a69764e1aeb16c3d0f7d53ff4c3001a4ccafc) | `` Updated emacs ``        |
| [`832a762e`](https://github.com/nix-community/emacs-overlay/commit/832a762e2789007887ab0720a14bbd03e6798f03) | `` Updated melpa ``        |
| [`7028dd82`](https://github.com/nix-community/emacs-overlay/commit/7028dd8249bb1306dfb7250d70bd9333dd056401) | `` Updated elpa ``         |
| [`98442aa3`](https://github.com/nix-community/emacs-overlay/commit/98442aa32bbe5f20c0065d9c81257cfe79959972) | `` Updated emacs ``        |
| [`917a11da`](https://github.com/nix-community/emacs-overlay/commit/917a11da8f010b4881d654967214a536b6cab2ba) | `` Updated melpa ``        |
| [`ddb89e84`](https://github.com/nix-community/emacs-overlay/commit/ddb89e842095c88b82b5334e0c87bde1875e7e01) | `` Updated flake inputs `` |
| [`9ba8ea91`](https://github.com/nix-community/emacs-overlay/commit/9ba8ea91b7d79baf8ced9723abc06d0217acace5) | `` Updated emacs ``        |
| [`250ff243`](https://github.com/nix-community/emacs-overlay/commit/250ff24376059a1495058985c229e0c71cd46c1d) | `` Updated melpa ``        |
| [`545b3e14`](https://github.com/nix-community/emacs-overlay/commit/545b3e143fad7f7da693e708f65718e03d1c3646) | `` Updated elpa ``         |