### PR TITLE
chore: Update flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,11 +39,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1760029873,
-        "narHash": "sha256-53QCEFn8yydyKN3gmjkQjzFhbWUCoGza94qaZUrYviQ=",
+        "lastModified": 1760148156,
+        "narHash": "sha256-esyF/JqpQGcq2neJwpfuoZXgg55DehNTxdGRMuHqCL4=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "c3e2ca282d91c806f1c10ae9387c9631241f21f7",
+        "rev": "487c16bfab1b4ff24496f18d2d5b60ca79a8bc59",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
       },
       "locked": {
         "dir": "pkgs/firefox-addons",
-        "lastModified": 1759982616,
-        "narHash": "sha256-08s74deJkzp7t2g20t9o+gnV5K2jJ+VWx0EPd8xuS1M=",
+        "lastModified": 1760155413,
+        "narHash": "sha256-IQ3BwuntXH56t06rafrxvhAJO+as7IdAXUtCZFnag00=",
         "owner": "rycee",
         "repo": "nur-expressions",
-        "rev": "4333b2c7fa0fbcdd87442c4e15324ad14f42c71b",
+        "rev": "e7e994715dee5edcd1c27919294682b007662845",
         "type": "gitlab"
       },
       "original": {
@@ -353,11 +353,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1760015796,
-        "narHash": "sha256-c/WkaynHrRE1EHWATe5+vb9M9YabfTaR1GHivdybaSU=",
+        "lastModified": 1760130406,
+        "narHash": "sha256-GKMwBaFRw/C1p1VtjDz4DyhyzjKUWyi1K50bh8lgA2E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "6564ee29d0521af3feba937a91024e6a3e77a8b6",
+        "rev": "d305eece827a3fe317a2d70138f53feccaf890a1",
         "type": "github"
       },
       "original": {
@@ -374,11 +374,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1759853171,
-        "narHash": "sha256-uqbhyXtqMbYIiMqVqUhNdSuh9AEEkiasoK3mIPIVRhk=",
+        "lastModified": 1760103600,
+        "narHash": "sha256-R4cltQFceN3POiPhBu7aTKsrwqTiwo6zjzmitrHD80E=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "1a09eb84fa9e33748432a5253102d01251f72d6d",
+        "rev": "bcccb01d0a353c028cc8cb3254cac7ebae32929e",
         "type": "github"
       },
       "original": {
@@ -467,11 +467,11 @@
     "lix": {
       "flake": false,
       "locked": {
-        "lastModified": 1759868088,
-        "narHash": "sha256-PthY1vlykNZmuKHQS01Qunut1fdM0imk5Myg3hcr8Oc=",
-        "rev": "42691f0d943b43842e69b76608cbe4416e35e94e",
+        "lastModified": 1760115334,
+        "narHash": "sha256-PPDHXtv6U5oIj8utzIqcH+ZSjMy4vXpv/y8c2I7dZ+g=",
+        "rev": "53d172a3083840846043f7579936e0a3e86737e5",
         "type": "tarball",
-        "url": "https://git.lix.systems/api/v1/repos/lix-project/lix/archive/42691f0d943b43842e69b76608cbe4416e35e94e.tar.gz?rev=42691f0d943b43842e69b76608cbe4416e35e94e"
+        "url": "https://git.lix.systems/api/v1/repos/lix-project/lix/archive/53d172a3083840846043f7579936e0a3e86737e5.tar.gz?rev=53d172a3083840846043f7579936e0a3e86737e5"
       },
       "original": {
         "type": "tarball",
@@ -511,11 +511,11 @@
         "nui-nvim": "nui-nvim"
       },
       "locked": {
-        "lastModified": 1759941590,
-        "narHash": "sha256-hdEXTX1ArPEiuHEY2NrMvv1UHsmpxbitHniMerEPBHI=",
+        "lastModified": 1760115015,
+        "narHash": "sha256-8hnoCm3nIvCwbrHIfZJkaz37uAiZPjkGQ8tThCYhX+U=",
         "owner": "LudovicoPiero",
         "repo": "nvim-flake",
-        "rev": "ba7f97c7ace1b9a1b4d4b65d9e463694b73084e3",
+        "rev": "0510b94f158125b7ee05aa8e182ac108e9887389",
         "type": "github"
       },
       "original": {
@@ -561,11 +561,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1759881893,
-        "narHash": "sha256-Kfq5VGzYyYvOJh//cz6+UXbwv8CRoSXjl+ynOknyP9Y=",
+        "lastModified": 1760082751,
+        "narHash": "sha256-aIAdEUaNE/J+DdH7qstr6D8QgRT0R8sCsDg8HvV1qkI=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "99029c447f51a09743ea8fb5546f58b5254216da",
+        "rev": "a7445585f3caff995d6aa62bdb5a29fb45639fce",
         "type": "github"
       },
       "original": {
@@ -577,11 +577,11 @@
     "neovim-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1759876140,
-        "narHash": "sha256-oRZeejH4NHzWAuavvfRgKAqYX6z4CsX1unpTKeLIz1M=",
+        "lastModified": 1760052728,
+        "narHash": "sha256-7DSxZwD34xJRI/6koseN0QCTAH/BBWu8r2D2Cd3cWaU=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "236d831d77d61e8de6bb7191fc0a7fb0743a5021",
+        "rev": "b1c41a332d183c4cb003329f7c2a3f310f48273c",
         "type": "github"
       },
       "original": {
@@ -688,11 +688,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1759735786,
-        "narHash": "sha256-a0+h02lyP2KwSNrZz4wLJTu9ikujNsTWIC874Bv7IJ0=",
+        "lastModified": 1759994382,
+        "narHash": "sha256-wSK+3UkalDZRVHGCRikZ//CyZUJWDJkBDTQX1+G77Ow=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "20c4598c84a671783f741e02bf05cbfaf4907cff",
+        "rev": "5da4a26309e796daa7ffca72df93dbe53b8164c7",
         "type": "github"
       },
       "original": {
@@ -720,11 +720,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1759989671,
-        "narHash": "sha256-3Wk0I5TYsd7cyIO8vYGxjOuQ8zraZEUFZqEhSSIhQLs=",
+        "lastModified": 1760075832,
+        "narHash": "sha256-yFPaAoVMivTE2cpNkVl6jrkNd+mIq1cae/4D0pN14XQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "837076de579c67aa0c2ce2ab49948b24d907d449",
+        "rev": "daebeba791763abfe3cce5e0f16376ddf1b724d4",
         "type": "github"
       },
       "original": {
@@ -780,11 +780,11 @@
         "systems": "systems_3"
       },
       "locked": {
-        "lastModified": 1759927289,
-        "narHash": "sha256-EWdwR9l+JG466rPuNmjjzDPvQAuh37lmhgWa2xeaMdk=",
+        "lastModified": 1760105514,
+        "narHash": "sha256-un7IqbXz3hC8rHGAgD/mVbDdzTxf9ar3UjGnRxuYoYA=",
         "owner": "nix-community",
         "repo": "nixvim",
-        "rev": "57006a3ace4a3c889ab61b70fd5d8b197de8314e",
+        "rev": "bb9d744b644d160336b7ff681dac1b19db01ba2c",
         "type": "github"
       },
       "original": {
@@ -868,11 +868,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1760002144,
-        "narHash": "sha256-rqoSTXX6IX03xMr8Q8t1k1BzbWU9QFM1pamGVLggu6s=",
+        "lastModified": 1760117199,
+        "narHash": "sha256-+EVaCq0h1zd1Rf++0oWc6QAxP8E+bzI9o8b9aEoXfqA=",
         "owner": "wamserma",
         "repo": "flake-programs-sqlite",
-        "rev": "54a15e6197aa6d9d4f10f80129f2a37bac0dedd7",
+        "rev": "157183476591805691cca440a21ffa9212a46b39",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'emacs-overlay':
    'github:nix-community/emacs-overlay/807781584b2f56a80ca8a0564fea7f6fca2841c7' (2025-10-09)
  → 'github:nix-community/emacs-overlay/487c16bfab1b4ff24496f18d2d5b60ca79a8bc59' (2025-10-11)
• Updated input 'emacs-overlay/nixpkgs-stable':
    'github:NixOS/nixpkgs/20c4598c84a671783f741e02bf05cbfaf4907cff' (2025-10-06)
  → 'github:NixOS/nixpkgs/5da4a26309e796daa7ffca72df93dbe53b8164c7' (2025-10-09)
• Updated input 'firefox-addons':
    'gitlab:rycee/nur-expressions/4333b2c7fa0fbcdd87442c4e15324ad14f42c71b?dir=pkgs/firefox-addons' (2025-10-09)
  → 'gitlab:rycee/nur-expressions/e7e994715dee5edcd1c27919294682b007662845?dir=pkgs/firefox-addons' (2025-10-11)
• Updated input 'home-manager':
    'github:nix-community/home-manager/6564ee29d0521af3feba937a91024e6a3e77a8b6' (2025-10-09)
  → 'github:nix-community/home-manager/d305eece827a3fe317a2d70138f53feccaf890a1' (2025-10-10)
• Updated input 'lix':
    'https://git.lix.systems/api/v1/repos/lix-project/lix/archive/42691f0d943b43842e69b76608cbe4416e35e94e.tar.gz?narHash=sha256-PthY1vlykNZmuKHQS01Qunut1fdM0imk5Myg3hcr8Oc%3D&rev=42691f0d943b43842e69b76608cbe4416e35e94e' (2025-10-07)
  → 'https://git.lix.systems/api/v1/repos/lix-project/lix/archive/53d172a3083840846043f7579936e0a3e86737e5.tar.gz?narHash=sha256-PPDHXtv6U5oIj8utzIqcH%2BZSjMy4vXpv/y8c2I7dZ%2Bg%3D&rev=53d172a3083840846043f7579936e0a3e86737e5' (2025-10-10)
• Updated input 'ludovico-nixvim':
    'github:LudovicoPiero/nvim-flake/ba7f97c7ace1b9a1b4d4b65d9e463694b73084e3' (2025-10-08)
  → 'github:LudovicoPiero/nvim-flake/0510b94f158125b7ee05aa8e182ac108e9887389' (2025-10-10)
• Updated input 'ludovico-nixvim/home-manager':
    'github:nix-community/home-manager/1a09eb84fa9e33748432a5253102d01251f72d6d' (2025-10-07)
  → 'github:nix-community/home-manager/bcccb01d0a353c028cc8cb3254cac7ebae32929e' (2025-10-10)
• Updated input 'ludovico-nixvim/neovim-overlay':
    'github:nix-community/neovim-nightly-overlay/99029c447f51a09743ea8fb5546f58b5254216da' (2025-10-08)
  → 'github:nix-community/neovim-nightly-overlay/a7445585f3caff995d6aa62bdb5a29fb45639fce' (2025-10-10)
• Updated input 'ludovico-nixvim/neovim-overlay/neovim-src':
    'github:neovim/neovim/236d831d77d61e8de6bb7191fc0a7fb0743a5021' (2025-10-07)
  → 'github:neovim/neovim/b1c41a332d183c4cb003329f7c2a3f310f48273c' (2025-10-09)
• Updated input 'ludovico-nixvim/nixvim':
    'github:nix-community/nixvim/57006a3ace4a3c889ab61b70fd5d8b197de8314e' (2025-10-08)
  → 'github:nix-community/nixvim/bb9d744b644d160336b7ff681dac1b19db01ba2c' (2025-10-10)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/837076de579c67aa0c2ce2ab49948b24d907d449' (2025-10-09)
  → 'github:NixOS/nixpkgs/daebeba791763abfe3cce5e0f16376ddf1b724d4' (2025-10-10)
• Updated input 'programsdb':
    'github:wamserma/flake-programs-sqlite/54a15e6197aa6d9d4f10f80129f2a37bac0dedd7' (2025-10-09)
  → 'github:wamserma/flake-programs-sqlite/157183476591805691cca440a21ffa9212a46b39' (2025-10-10)