### PR TITLE
chore(flake/nix-index-database): `93aed672` -> `07ece11b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -976,11 +976,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713067146,
-        "narHash": "sha256-9D20xjblGKEVRVCnM3qWhiizEa9i6OpK6xQJajwcwOQ=",
+        "lastModified": 1713668931,
+        "narHash": "sha256-rVlwWQlgFGGK3aPVcKmtYqWgjYnPah5FOIsYAqrMN2w=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "93aed67288be60c9ef6133ba2f8de128f4ef265c",
+        "rev": "07ece11b22217b8459df589f858e92212b74f1a1",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                            | Message                                                |
| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
| [`07ece11b`](https://github.com/nix-community/nix-index-database/commit/07ece11b22217b8459df589f858e92212b74f1a1) | `` update packages.nix to release 2024-04-21-030753 `` |
| [`be659309`](https://github.com/nix-community/nix-index-database/commit/be6593097ad7635defd5e08560cf9952b75f0046) | `` flake.lock: Update ``                               |