### PR TITLE
chore(flake/nixpkgs-master): `7eceafd9` -> `67dfd153`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1225,11 +1225,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1713553221,
-        "narHash": "sha256-y5sOi1s/y/fMpIJZk0lYZEW6H5WDe/Ly7ZoyPYSeYgA=",
+        "lastModified": 1713718614,
+        "narHash": "sha256-rpOeRLcBIB9T0MHIUaTH82DMEPs5y9zlaUT9o6U41f8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7eceafd98fcc18e57305ae82f2e6cba51b06ceac",
+        "rev": "67dfd1530243f6aaaad22f74651f6a3f098f61d6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                 |
| ---------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
| [`2872e103`](https://github.com/NixOS/nixpkgs/commit/2872e103333eb910cf015c36dbab5911f3630f95) | `` nixos/manual: apply `cfg.warningsAreErrors` to nix eval as well ``                   |
| [`c1181516`](https://github.com/NixOS/nixpkgs/commit/c11815167fcc656f84f1bc63e26f9de76967e32e) | `` nixos/duosec: Split `mkdir` mode into `chmod` command for clarity ``                 |
| [`6c0a5bef`](https://github.com/NixOS/nixpkgs/commit/6c0a5bef965318da037febf4114e4dfe52ada460) | `` zziplib: 0.13.72 -> 0.13.74 ``                                                       |
| [`b791c2e7`](https://github.com/NixOS/nixpkgs/commit/b791c2e7236e7cc9415887ff1ca515563a4b2da4) | `` cppcheck: 2.13.4 -> 2.14.0 ``                                                        |
| [`f875d413`](https://github.com/NixOS/nixpkgs/commit/f875d413f190509ea8233f464216eb9e2b08879c) | `` xorg.xorgserver: 21.1.12 -> 21.1.13 ``                                               |
| [`58bcc174`](https://github.com/NixOS/nixpkgs/commit/58bcc174af38c22b6846cb51de73f4a065ba43ac) | `` ccls: 0.20230717 -> 0.20240202 ``                                                    |
| [`00ad4eba`](https://github.com/NixOS/nixpkgs/commit/00ad4eba21cb456b0d6262ad3328c24cf77ec417) | `` nixos/tests/phosh: check phosh-mobile-settings starts ``                             |
| [`dba16322`](https://github.com/NixOS/nixpkgs/commit/dba1632221ede93219e940f4d51aa9a2c02b1aa0) | `` vscode-extensions.myriad-dreamin.tinymist: 0.11.4 -> 0.11.5 ``                       |
| [`93ed9a47`](https://github.com/NixOS/nixpkgs/commit/93ed9a478212a54f92293358c98633c27ab22648) | `` rtfm: Add meta.mainProgram ``                                                        |
| [`b8779053`](https://github.com/NixOS/nixpkgs/commit/b87790536d7151d6fef61bc9362bafb0ce8b1445) | `` nixos/greenclip: restart daemon if it exits ``                                       |
| [`5d60c614`](https://github.com/NixOS/nixpkgs/commit/5d60c6147a4a860c5fa07647ea9ea10df8936d46) | `` ov: 0.33.3 -> 0.34.0 ``                                                              |
| [`3a506c12`](https://github.com/NixOS/nixpkgs/commit/3a506c127429517163e61aca6afc8c0a3e0867e0) | `` faircamp: 0.13.0 -> 0.14.0 ``                                                        |
| [`1ada5045`](https://github.com/NixOS/nixpkgs/commit/1ada504517ec7b763a72496396fc51ce2f40f530) | `` rkpd2: 2.0.5 -> 2.0.6 ``                                                             |
| [`2980c621`](https://github.com/NixOS/nixpkgs/commit/2980c6217b0d0726e9d0040178a6adb8cb596738) | `` nh: 3.5.10 -> 3.5.13 ``                                                              |
| [`cf99dec3`](https://github.com/NixOS/nixpkgs/commit/cf99dec338917009c992386bf037ad0e778a8c0b) | `` python311Packages.mechanize: fix compat with Python 3.11+ ``                         |
| [`821fa71d`](https://github.com/NixOS/nixpkgs/commit/821fa71ddff3e8aa2e3f53225bfadcdb00757c5c) | `` cargo-modules: 0.11.2 -> 0.15.5 ``                                                   |
| [`3c35c90c`](https://github.com/NixOS/nixpkgs/commit/3c35c90c20c75d9268bbd3ae1c0e87707d13a392) | `` home-assistant: 2024.4.2 -> 2024.4.3 ``                                              |
| [`473b609c`](https://github.com/NixOS/nixpkgs/commit/473b609c37d9b896823a1909d4c7c5c62574e9f0) | `` python312Packages.homeassistant-stubs: 2024.4.2 -> 2024.4.3 ``                       |
| [`378dfa70`](https://github.com/NixOS/nixpkgs/commit/378dfa7057eac2d9d8db7e56812e6ebc7bb097bb) | `` python312Packages.gios: 3.2.2 -> 4.0.0 ``                                            |
| [`987bfa6b`](https://github.com/NixOS/nixpkgs/commit/987bfa6b06ff79da807b3b88084a26a65bb3006e) | `` vscode-extensions.thenuprojectcontributors.vscode-nushell-lang: 1.1.0 -> 1.9.0 ``    |
| [`9604b22e`](https://github.com/NixOS/nixpkgs/commit/9604b22e787a9fa3fc60181d9836645f62ef061d) | `` python312Packages.gios: refactor ``                                                  |
| [`3e81edee`](https://github.com/NixOS/nixpkgs/commit/3e81edee3c9fa0154c59f75dbddf4f795c8f6913) | `` python312Packages.ondilo: format with nixfmt ``                                      |
| [`bc4f8054`](https://github.com/NixOS/nixpkgs/commit/bc4f8054e9dc965171a8cde6e3231e66f2a2d735) | `` python312Packages.ondilo: 0.4.0 -> 0.5.0 ``                                          |
| [`f4fe9076`](https://github.com/NixOS/nixpkgs/commit/f4fe9076efaab3b11885e69b4f4020a95d40c6ac) | `` python312Packages.githubkit: foramt with nixfmt ``                                   |
| [`44cd3027`](https://github.com/NixOS/nixpkgs/commit/44cd302796135026a743cc442485670adada14ee) | `` python312Packages.githubkit: refactor ``                                             |
| [`2418a1bd`](https://github.com/NixOS/nixpkgs/commit/2418a1bdb1fb3f5690a2cf559446bffe66b25b39) | `` python312Packages.nettigo-air-monitor: format with nixfmt ``                         |
| [`dfadf9d7`](https://github.com/NixOS/nixpkgs/commit/dfadf9d7da174e74a4cde80a4afa6cb2c74b3948) | `` python312Packages.nettigo-air-monitor: 2.2.2 -> 3.0.0 ``                             |
| [`3fabc353`](https://github.com/NixOS/nixpkgs/commit/3fabc35312fddd42a411b75ae0c1ca9d3c599462) | `` python312Packages.nettigo-air-monitor: refactor ``                                   |
| [`7377ee13`](https://github.com/NixOS/nixpkgs/commit/7377ee13d05b251adf1ebe21ae855f9e3006e813) | `` python312Packages.nextdns: format with nixfmt ``                                     |
| [`67e38923`](https://github.com/NixOS/nixpkgs/commit/67e38923cf906d5b0eff1b732dcdecc730dab1cf) | `` python312Packages.nextdns: 2.1.0 -> 3.0.0 ``                                         |
| [`e7354669`](https://github.com/NixOS/nixpkgs/commit/e7354669dad1b32e18cfb875e8d55611dc3573e3) | `` python312Packages.nextdns: refactor ``                                               |
| [`a8a8401b`](https://github.com/NixOS/nixpkgs/commit/a8a8401b7b26112a9b75d6c00306e160fe8f8cb3) | `` vlc-bittorrent: fix version ``                                                       |
| [`eaf5ec98`](https://github.com/NixOS/nixpkgs/commit/eaf5ec98fe5bd102e1ec6b64df192e4fba6d6a32) | `` fetchurl: add codemirror.dlang.org to the list of dub mirrors ``                     |
| [`b08a1a4d`](https://github.com/NixOS/nixpkgs/commit/b08a1a4dd992066ec4df8ed8f4f9050603016b22) | `` vimPlugins.nvim-treesitter: update grammars ``                                       |
| [`f713f3c4`](https://github.com/NixOS/nixpkgs/commit/f713f3c4427a023920b63be7a13ddc5298005b51) | `` vimPlugins: resolve github repository redirects ``                                   |
| [`5d372830`](https://github.com/NixOS/nixpkgs/commit/5d37283092ef05c187e58e475558ddf4b8c7ddca) | `` vimPlugins: update on 2024-04-21 ``                                                  |
| [`89a1bde0`](https://github.com/NixOS/nixpkgs/commit/89a1bde018ad10f723658a988e5aee0b78846b73) | `` nixos/wireless: correctly handle secrets containing & ``                             |
| [`4d2f457f`](https://github.com/NixOS/nixpkgs/commit/4d2f457f6e02a08c9a6e8b879236facd8dd15fd7) | `` nixos/tests/wpa_supplicant: test allowAuxiliaryImperativeNetworks ``                 |
| [`2d9237e7`](https://github.com/NixOS/nixpkgs/commit/2d9237e70cce8f7602ee8d20e9ec4a35194e466b) | `` swayosd: unstable-2023-09-26 -> 0-unstable-2024-04-15 ``                             |
| [`37c02299`](https://github.com/NixOS/nixpkgs/commit/37c022996839d775b49fb42f7d6fe3d9e2e1dd35) | `` kubevpn: 2.2.5 -> 2.2.6 ``                                                           |
| [`b1162aa8`](https://github.com/NixOS/nixpkgs/commit/b1162aa853cd481270f793571bb3ee2d03b73643) | `` maintainers: add sergioribera ``                                                     |
| [`0dcf4b68`](https://github.com/NixOS/nixpkgs/commit/0dcf4b681d0c8ade1d16d29ece940493918bcfd6) | `` vscode-extensions.redhat.java: 1.17.2023032504 -> 1.30.2024041908 ``                 |
| [`13876bd2`](https://github.com/NixOS/nixpkgs/commit/13876bd27ad6c54910181fc7a611a11e622bb2f5) | `` libucl: 0.9.1 -> 0.9.2 ``                                                            |
| [`3d9dab80`](https://github.com/NixOS/nixpkgs/commit/3d9dab80e1b0f143a762cf090d8f5029c346edeb) | `` python312Packages.bellows: fix build ``                                              |
| [`de8da1b5`](https://github.com/NixOS/nixpkgs/commit/de8da1b57b77d1a66881f7f38ece7cad992aa21a) | `` python312Packages.aranet4: 2.2.3 -> 2.3.3 ``                                         |
| [`4fa107f1`](https://github.com/NixOS/nixpkgs/commit/4fa107f1c9bcf0af6eaea23e30f37c69296ff7bc) | `` nixos/wireless: create empty config for imperative setup ``                          |
| [`f30d13d0`](https://github.com/NixOS/nixpkgs/commit/f30d13d04a3648d0e44a5e1543aa4d1c735dceac) | `` phpPackages.composer: 2.7.2 -> 2.7.3 ``                                              |
| [`0ce3e115`](https://github.com/NixOS/nixpkgs/commit/0ce3e115de2c95039ea977052210255f18c4cb2c) | `` dublin-traceroute: mark as broken on darwin ``                                       |
| [`150aabdc`](https://github.com/NixOS/nixpkgs/commit/150aabdc4217b4162f79c40af63133947741ae05) | `` dublin-traceroute: 0.4.2-unstable-2024-01-09 -> 0.4.2-unstable-2024-04-11 ``         |
| [`23e8ad4c`](https://github.com/NixOS/nixpkgs/commit/23e8ad4cee19b21dad3f29944ad8186897f8ff25) | `` cakelisp: 0.3.0-unstable-2024-04-01 -> 0.3.0-unstable-2024-04-18 ``                  |
| [`26b947c9`](https://github.com/NixOS/nixpkgs/commit/26b947c9bcc312464b547ba68acaecf57398bafd) | `` limine: mark as broken on darwin ``                                                  |
| [`5fb27020`](https://github.com/NixOS/nixpkgs/commit/5fb270209755688cf9f5c6e44fa3d9420c07a21f) | `` maa-assistant-arknights: 5.2.0 -> 5.2.1 ``                                           |
| [`45118883`](https://github.com/NixOS/nixpkgs/commit/451188832a2f29830c695d85fb52100fc283a703) | `` python311Packages.txtai: 7.0.0 -> 7.1.0 ``                                           |
| [`d6848122`](https://github.com/NixOS/nixpkgs/commit/d68481224a09ce13d43305f60f15fc745e087639) | `` nixos/release-small: fix eval ``                                                     |
| [`e12029c3`](https://github.com/NixOS/nixpkgs/commit/e12029c3049265cb52126adf9eba0de96d36fa3b) | `` home-assistant-custom-components.miele: 0.1.19 -> 2024.3.0 ``                        |
| [`8b93127c`](https://github.com/NixOS/nixpkgs/commit/8b93127c339b18a069d66dd7d311e3205afac501) | `` python311Packages.openstacksdk: 3.0.0 -> 3.1.0 ``                                    |
| [`5b65a57e`](https://github.com/NixOS/nixpkgs/commit/5b65a57ea08215a7c62d837baf5c22553fc2891b) | `` forgejo: 1.21.11-0 -> 1.21.11-1 ``                                                   |
| [`864095a7`](https://github.com/NixOS/nixpkgs/commit/864095a7a00eaeb0e13a95ac93ba1ac278ec2aa7) | `` vscode-extensions.adzero.vscode-sievehighlight: init 1.0.6 ``                        |
| [`9b45c0c6`](https://github.com/NixOS/nixpkgs/commit/9b45c0c6593f37ef3899a3ceaacf1e3df4556d1e) | `` Revert "ovftool: init at 4.6.2 for x86_64-darwin" ``                                 |
| [`c64f61e4`](https://github.com/NixOS/nixpkgs/commit/c64f61e478b237f2f903d9e2596baa67cfa19ad9) | `` systemctl-tui: 0.2.4 -> 0.3.3 ``                                                     |
| [`0f5cb6b7`](https://github.com/NixOS/nixpkgs/commit/0f5cb6b70294c52e643d0ca099b35308563a2674) | `` deconz: 2.23.00 -> 2.26.3 ``                                                         |
| [`c7ab550b`](https://github.com/NixOS/nixpkgs/commit/c7ab550bbc7fede3c00b20392ad712d3daee5acb) | `` nixos/deconz: fix curl redirect option in postStart ``                               |
| [`07b7ca83`](https://github.com/NixOS/nixpkgs/commit/07b7ca8345611c1e46fde38ae40397737e4695d7) | `` avrdude: use finalAttrs instead of rec ``                                            |
| [`55ddcaf7`](https://github.com/NixOS/nixpkgs/commit/55ddcaf70d70bf287a916624db2bbb5bb41c011a) | `` avrdude: use either vendored libelf or elfutils instead of abandoned upstream ``     |
| [`4f05b69e`](https://github.com/NixOS/nixpkgs/commit/4f05b69ed5f2d4b0c2773adaa999d0e7008dd1b8) | `` adminerevo: init at 4.8.6 ``                                                         |
| [`605be9e6`](https://github.com/NixOS/nixpkgs/commit/605be9e6dafc8170a940255b6ab740f1b27c7177) | `` mystmd: 1.1.53 -> 1.1.55 ``                                                          |
| [`f22430b6`](https://github.com/NixOS/nixpkgs/commit/f22430b657f73a8be8eb933bee08ca3d19b03ed9) | `` cargo-spellcheck: fix build ``                                                       |
| [`f2248104`](https://github.com/NixOS/nixpkgs/commit/f22481048d64837f0ea85d607da711648d2e4e3b) | `` niri: 0.1.4 -> 0.1.5 ``                                                              |
| [`d9feb2e9`](https://github.com/NixOS/nixpkgs/commit/d9feb2e9baba5bc136e348c2cc3a80d97eb6726c) | `` podman: fix darwin support ``                                                        |
| [`7b965f54`](https://github.com/NixOS/nixpkgs/commit/7b965f54001bfc20cb88d278cb5520d8dc19deff) | `` _64gram: 1.1.18 -> 1.1.19 ``                                                         |
| [`ff8eddac`](https://github.com/NixOS/nixpkgs/commit/ff8eddacb1617625ccf5d7f10a1e1b606e8161df) | `` biglybt: init at 3.5.0.0 ``                                                          |
| [`2268cf93`](https://github.com/NixOS/nixpkgs/commit/2268cf93d4de6fcd53f008da2a7d2bdfa871f72e) | `` coder: add support for mainline channel ``                                           |
| [`f94aaf84`](https://github.com/NixOS/nixpkgs/commit/f94aaf8483cb2c8424263dfd4bad68b077bf94bf) | `` trust-dns: fix hash ``                                                               |
| [`ac01eef7`](https://github.com/NixOS/nixpkgs/commit/ac01eef7b19a8bdd22ef72ce4762bb0bf4e053a5) | `` v8: unpin llvmPackages_15.stdenv on darwin ``                                        |
| [`4b116b8f`](https://github.com/NixOS/nixpkgs/commit/4b116b8ff393d8c04c76f068564886700f3f8157) | `` ockam: fix hash, cleanup ``                                                          |
| [`fc7d8b34`](https://github.com/NixOS/nixpkgs/commit/fc7d8b347a6d3deb8dd765e8bc026cdcaf0eed1f) | `` pymeshlab: init at 2023.12 ``                                                        |
| [`74900367`](https://github.com/NixOS/nixpkgs/commit/74900367e85e4d7560db2aaf12d5282afc0f12b0) | `` meshlab: 2022.02 -> 2023.12 ``                                                       |
| [`e71d969c`](https://github.com/NixOS/nixpkgs/commit/e71d969ca7d0c66e1fb5a4122f13cbbb680f9bf6) | `` structuresynth: init at 1.5.1 ``                                                     |
| [`df69ac58`](https://github.com/NixOS/nixpkgs/commit/df69ac58f030234a251edebe35efa625282a7dd0) | `` openctm: init at 1.0.3 ``                                                            |
| [`835c1cbf`](https://github.com/NixOS/nixpkgs/commit/835c1cbf108429ed017793ee6f76fed4e1cfbb1e) | `` corto: init at unstable-2023-06-27 ``                                                |
| [`a9a10414`](https://github.com/NixOS/nixpkgs/commit/a9a1041404e3ec578e7ffe5117ee498f627892fc) | `` python312Packages.githubkit: 0.11.3 -> 0.11.4 ``                                     |
| [`e324e2ff`](https://github.com/NixOS/nixpkgs/commit/e324e2ff82584ad43f6da104371cb4dca81b2f8a) | `` vscode-extensions: format using nixfmt-rfc-style ``                                  |
| [`45f06b50`](https://github.com/NixOS/nixpkgs/commit/45f06b5037f25c239ab3173dc8afc2eb8b260de3) | `` feather: fix trezor support ``                                                       |
| [`d2bc1006`](https://github.com/NixOS/nixpkgs/commit/d2bc1006a686e51c3fcb9ecb65acaa5da80a5f83) | `` synology-drive-client: add aarch64-darwin support ``                                 |
| [`4e527ac3`](https://github.com/NixOS/nixpkgs/commit/4e527ac342440fe234e549d792f7a4f343b90fd2) | `` iosevka: 29.2.1 -> 29.2.1 ``                                                         |
| [`0c261992`](https://github.com/NixOS/nixpkgs/commit/0c261992cc222bece5261ed4fc3cbe5c5b437754) | `` add aarch64-linux (#305521) ``                                                       |
| [`ce3c0776`](https://github.com/NixOS/nixpkgs/commit/ce3c07768d8cb97dfa3a8038767b3c31c1ea485a) | `` doublecmd: 1.1.12 -> 1.1.13 ``                                                       |
| [`5efa13b4`](https://github.com/NixOS/nixpkgs/commit/5efa13b4a40d236a3b39d82b60c250b82112c062) | `` nixci: 0.2.0 -> 0.4.0; fix Darwin build ``                                           |
| [`6ec76d93`](https://github.com/NixOS/nixpkgs/commit/6ec76d93988e9562b47497a7edc9a131e39de08a) | `` maintainers: add aktaboot ``                                                         |
| [`9ca7c79e`](https://github.com/NixOS/nixpkgs/commit/9ca7c79ed2cf8a223e1e9a8610c8157f765ddc6e) | `` dogedns: init at 0.2.6 ``                                                            |
| [`9c42b802`](https://github.com/NixOS/nixpkgs/commit/9c42b802baa35dd030e3272d25695a80f2045009) | `` podman-compose: 1.0.6 -> 1.1.0 ``                                                    |
| [`2c817408`](https://github.com/NixOS/nixpkgs/commit/2c817408905d7b32ee1cdf5a4aa0ec2b76b3b652) | `` zfs-replicate: 3.2.12 -> 3.2.13 ``                                                   |
| [`e145d5d7`](https://github.com/NixOS/nixpkgs/commit/e145d5d7802313345cabbc86d551818de4224def) | `` Revert "fw-ectool: unstable-2022-12-03 -> 0-unstable-2023-12-15, switch upstream" `` |
| [`96859836`](https://github.com/NixOS/nixpkgs/commit/96859836d473f25f80a37b63aae14de6d720426b) | `` python311Packages.qtile-extras: format with nixfmt ``                                |
| [`e8e5011c`](https://github.com/NixOS/nixpkgs/commit/e8e5011c6e48d090b728180a5473e22f81d74dec) | `` python311Packages.qtile-extras: refactor ``                                          |