### PR TITLE
chore(flake/sops-nix): `a929a011` -> `09f1bc8b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1535,11 +1535,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713532771,
-        "narHash": "sha256-vfKxhYVMzG2tg48/1rewBoSLCrKIjQsG1j7Nm/Y2gf4=",
+        "lastModified": 1713668495,
+        "narHash": "sha256-4BvlfPfyUmB1U0r/oOF6jGEW/pG59c5yv6PJwgucTNM=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "a929a011a09db735abc45a8a45d1ff7fdee62755",
+        "rev": "09f1bc8ba3277c0f052f7887ec92721501541938",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                          | Message                  |
| ----------------------------------------------------------------------------------------------- | ------------------------ |
| [`09f1bc8b`](https://github.com/Mic92/sops-nix/commit/09f1bc8ba3277c0f052f7887ec92721501541938) | `` flake.lock: Update `` |