### PR TITLE
chore(flake/nixpkgs-unstable): `739cfd4a` -> `a8a8401b`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1304,11 +1304,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1713537052,
-        "narHash": "sha256-yA9GasPETw3HGv9w9MbdSnwaLCPFQAuzN+6uDLeEILA=",
+        "lastModified": 1713689773,
+        "narHash": "sha256-4M4c9n6sYbT7Sd/RvB9pej+7BoP7X1lNrFiboNV4O7I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "739cfd4a6f2d4ca6a86304578ef5578cae8d1924",
+        "rev": "a8a8401b7b26112a9b75d6c00306e160fe8f8cb3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`a8a8401b`](https://github.com/NixOS/nixpkgs/commit/a8a8401b7b26112a9b75d6c00306e160fe8f8cb3) | `` vlc-bittorrent: fix version ``                                                       |
| [`eaf5ec98`](https://github.com/NixOS/nixpkgs/commit/eaf5ec98fe5bd102e1ec6b64df192e4fba6d6a32) | `` fetchurl: add codemirror.dlang.org to the list of dub mirrors ``                     |
| [`f30d13d0`](https://github.com/NixOS/nixpkgs/commit/f30d13d04a3648d0e44a5e1543aa4d1c735dceac) | `` phpPackages.composer: 2.7.2 -> 2.7.3 ``                                              |
| [`23e8ad4c`](https://github.com/NixOS/nixpkgs/commit/23e8ad4cee19b21dad3f29944ad8186897f8ff25) | `` cakelisp: 0.3.0-unstable-2024-04-01 -> 0.3.0-unstable-2024-04-18 ``                  |
| [`26b947c9`](https://github.com/NixOS/nixpkgs/commit/26b947c9bcc312464b547ba68acaecf57398bafd) | `` limine: mark as broken on darwin ``                                                  |
| [`5fb27020`](https://github.com/NixOS/nixpkgs/commit/5fb270209755688cf9f5c6e44fa3d9420c07a21f) | `` maa-assistant-arknights: 5.2.0 -> 5.2.1 ``                                           |
| [`45118883`](https://github.com/NixOS/nixpkgs/commit/451188832a2f29830c695d85fb52100fc283a703) | `` python311Packages.txtai: 7.0.0 -> 7.1.0 ``                                           |
| [`d6848122`](https://github.com/NixOS/nixpkgs/commit/d68481224a09ce13d43305f60f15fc745e087639) | `` nixos/release-small: fix eval ``                                                     |
| [`e12029c3`](https://github.com/NixOS/nixpkgs/commit/e12029c3049265cb52126adf9eba0de96d36fa3b) | `` home-assistant-custom-components.miele: 0.1.19 -> 2024.3.0 ``                        |
| [`5b65a57e`](https://github.com/NixOS/nixpkgs/commit/5b65a57ea08215a7c62d837baf5c22553fc2891b) | `` forgejo: 1.21.11-0 -> 1.21.11-1 ``                                                   |
| [`864095a7`](https://github.com/NixOS/nixpkgs/commit/864095a7a00eaeb0e13a95ac93ba1ac278ec2aa7) | `` vscode-extensions.adzero.vscode-sievehighlight: init 1.0.6 ``                        |
| [`9b45c0c6`](https://github.com/NixOS/nixpkgs/commit/9b45c0c6593f37ef3899a3ceaacf1e3df4556d1e) | `` Revert "ovftool: init at 4.6.2 for x86_64-darwin" ``                                 |
| [`c64f61e4`](https://github.com/NixOS/nixpkgs/commit/c64f61e478b237f2f903d9e2596baa67cfa19ad9) | `` systemctl-tui: 0.2.4 -> 0.3.3 ``                                                     |
| [`0f5cb6b7`](https://github.com/NixOS/nixpkgs/commit/0f5cb6b70294c52e643d0ca099b35308563a2674) | `` deconz: 2.23.00 -> 2.26.3 ``                                                         |
| [`c7ab550b`](https://github.com/NixOS/nixpkgs/commit/c7ab550bbc7fede3c00b20392ad712d3daee5acb) | `` nixos/deconz: fix curl redirect option in postStart ``                               |
| [`07b7ca83`](https://github.com/NixOS/nixpkgs/commit/07b7ca8345611c1e46fde38ae40397737e4695d7) | `` avrdude: use finalAttrs instead of rec ``                                            |
| [`55ddcaf7`](https://github.com/NixOS/nixpkgs/commit/55ddcaf70d70bf287a916624db2bbb5bb41c011a) | `` avrdude: use either vendored libelf or elfutils instead of abandoned upstream ``     |
| [`4f05b69e`](https://github.com/NixOS/nixpkgs/commit/4f05b69ed5f2d4b0c2773adaa999d0e7008dd1b8) | `` adminerevo: init at 4.8.6 ``                                                         |
| [`605be9e6`](https://github.com/NixOS/nixpkgs/commit/605be9e6dafc8170a940255b6ab740f1b27c7177) | `` mystmd: 1.1.53 -> 1.1.55 ``                                                          |
| [`f2248104`](https://github.com/NixOS/nixpkgs/commit/f22481048d64837f0ea85d607da711648d2e4e3b) | `` niri: 0.1.4 -> 0.1.5 ``                                                              |
| [`d9feb2e9`](https://github.com/NixOS/nixpkgs/commit/d9feb2e9baba5bc136e348c2cc3a80d97eb6726c) | `` podman: fix darwin support ``                                                        |
| [`7b965f54`](https://github.com/NixOS/nixpkgs/commit/7b965f54001bfc20cb88d278cb5520d8dc19deff) | `` _64gram: 1.1.18 -> 1.1.19 ``                                                         |
| [`ff8eddac`](https://github.com/NixOS/nixpkgs/commit/ff8eddacb1617625ccf5d7f10a1e1b606e8161df) | `` biglybt: init at 3.5.0.0 ``                                                          |
| [`2268cf93`](https://github.com/NixOS/nixpkgs/commit/2268cf93d4de6fcd53f008da2a7d2bdfa871f72e) | `` coder: add support for mainline channel ``                                           |
| [`f94aaf84`](https://github.com/NixOS/nixpkgs/commit/f94aaf8483cb2c8424263dfd4bad68b077bf94bf) | `` trust-dns: fix hash ``                                                               |
| [`ac01eef7`](https://github.com/NixOS/nixpkgs/commit/ac01eef7b19a8bdd22ef72ce4762bb0bf4e053a5) | `` v8: unpin llvmPackages_15.stdenv on darwin ``                                        |
| [`4b116b8f`](https://github.com/NixOS/nixpkgs/commit/4b116b8ff393d8c04c76f068564886700f3f8157) | `` ockam: fix hash, cleanup ``                                                          |
| [`fc7d8b34`](https://github.com/NixOS/nixpkgs/commit/fc7d8b347a6d3deb8dd765e8bc026cdcaf0eed1f) | `` pymeshlab: init at 2023.12 ``                                                        |
| [`74900367`](https://github.com/NixOS/nixpkgs/commit/74900367e85e4d7560db2aaf12d5282afc0f12b0) | `` meshlab: 2022.02 -> 2023.12 ``                                                       |
| [`e71d969c`](https://github.com/NixOS/nixpkgs/commit/e71d969ca7d0c66e1fb5a4122f13cbbb680f9bf6) | `` structuresynth: init at 1.5.1 ``                                                     |
| [`df69ac58`](https://github.com/NixOS/nixpkgs/commit/df69ac58f030234a251edebe35efa625282a7dd0) | `` openctm: init at 1.0.3 ``                                                            |
| [`835c1cbf`](https://github.com/NixOS/nixpkgs/commit/835c1cbf108429ed017793ee6f76fed4e1cfbb1e) | `` corto: init at unstable-2023-06-27 ``                                                |
| [`e324e2ff`](https://github.com/NixOS/nixpkgs/commit/e324e2ff82584ad43f6da104371cb4dca81b2f8a) | `` vscode-extensions: format using nixfmt-rfc-style ``                                  |
| [`45f06b50`](https://github.com/NixOS/nixpkgs/commit/45f06b5037f25c239ab3173dc8afc2eb8b260de3) | `` feather: fix trezor support ``                                                       |
| [`d2bc1006`](https://github.com/NixOS/nixpkgs/commit/d2bc1006a686e51c3fcb9ecb65acaa5da80a5f83) | `` synology-drive-client: add aarch64-darwin support ``                                 |
| [`4e527ac3`](https://github.com/NixOS/nixpkgs/commit/4e527ac342440fe234e549d792f7a4f343b90fd2) | `` iosevka: 29.2.1 -> 29.2.1 ``                                                         |
| [`0c261992`](https://github.com/NixOS/nixpkgs/commit/0c261992cc222bece5261ed4fc3cbe5c5b437754) | `` add aarch64-linux (#305521) ``                                                       |
| [`5efa13b4`](https://github.com/NixOS/nixpkgs/commit/5efa13b4a40d236a3b39d82b60c250b82112c062) | `` nixci: 0.2.0 -> 0.4.0; fix Darwin build ``                                           |
| [`6ec76d93`](https://github.com/NixOS/nixpkgs/commit/6ec76d93988e9562b47497a7edc9a131e39de08a) | `` maintainers: add aktaboot ``                                                         |
| [`9ca7c79e`](https://github.com/NixOS/nixpkgs/commit/9ca7c79ed2cf8a223e1e9a8610c8157f765ddc6e) | `` dogedns: init at 0.2.6 ``                                                            |
| [`9c42b802`](https://github.com/NixOS/nixpkgs/commit/9c42b802baa35dd030e3272d25695a80f2045009) | `` podman-compose: 1.0.6 -> 1.1.0 ``                                                    |
| [`2c817408`](https://github.com/NixOS/nixpkgs/commit/2c817408905d7b32ee1cdf5a4aa0ec2b76b3b652) | `` zfs-replicate: 3.2.12 -> 3.2.13 ``                                                   |
| [`e145d5d7`](https://github.com/NixOS/nixpkgs/commit/e145d5d7802313345cabbc86d551818de4224def) | `` Revert "fw-ectool: unstable-2022-12-03 -> 0-unstable-2023-12-15, switch upstream" `` |
| [`96859836`](https://github.com/NixOS/nixpkgs/commit/96859836d473f25f80a37b63aae14de6d720426b) | `` python311Packages.qtile-extras: format with nixfmt ``                                |
| [`e8e5011c`](https://github.com/NixOS/nixpkgs/commit/e8e5011c6e48d090b728180a5473e22f81d74dec) | `` python311Packages.qtile-extras: refactor ``                                          |
| [`813b8e0c`](https://github.com/NixOS/nixpkgs/commit/813b8e0ca28aca5563455c6be33c839b85634dbb) | `` python312Packages.pulsectl-asyncio: format with nixfmt ``                            |
| [`6c4468c3`](https://github.com/NixOS/nixpkgs/commit/6c4468c349286c80d31565dec470d40ceb9de73a) | `` python312Packages.pulsectl-asyncio: refactor ``                                      |
| [`f5327525`](https://github.com/NixOS/nixpkgs/commit/f53275255816205647308941035787d65357dc32) | `` python312Packages.pulsectl-asyncio: 1.1.1 -> 1.2.0 ``                                |
| [`be74a1bf`](https://github.com/NixOS/nixpkgs/commit/be74a1bf4b3652fba2814597129eb76901e843f1) | `` mqttui: format with nixfmt ``                                                        |
| [`1c455ee3`](https://github.com/NixOS/nixpkgs/commit/1c455ee3ff94c0e6e2671b59662a21e805f537cf) | `` mqttui: 0.20.0 -> 0.21.0 ``                                                          |
| [`7ffbf20d`](https://github.com/NixOS/nixpkgs/commit/7ffbf20dc7513bd0835e1ba95794e399b535a7ba) | `` python311Packages.grpcio-reflection: 1.62.1 -> 1.62.2 ``                             |
| [`0c944c60`](https://github.com/NixOS/nixpkgs/commit/0c944c6029ef4f740f828bd213352e8239efdeb3) | `` exploitdb: 2024-04-16 -> 2024-04-20 ``                                               |
| [`6b765068`](https://github.com/NixOS/nixpkgs/commit/6b765068ab755951c0dc71cb9190f03ef34105cf) | `` sqlfluff: 3.0.4 -> 3.0.5 ``                                                          |
| [`76e51d33`](https://github.com/NixOS/nixpkgs/commit/76e51d33794dca939968e8fbd6c86ce93bfc38d6) | `` python312Packages.google-generativeai: 0.5.0 -> 0.5.2 ``                             |
| [`6539631a`](https://github.com/NixOS/nixpkgs/commit/6539631a844e225c1071e7d3e704a69355ae153b) | `` python312Packages.influxdb3-python: format with nixfmt ``                            |
| [`c1afabd2`](https://github.com/NixOS/nixpkgs/commit/c1afabd21d73928a48b1af762e35d6875baa25b3) | `` python312Packages.influxdb3-python: refactor ``                                      |
| [`78d0433e`](https://github.com/NixOS/nixpkgs/commit/78d0433e2dfa1b3d51154b27bf4a25313d0d0bba) | `` python312Packages.influxdb3-python: 0.3.6 -> 0.4.0 ``                                |
| [`4528b9e7`](https://github.com/NixOS/nixpkgs/commit/4528b9e725fbb44066943f9cc3328ae96402af51) | `` python312Packages.vt-py: format with nixfmt ``                                       |
| [`98cd7e3b`](https://github.com/NixOS/nixpkgs/commit/98cd7e3b552fe46012f7441a27994e408bff1012) | `` python312Packages.vt-py: 0.18.0 -> 0.18.1 ``                                         |
| [`20c26819`](https://github.com/NixOS/nixpkgs/commit/20c268192e403e2193f1398e7323fbbf55bda5b2) | `` python312Packages.vt-py: refactor ``                                                 |
| [`1fccf77f`](https://github.com/NixOS/nixpkgs/commit/1fccf77fdab6873ac8d19cd0f4ea11ef5cbc1d28) | `` markdown-anki-decks: refactor ``                                                     |
| [`9e38de65`](https://github.com/NixOS/nixpkgs/commit/9e38de653afc5f5db2599769822bd4568c20cefa) | `` shell-genie: refactor ``                                                             |
| [`af7a6507`](https://github.com/NixOS/nixpkgs/commit/af7a65070d866dfed5b42542bcb1ad7807bf9e53) | `` pwdsafety: format with nixfmt ``                                                     |
| [`4fb51d08`](https://github.com/NixOS/nixpkgs/commit/4fb51d082bfd75068231f8881219c9e6f23ad246) | `` pwdsafety: refactor ``                                                               |
| [`52166c45`](https://github.com/NixOS/nixpkgs/commit/52166c45cf0f17ddf7613e4d71bced66b3d6e050) | `` python3Package.pyowm: foramt with nixfmt ``                                          |
| [`1feeea57`](https://github.com/NixOS/nixpkgs/commit/1feeea57f4c41867c5367925ad2977c9e9bdaa14) | `` python312Package.pyowm: refactor ``                                                  |
| [`7423442c`](https://github.com/NixOS/nixpkgs/commit/7423442c1657976e2272c52cd680cd1448a3b7c1) | `` python312Packages.plugwise: format with nixfmt ``                                    |
| [`11f0a5ba`](https://github.com/NixOS/nixpkgs/commit/11f0a5ba2cdd1d99c62de8946f395a90f5ee413b) | `` keepwn: format with nixfmt ``                                                        |
| [`9f7f5d9b`](https://github.com/NixOS/nixpkgs/commit/9f7f5d9b6b5d6a9e9279f30abfcd1973245738f1) | `` keepwn: refactor ``                                                                  |
| [`063f6159`](https://github.com/NixOS/nixpkgs/commit/063f61598d3c056857f92ee1e52a504128626884) | `` uv: 0.1.34 -> 0.1.35 ``                                                              |
| [`e3ad273f`](https://github.com/NixOS/nixpkgs/commit/e3ad273ffbf063b917bcf42f8950a1dda1f0eb95) | `` python311Packages.pysolcast: format with nixfmt ``                                   |
| [`eee582a9`](https://github.com/NixOS/nixpkgs/commit/eee582a989d49c32ac2bc2cf3770b3572cbf4cfc) | `` python311Packages.pysolcast: refactor ``                                             |
| [`2f63bd94`](https://github.com/NixOS/nixpkgs/commit/2f63bd94494732b1b7b0704152e98e418d460e98) | `` libzim: format with nixfmt ``                                                        |
| [`2ab35f2a`](https://github.com/NixOS/nixpkgs/commit/2ab35f2aaf749d56a549f73377cdc3b140d7a228) | `` python312Packages.camel-converter: format with nixfmt ``                             |
| [`8a8f283a`](https://github.com/NixOS/nixpkgs/commit/8a8f283acd7af983d3c8cd17ed86315d56b83a95) | `` python312Packages.camel-converter: refactor ``                                       |
| [`f0fb9cc0`](https://github.com/NixOS/nixpkgs/commit/f0fb9cc0ffbd4dc73b62e8e3b202ae786b06ae9c) | `` python312Packages.apkinspector: enable tests ``                                      |
| [`6cec50ee`](https://github.com/NixOS/nixpkgs/commit/6cec50eeb0c85bf3720420e18331c7a7470fee48) | `` python312Packages.apkinspector: format with nixfmt ``                                |
| [`67da5a7e`](https://github.com/NixOS/nixpkgs/commit/67da5a7e3873fec968646b0ec470303a658c8899) | `` python312Packages.apkinspector: refactor ``                                          |
| [`5f7f17ab`](https://github.com/NixOS/nixpkgs/commit/5f7f17ab72b1ab04ed5cb900c8ab52840cf4b256) | `` oterm: 0.2.5 -> 0.2.6 ``                                                             |
| [`9dd93daa`](https://github.com/NixOS/nixpkgs/commit/9dd93daa2e2ad279728d0b6f786bc6d9073c747e) | `` python312Packages.llama-index-llms-openai: 0.1.15 -> 0.1.16 ``                       |
| [`d23806d0`](https://github.com/NixOS/nixpkgs/commit/d23806d0de52b630e81bc46378e74ed72135502e) | `` python312Packages.llama-index-embeddings-openai: 0.1.7 -> 0.1.8 ``                   |
| [`8c303e83`](https://github.com/NixOS/nixpkgs/commit/8c303e83c56a7e534d61ae6c852d2e4061afb811) | `` python312Packages.boto3-stubs: 1.34.87 -> 1.34.88 ``                                 |
| [`8626d584`](https://github.com/NixOS/nixpkgs/commit/8626d584777f23c3dbd88fb9ce73c047eac1aa2b) | `` python312Packages.tencentcloud-sdk-python: 3.0.1131 -> 3.0.1132 ``                   |
| [`fd77096c`](https://github.com/NixOS/nixpkgs/commit/fd77096ca10aa45cd978ef434eaf92bfa014d32b) | `` python312Packages.botocore-stubs: 1.34.87 -> 1.34.88 ``                              |
| [`e4a2abca`](https://github.com/NixOS/nixpkgs/commit/e4a2abca5d11a9f55bc0701179ae78bf93010bfe) | `` python312Packages.publicsuffixlist: 0.10.0.20240416 -> 0.10.0.20240420 ``            |
| [`63969d3a`](https://github.com/NixOS/nixpkgs/commit/63969d3a940c467d1548abf498b973a9379f8617) | `` goawk: 1.26.0 -> 1.27.0 ``                                                           |
| [`5eedc805`](https://github.com/NixOS/nixpkgs/commit/5eedc8052fafd1eb691cd2965d800cf7de07dd5f) | `` metasploit: 6.4.3 -> 6.4.5 ``                                                        |
| [`081bd774`](https://github.com/NixOS/nixpkgs/commit/081bd774ca98b60c0349c1a46e79457eab06d8be) | `` checkov: 3.2.69 -> 3.2.72 ``                                                         |
| [`5bc78821`](https://github.com/NixOS/nixpkgs/commit/5bc788216adaa882f93443f25dea30ba95f05dce) | `` nest: fix hash ``                                                                    |
| [`29637436`](https://github.com/NixOS/nixpkgs/commit/29637436923a6e4673a08e36595ad45f6a686fb8) | `` python311Packages.aiomisc: 17.5.4 -> 17.5.6 ``                                       |
| [`1b891c53`](https://github.com/NixOS/nixpkgs/commit/1b891c5346305746d50c070be61e0086aa309122) | `` python311Packages.grpcio-health-checking: 1.62.1 -> 1.62.2 ``                        |
| [`30c60b81`](https://github.com/NixOS/nixpkgs/commit/30c60b8164854c207c8233e813aaaed7571897ed) | `` cargo-dist: 0.13.1 -> 0.13.2 ``                                                      |