### PR TITLE
chore(flake/home-manager): `938357cb` -> `2846d523`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -630,11 +630,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1713547559,
-        "narHash": "sha256-zju60y4pyYQoRmqhbgkw+jwmKZReVsCNvb8mZxID2Do=",
+        "lastModified": 1713713092,
+        "narHash": "sha256-rvyr6BBtn3cq5B/48rhJlbIOpxprwlO/71663sd9Gik=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "938357cb234e85da37109df2cdd9cc59ab9c1cc0",
+        "rev": "2846d5230a3c3923618eabb367deaf8885df580f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                      | Message                                       |
| ----------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
| [`2846d523`](https://github.com/nix-community/home-manager/commit/2846d5230a3c3923618eabb367deaf8885df580f) | `` joplin-desktop: allow undefined options `` |
| [`ad83c154`](https://github.com/nix-community/home-manager/commit/ad83c154bdfedad9807e86dd0633729ea3b116c5) | `` qt: fix `qt.platformTheme = "gtk3"` ``     |
| [`147b5a5e`](https://github.com/nix-community/home-manager/commit/147b5a5e1c04e1f27e30b6df720966422fb4bc09) | `` qt: fix platform theme package install ``  |
| [`4cec20db`](https://github.com/nix-community/home-manager/commit/4cec20dbf5c0a716115745ae32531e34816ecbbe) | `` flake.lock: Update ``                      |
| [`057117a4`](https://github.com/nix-community/home-manager/commit/057117a401a34259c9615ce62218aea7afdee4d3) | `` kdeconnect: fix "tray.target" requires ``  |
| [`a2040822`](https://github.com/nix-community/home-manager/commit/a20408227466032a16e73893b09a67092258cf67) | `` firefox: fix test ``                       |
| [`3a435342`](https://github.com/nix-community/home-manager/commit/3a435342e2e5e2bff1d3331c2bd9e70f25693ea2) | `` sway: check config file validity ``        |
| [`95888b15`](https://github.com/nix-community/home-manager/commit/95888b153c24c36971c4b4b66beecf32593064fb) | `` sway: writeText -> writeTextFile ``        |
| [`7c61e400`](https://github.com/nix-community/home-manager/commit/7c61e400a99f33cdff3118c1e4032bcb049e1a30) | `` Translate using Weblate (Turkish) ``       |
| [`991f6faf`](https://github.com/nix-community/home-manager/commit/991f6fafce729e6d7d64107a66e445114194b778) | `` Translate using Weblate (Portuguese) ``    |
| [`5682ccdc`](https://github.com/nix-community/home-manager/commit/5682ccdcaf72aef74be97e4b683545a9de27c386) | `` Translate using Weblate (Spanish) ``       |