### PR TITLE
modules/shared: disable `lix-custom-sub-commands`

### DIFF
--- a/modules/etc/shared/default.nix
+++ b/modules/etc/shared/default.nix
@@ -189,7 +189,7 @@
 
         # Allows Lix to invoke a custom command via its main binary `lix`,
         # i.e. `lix-foo` gets invoked when `lix foo` is executed.
-        "lix-custom-sub-commands"
+        # "lix-custom-sub-commands"
 
         # Allows Nix to automatically pick UIDs for builds, rather than creating `nixbld*` user accounts.
         "auto-allocate-uids"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled the experimental “custom sub-commands” feature flag in the configuration.
  * Impact: Experimental custom sub-commands are no longer available. Any workflows relying on them will not function until re-enabled.
  * Standard commands and other features remain unaffected.
  * No user-facing settings or interfaces were added or changed beyond this feature being turned off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->