### PR TITLE
flake: use nixos-unstable-small

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -169,11 +169,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1747195422,
-        "narHash": "sha256-tr4ATmqPQ+9LtFtfTLfugSXcsXcow8T6PJvidCeAnwg=",
+        "lastModified": 1747281799,
+        "narHash": "sha256-TB7CZflDLI8H0np8AsSmyF21v1smbhZ1u3c7RR4S78M=",
         "owner": "rycee",
         "repo": "nur-expressions",
-        "rev": "7f04c28c17c2c84404e4cdf9e7d371a7f65becc9",
+        "rev": "49f3c5693b7d83dc5b6d1fb483cfc670bc397f6c",
         "type": "gitlab"
       },
       "original": {
@@ -679,11 +679,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1747247479,
-        "narHash": "sha256-y+S9IsF+VbGPvSh/Xr/Qbz1/xGtpsU4DbEE+PnvKg8I=",
+        "lastModified": 1747301504,
+        "narHash": "sha256-GAI36RNzF9yC0JOauS1+h681ElwdbD9q/qxxuIqcejQ=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "75f2cb5f6559ca6ca7c6300b270e5ddc3fdabe31",
+        "rev": "a5c9b3e49047b4f03f79c5146d8925363eab3072",
         "type": "github"
       },
       "original": {
@@ -953,7 +953,9 @@
         "flake-parts": "flake-parts_3",
         "home-manager": "home-manager",
         "neovim-overlay": "neovim-overlay",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "nixvim": "nixvim",
         "nui-nvim": "nui-nvim"
       },
@@ -1000,11 +1002,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747167147,
-        "narHash": "sha256-FJtVtQ9AaYvBilvQs0tkGzQ/iGQrSNnyq1SmaNPwoQg=",
+        "lastModified": 1747327565,
+        "narHash": "sha256-CPBdZ/1mQAw0cC36D1Yo+ml+3eDDJtfSELYNIF0fKRw=",
         "owner": "moonlight-mod",
         "repo": "moonlight",
-        "rev": "9b86294de85f5ec3448aee62e040b396ab7436d9",
+        "rev": "e917cacbc06f873630feba5a3e0b431a2269c606",
         "type": "github"
       },
       "original": {
@@ -1123,22 +1125,6 @@
         "type": "github"
       }
     },
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1747242394,
-        "narHash": "sha256-cKhqyDHlKYTUjiv/C1DAGKjEzKcZkLpp32hMoohQjPI=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "b112281ce6d4d1b0d892098bebe76861134c44c2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-lib": {
       "locked": {
         "lastModified": 1743296961,
@@ -1186,16 +1172,16 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1747179050,
-        "narHash": "sha256-qhFMmDkeJX9KJwr5H32f1r7Prs7XbQWtO0h3V0a0rFY=",
+        "lastModified": 1747327360,
+        "narHash": "sha256-LSmTbiq/nqZR9B2t4MRnWG7cb0KVNU70dB7RT4+wYK4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "adaa24fbf46737f3f1b5497bf64bae750f82942e",
+        "rev": "e06158e58f3adee28b139e9c2bcfcc41f8625b46",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-unstable-small",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1298,11 +1284,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1747277962,
-        "narHash": "sha256-QC2MtPy7EV0axorQLabz9GocnfBfiwLbKwdY4hU1D14=",
+        "lastModified": 1747330635,
+        "narHash": "sha256-oAJxbE8vbkGHSgr9mYiFM+Xdlt7EmJvPn8XmqJ7TsYc=",
         "owner": "wamserma",
         "repo": "flake-programs-sqlite",
-        "rev": "1d7de574978bf97ba56126feddda32c3fc28c5dc",
+        "rev": "58ea1a997594014a931aa5f4e7dc90cac3d49dc1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "xd uwu";
 
   inputs = {
-    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable-small";
     nixpkgs.follows = "nixpkgs-unstable";
 
     hjem.url = "github:feel-co/hjem";
@@ -50,6 +50,8 @@
     moonlight.inputs.nixpkgs.follows = "nixpkgs";
 
     ludovico-nixvim.url = "github:LudovicoPiero/nvim-flake";
+    ludovico-nixvim.inputs.nixpkgs.follows = "nixpkgs";
+
     nix-colors.url = "github:misterio77/nix-colors";
     catppuccin-base16.url = "github:catppuccin/base16";
     catppuccin-base16.flake = false;


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'firefox-addons':
    'gitlab:rycee/nur-expressions/7f04c28c17c2c84404e4cdf9e7d371a7f65becc9?dir=pkgs/firefox-addons' (2025-05-14)
  → 'gitlab:rycee/nur-expressions/49f3c5693b7d83dc5b6d1fb483cfc670bc397f6c?dir=pkgs/firefox-addons' (2025-05-15)
• Updated input 'hyprland':
    'github:hyprwm/Hyprland/75f2cb5f6559ca6ca7c6300b270e5ddc3fdabe31' (2025-05-14)
  → 'github:hyprwm/Hyprland/a5c9b3e49047b4f03f79c5146d8925363eab3072' (2025-05-15)
• Updated input 'moonlight':
    'github:moonlight-mod/moonlight/9b86294de85f5ec3448aee62e040b396ab7436d9' (2025-05-13)
  → 'github:moonlight-mod/moonlight/e917cacbc06f873630feba5a3e0b431a2269c606' (2025-05-15)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/adaa24fbf46737f3f1b5497bf64bae750f82942e' (2025-05-13)
  → 'github:NixOS/nixpkgs/e06158e58f3adee28b139e9c2bcfcc41f8625b46' (2025-05-15)
• Updated input 'programsdb':
    'github:wamserma/flake-programs-sqlite/1d7de574978bf97ba56126feddda32c3fc28c5dc' (2025-05-15)
  → 'github:wamserma/flake-programs-sqlite/58ea1a997594014a931aa5f4e7dc90cac3d49dc1' (2025-05-15)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the source for `nixpkgs-unstable` to use a smaller branch.
  - Adjusted input alignment for improved consistency with other configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->