### PR TITLE
hosts/sforza: enable emacs

### DIFF
--- a/hosts/sforza/mine.nix
+++ b/hosts/sforza/mine.nix
@@ -34,7 +34,7 @@
     };
 
     emacs = {
-      enable = false;
+      enable = true;
     };
 
     fcitx5 = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Emacs is now enabled on the Sforza environment, making the editor available by default for all users of this host. Launch Emacs without additional setup; it will be provisioned automatically on build/deploy. Other modules remain unchanged, ensuring a stable experience. Ideal for editing, scripting, and development tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->